### PR TITLE
Feature/parallel grid

### DIFF
--- a/autofit/optimize/grid_search.py
+++ b/autofit/optimize/grid_search.py
@@ -209,19 +209,9 @@ class GridSearch(object):
                                       results_list)))
 
         for values in lists:
-            arguments = self.make_arguments(values, grid_priors)
-            model_mapper = self.variable.mapper_from_partial_prior_arguments(arguments)
+            job = self.job_for_analysis_grid_priors_and_values(analysis, grid_priors, values)
 
-            labels = []
-            for prior in arguments.values():
-                labels.append(
-                    "{}_{:.2f}_{:.2f}".format(model_mapper.name_for_prior(prior), prior.lower_limit, prior.upper_limit))
-
-            name_path = "{}{}/{}".format(self.phase_name, self.phase_tag, "_".join(labels))
-            optimizer_instance = self.optimizer_instance(model_mapper, name_path)
-            optimizer_instance.constant = self.constant
-
-            result = Job(optimizer_instance, analysis, arguments).perform()
+            result = job.perform()
 
             results.append(result.result)
             results_list.append(result.result_list_row)
@@ -229,6 +219,21 @@ class GridSearch(object):
             write_results()
 
         return GridSearchResult(results, lists)
+
+    def job_for_analysis_grid_priors_and_values(self, analysis, grid_priors, values):
+        arguments = self.make_arguments(values, grid_priors)
+        model_mapper = self.variable.mapper_from_partial_prior_arguments(arguments)
+
+        labels = []
+        for prior in arguments.values():
+            labels.append(
+                "{}_{:.2f}_{:.2f}".format(model_mapper.name_for_prior(prior), prior.lower_limit, prior.upper_limit))
+
+        name_path = "{}{}/{}".format(self.phase_name, self.phase_tag, "_".join(labels))
+        optimizer_instance = self.optimizer_instance(model_mapper, name_path)
+        optimizer_instance.constant = self.constant
+
+        return Job(optimizer_instance, analysis, arguments)
 
     def optimizer_instance(self, model_mapper, name_path):
 

--- a/autofit/optimize/grid_search.py
+++ b/autofit/optimize/grid_search.py
@@ -210,6 +210,23 @@ class GridSearch(object):
             return self.fit_sequential(analysis, grid_priors)
 
     def fit_parallel(self, analysis, grid_priors):
+        """
+        Perform the grid search in parallel, with all the optimisation for each grid square being performed on a
+        different process.
+
+        Parameters
+        ----------
+        analysis
+            An analysis
+        grid_priors
+            Priors describing the position in the grid
+
+        Returns
+        -------
+        result: GridSearchResult
+            The result of the grid search
+        """
+
         grid_priors = list(set(grid_priors))
         results = []
         lists = self.make_lists(grid_priors)
@@ -244,6 +261,23 @@ class GridSearch(object):
         return GridSearchResult(results, lists)
 
     def fit_sequential(self, analysis, grid_priors):
+        """
+        Perform the grid search sequentially, with all the optimisation for each grid square being performed on the
+        same process.
+
+        Parameters
+        ----------
+        analysis
+            An analysis
+        grid_priors
+            Priors describing the position in the grid
+
+        Returns
+        -------
+        result: GridSearchResult
+            The result of the grid search
+        """
+
         grid_priors = list(set(grid_priors))
         results = []
         lists = self.make_lists(grid_priors)
@@ -298,12 +332,34 @@ class GridSearch(object):
 
 class JobResult:
     def __init__(self, result, result_list_row):
+        """
+        The result of a job
+
+        Parameters
+        ----------
+        result
+            The result of a grid search
+        result_list_row
+            A row in the result list
+        """
         self.result = result
         self.result_list_row = result_list_row
 
 
 class Job:
     def __init__(self, optimizer_instance, analysis, arguments):
+        """
+        A job to be performed in parallel.
+
+        Parameters
+        ----------
+        optimizer_instance
+            An instance of an optimiser
+        analysis
+            An analysis
+        arguments
+            The grid search arguments
+        """
         self.optimizer_instance = optimizer_instance
         self.analysis = analysis
         self.arguments = arguments
@@ -317,6 +373,16 @@ class Job:
 
 class Process(multiprocessing.Process):
     def __init__(self, name: str, job_queue: multiprocessing.Queue):
+        """
+        A parallel process that consumes Jobs through the job queue and outputs results through its own queue.
+
+        Parameters
+        ----------
+        name: str
+            The name of the process
+        job_queue: multiprocessing.Queue
+            The queue through which jobs are submitted
+        """
         super().__init__(name=name)
         logger.info("created process {}".format(name))
 

--- a/autofit/tools/phase.py
+++ b/autofit/tools/phase.py
@@ -109,15 +109,35 @@ class AbstractPhase(object):
         raise NotImplementedError()
 
 
-def as_grid_search(phase_class):
+def as_grid_search(phase_class, parallel=False):
+    """
+    Create a grid search phase class from a regular phase class. Instead of the phase being optimised by a single
+    non-linear optimiser, a new optimiser is created for each square in a grid.
+
+    Parameters
+    ----------
+    phase_class
+        The original phase class
+    parallel: bool
+        Indicates whether non linear searches in the grid should be performed on parallel processes.
+
+    Returns
+    -------
+    grid_search_phase_class: GridSearchExtension
+        A class that inherits from the original class, replacing the optimiser with a grid search optimiser.
+
+    """
+
     class GridSearchExtension(phase_class):
         def __init__(self, *args, phase_name, tag_phases=True, phase_folders=None, number_of_steps=10,
                      optimizer_class=non_linear.MultiNest, **kwargs):
             super().__init__(*args, phase_name=phase_name, tag_phases=tag_phases, phase_folders=phase_folders,
                              optimizer_class=optimizer_class, **kwargs)
-            self.optimizer = grid_search.GridSearch(phase_name=phase_name, phase_tag=self.phase_tag, phase_folders=phase_folders,
+            self.optimizer = grid_search.GridSearch(phase_name=phase_name, phase_tag=self.phase_tag,
+                                                    phase_folders=phase_folders,
                                                     number_of_steps=number_of_steps, optimizer_class=optimizer_class,
-                                                    model_mapper=self.variable, constant=self.constant)
+                                                    model_mapper=self.variable, constant=self.constant,
+                                                    parallel=parallel)
 
         def run_analysis(self, analysis):
             return self.optimizer.fit(analysis, self.grid_priors)

--- a/test/integration/parallel_grid_search.py
+++ b/test/integration/parallel_grid_search.py
@@ -28,7 +28,8 @@ class Analysis(non_linear.Analysis):
 
 
 if __name__ == "__main__":
-    grid_search = gs.GridSearch(phase_name="phase_grid_search", phase_tag='_tag', phase_folders=['integration'])
+    grid_search = gs.GridSearch(phase_name="phase_grid_search", phase_tag='_tag', phase_folders=['integration'],
+                                optimizer_class=non_linear.MultiNest, parallel=True)
     grid_search.variable.profile = mock.EllipticalProfile
 
     # noinspection PyUnresolvedReferences

--- a/test/integration/parallel_grid_search.py
+++ b/test/integration/parallel_grid_search.py
@@ -1,0 +1,38 @@
+import logging
+import shutil
+from os import path
+
+from autofit import mock
+from autofit.optimize import grid_search as gs
+from autofit.optimize import non_linear
+
+logger = logging.getLogger(__name__)
+
+try:
+    output_dir = "{}/../../workspace/output".format(path.dirname(path.realpath(__file__)))
+    logger.info("Removing {}".format(output_dir))
+    shutil.rmtree(output_dir)
+except FileNotFoundError:
+    logging.info("Not found")
+
+
+class Analysis(non_linear.Analysis):
+    def fit(self, instance):
+        return -(instance.profile.centre[0] ** 2 + instance.profile.centre[1] ** 2)
+
+    def visualize(self, instance, **kwargs):
+        pass
+
+    def describe(self, instance):
+        return "{}, {}".format(*instance.profile.centre)
+
+
+if __name__ == "__main__":
+    grid_search = gs.GridSearch(phase_name="phase_grid_search", phase_tag='_tag', phase_folders=['integration'])
+    grid_search.variable.profile = mock.EllipticalProfile
+
+    # noinspection PyUnresolvedReferences
+    result = grid_search.fit(Analysis(),
+                             [grid_search.variable.profile.centre_0, grid_search.variable.profile.centre_1])
+
+    print(result)

--- a/test/optimize/test_optimizer_grid_search.py
+++ b/test/optimize/test_optimizer_grid_search.py
@@ -318,3 +318,7 @@ class TestMixin(object):
         assert len(result.results) == 2
 
         assert isinstance(result.best_result, non_linear.Result)
+
+    def test_parallel_flag(self):
+        my_phase = phase.as_grid_search(phase.AbstractPhase, parallel=True)(phase_name="phase name")
+        assert my_phase.optimizer.parallel

--- a/test/optimize/test_optimizer_grid_search.py
+++ b/test/optimize/test_optimizer_grid_search.py
@@ -210,6 +210,22 @@ class TestGridNLOBehaviour(object):
         assert result.no_dimensions == 2
         assert result.figure_of_merit_array.shape == (10, 10)
 
+    def test_results_parallel(self, grid_search_05, mapper, container):
+        result = grid_search_05.fit(container.MockAnalysis(), [mapper.profile.centre_0, mapper.profile.centre_1])
+
+        assert len(result.results) == 4
+        assert result.no_dimensions == 2
+        assert np.equal(result.figure_of_merit_array, np.array([[1.0, 1.0],
+                                                                [1.0, 1.0]])).all()
+
+        grid_search = gs.GridSearch(model_mapper=mapper, optimizer_class=container.MockOptimizer, number_of_steps=10,
+                                    phase_name="sample_name", parallel=True)
+        result = grid_search.fit(container.MockAnalysis(), [mapper.profile.centre_0, mapper.profile.centre_1])
+
+        assert len(result.results) == 100
+        assert result.no_dimensions == 2
+        assert result.figure_of_merit_array.shape == (10, 10)
+
     def test_generated_models_with_constants(self, grid_search, container):
         constant_profile = mock.GeometryProfile()
         grid_search.constant.constant_profile = constant_profile

--- a/test/test_files/configs/non_linear/non_linear.ini
+++ b/test/test_files/configs/non_linear/non_linear.ini
@@ -27,3 +27,6 @@ maxfun = None
 full_output = 0
 disp = 1
 retall = 0
+
+[GridSearch]
+number_of_cores = 3

--- a/workspace/config/non_linear.ini
+++ b/workspace/config/non_linear.ini
@@ -30,3 +30,4 @@ retall = 0
 
 [GridSearch]
 step_size = 0.1
+number_of_cores = 3


### PR DESCRIPTION
Adds the option to perform optimizer grid search in parallel.

The number of cores is set in non_linear.ini under GridSearch/number_of_cores. It is assumed that the main process takes one core so a minimum of two cores must be set (in which case one process would handle grid searches); The number of processes performing the grid search is number_of_cores - 1. Each process takes jobs from a queue and outputs results to a queue.

The GridSearch class takes a "parallel" argument. This has a default value of False. If set to True then grid searches are performed across multiple processes. 

The parallel argument can also be passed to a GridSearch via the as_grid_search which is used to create a grid search phase from another phase. Here it is also set to False by default.
