### PR TITLE
Feature/eden

### DIFF
--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -11,7 +11,6 @@ dir(conf)
 from . import exc
 from .optimize.non_linear.samples import AbstractSamples, MCMCSamples, NestedSamplerSamples
 from .aggregator import Aggregator, PhaseOutput
-from .mapper import *
 from .mapper import link
 from .mapper.model import AbstractModel
 from .mapper.model import ModelInstance
@@ -31,7 +30,6 @@ from .mapper.prior_model.prior_model import PriorModel
 from .mapper.prior_model.prior_model import PriorModel as Model
 from .mapper.prior_model.util import PriorModelNameValue
 from .optimize.grid_search import GridSearch as OptimizerGridSearch
-from .optimize import *
 from .optimize.non_linear.downhill_simplex import DownhillSimplex
 from .optimize.non_linear.nested_sampling.dynesty import DynestyStatic, DynestyDynamic
 from .optimize.grid_search import GridSearchResult
@@ -45,7 +43,6 @@ from .optimize.non_linear.paths import make_path
 from .optimize.non_linear.paths import convert_paths
 from .optimize.non_linear.non_linear import Result
 from .text import formatter, samples_text
-from .tools import *
 from .tools import path_util
 from .tools.phase import AbstractPhase
 from .tools.phase import Phase
@@ -56,6 +53,10 @@ from .tools.pipeline import Pipeline
 from .tools.pipeline import ResultsCollection
 from .mapper.prior import AbstractPromise
 from .mapper.prior import last
-from .mapper.prior import *
+from .mapper.prior import GaussianPrior
+from .mapper.prior import UniformPrior
+from .mapper.prior import LogUniformPrior
+from .mapper.prior import Prior
+from .mapper import prior
 
 __version__ = '0.58.0'

--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -9,7 +9,7 @@ from autofit.mapper.prior_model.attribute_pair import (
 
 dir(conf)
 from . import exc
-from autofit.optimize.non_linear.samples import AbstractSamples, MCMCSamples, NestedSamplerSamples
+from .optimize.non_linear.samples import AbstractSamples, MCMCSamples, NestedSamplerSamples
 from .aggregator import Aggregator, PhaseOutput
 from .mapper import *
 from .mapper import link
@@ -24,8 +24,8 @@ from .mapper.prior_model.abstract import AbstractPriorModel
 from .mapper.prior_model.annotation import AnnotationPriorModel
 from .mapper.prior_model.collection import CollectionPriorModel
 from .mapper.prior_model.collection import CollectionPriorModel as Collection
-from autofit.mapper.prior.deferred import DeferredArgument
-from autofit.mapper.prior.deferred import DeferredInstance
+from .mapper.prior.deferred import DeferredArgument
+from .mapper.prior.deferred import DeferredInstance
 from .mapper.prior_model.dimension_type import DimensionType, map_types
 from .mapper.prior_model.prior_model import PriorModel
 from .mapper.prior_model.prior_model import PriorModel as Model
@@ -40,9 +40,9 @@ from .optimize.non_linear.mock_nlo import MockNLO
 from .optimize.non_linear.non_linear import Analysis
 from .optimize.non_linear.non_linear import NonLinearOptimizer
 from .optimize.non_linear.emcee import Emcee
-from autofit.optimize.non_linear.paths import Paths
-from autofit.optimize.non_linear.paths import make_path
-from autofit.optimize.non_linear.paths import convert_paths
+from .optimize.non_linear.paths import Paths
+from .optimize.non_linear.paths import make_path
+from .optimize.non_linear.paths import convert_paths
 from .optimize.non_linear.non_linear import Result
 from .text import formatter, samples_text
 from .tools import *
@@ -54,8 +54,8 @@ from .tools.phase import as_grid_search
 from .tools.phase_property import PhaseProperty
 from .tools.pipeline import Pipeline
 from .tools.pipeline import ResultsCollection
-from autofit.mapper.prior import AbstractPromise
-from autofit.mapper.prior import last
+from .mapper.prior import AbstractPromise
+from .mapper.prior import last
 from .mapper.prior import *
 
 __version__ = '0.58.0'

--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -18,7 +18,6 @@ from .mapper.model import ModelInstance as Instance
 from .mapper.model_mapper import ModelMapper
 from .mapper.model_mapper import ModelMapper as Mapper
 from .mapper.model_object import ModelObject
-from .mapper.prior_model import *
 from .mapper.prior_model.abstract import AbstractPriorModel
 from .mapper.prior_model.annotation import AnnotationPriorModel
 from .mapper.prior_model.collection import CollectionPriorModel

--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -1,13 +1,11 @@
-from autoconf import conf
-from autofit.mapper.model import path_instances_of_class
-from autofit.mapper.prior_model.attribute_pair import (
+from .mapper.model import path_instances_of_class
+from .mapper.prior_model.attribute_pair import (
     cast_collection,
     AttributeNameValue,
     PriorNameValue,
     InstanceNameValue,
 )
 
-dir(conf)
 from . import exc
 from .optimize.non_linear.samples import AbstractSamples, MCMCSamples, NestedSamplerSamples
 from .aggregator import Aggregator, PhaseOutput

--- a/autofit/conf.py
+++ b/autofit/conf.py
@@ -1,0 +1,1 @@
+from autoconf.conf import *

--- a/autofit/mapper/prior/prior.py
+++ b/autofit/mapper/prior/prior.py
@@ -7,7 +7,7 @@ from typing import Union, Tuple
 import numpy as np
 from scipy.special import erfcinv
 
-from autoconf import conf
+from autofit import conf
 from autofit import exc
 from autofit.mapper.model_object import ModelObject
 from autofit.mapper.prior.arithmetic import ArithmeticMixin

--- a/autofit/tools/edenise.py
+++ b/autofit/tools/edenise.py
@@ -125,3 +125,5 @@ def edenise(
                         )
                     )
                     f.truncate()
+
+    open(f"{target_directory}/{name}/__init__.py", "w+").close()

--- a/autofit/tools/edenise.py
+++ b/autofit/tools/edenise.py
@@ -1,0 +1,108 @@
+import re
+import shutil
+from os import walk
+
+
+class Line:
+    def __init__(self, string):
+        if "*" in string:
+            print("Please ensure no imports in the __init__ contain a *")
+            exit(1)
+        self.string = string.replace("\n", "")
+
+    def __str__(self):
+        return f"{self.source} -> {self.target}"
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self}>"
+
+    @property
+    def is_import(self):
+        return self.string.startswith("from")
+
+    @property
+    def source(self):
+        match = re.match("from .* as (.+)", self.string)
+        if match is not None:
+            return match.group(1)
+        return re.match("from .* import (.+)", self.string).group(1)
+
+    @property
+    def target(self):
+        return self.string.replace(
+            f" as {self.source}",
+            ""
+        ).replace(
+            "from ",
+            ""
+        ).replace(
+            " import ",
+            "."
+        ).lstrip(
+            "."
+        )
+
+
+class Converter:
+    def __init__(self, prefix, lines):
+        self.prefix = prefix
+        self.lines = list(filter(
+            lambda line: line.is_import,
+            lines
+        ))
+
+    @classmethod
+    def from_prefix_and_source_directory(
+            cls,
+            prefix,
+            source_directory
+    ):
+        source_directory = source_directory
+        with open(
+                f"{source_directory}/__init__.py"
+        ) as f:
+            lines = map(Line, f.readlines())
+        return Converter(prefix, lines)
+
+    def convert(self, string):
+        for line in self.lines:
+            source = f"{self.prefix}.{line.source}"
+            target = f"{self.prefix}.{line.target}"
+            string = string.replace(
+                source,
+                target
+            )
+        return string
+
+
+def edenise(
+        root_directory,
+        name,
+        prefix
+):
+    target_directory = f"{root_directory}/../{name}_eden"
+
+    print(f"Creating {target_directory}...")
+    shutil.copytree(
+        root_directory,
+        target_directory,
+        symlinks=True
+    )
+
+    converter = Converter.from_prefix_and_source_directory(
+        prefix=prefix,
+        source_directory=f"{root_directory}/{name}"
+    )
+
+    for root, _, files in walk(f"{target_directory}/test_{name}"):
+        for file in files:
+            if file.endswith(".py"):
+                with open(f"{root}/{file}", "r+") as f:
+                    string = f.read()
+                    f.seek(0)
+                    f.write(
+                        converter.convert(
+                            string
+                        )
+                    )
+                    f.truncate()

--- a/scripts/edenise.py
+++ b/scripts/edenise.py
@@ -14,14 +14,23 @@ class Line:
 
     @property
     def source(self):
-        match = re.match(".* as (.+)", self.string)
+        match = re.match("from .* as (.+)", self.string)
         if match is not None:
             return match.group(1)
-        return re.match(".* import (.+)", self.string).group(1)
+        return re.match("from .* import (.+)", self.string).group(1)
 
     @property
     def target(self):
-        pass
+        return self.string.replace(
+            f" as {self.source}",
+            ""
+        ).replace(
+            "from ",
+            ""
+        ).replace(
+            " import ",
+            "."
+        )
 
 
 class Converter:
@@ -44,16 +53,27 @@ def make_as_line():
     )
 
 
+@pytest.fixture(
+    name="line"
+)
+def make_line():
+    return Line(
+        "from .mapper.model import ModelInstance"
+    )
+
+
 class Test:
     def test_line_is_import(self, as_line):
         assert as_line.is_import
         assert not Line(".mapper.model").is_import
 
-    def test_source(self, as_line):
+    def test_source(self, as_line, line):
         assert as_line.source == "Instance"
-        assert Line(
-            "from .mapper.model import ModelInstance"
-        ).source == "ModelInstance"
+        assert line.source == "ModelInstance"
+
+    def test_target(self, as_line, line):
+        assert as_line.target == ".mapper.model.ModelInstance"
+        assert line.target == ".mapper.model.ModelInstance"
 
 
 if __name__ == "__main__":

--- a/scripts/edenise.py
+++ b/scripts/edenise.py
@@ -30,18 +30,41 @@ class Line:
         ).replace(
             " import ",
             "."
+        ).lstrip(
+            "."
         )
 
 
 class Converter:
-    def __init__(self, source_directory):
-        self.source_directory = source_directory
-        with open(self._init_directory) as f:
-            lines = map(Line, f.readlines())
+    def __init__(self, prefix, lines):
+        self.prefix = prefix
+        self.lines = lines
 
-    @property
-    def _init_directory(self):
-        return f"{self.source_directory}/__init__.py"
+    @classmethod
+    def from_prefix_and_source_directory(
+            cls,
+            prefix,
+            source_directory
+    ):
+        source_directory = source_directory
+        with open(
+                f"{source_directory}/__init__.py"
+        ) as f:
+            lines = map(Line, f.readlines())
+        return Converter(prefix, lines)
+
+    def convert(self, string):
+        print(string)
+        for line in self.lines:
+            source = f"{self.prefix}.{line.source}"
+            target = f"{self.prefix}.{line.target}"
+            print(source)
+            print(target)
+            string = string.replace(
+                source,
+                target
+            )
+        return string
 
 
 @pytest.fixture(
@@ -72,13 +95,27 @@ class Test:
         assert line.source == "ModelInstance"
 
     def test_target(self, as_line, line):
-        assert as_line.target == ".mapper.model.ModelInstance"
-        assert line.target == ".mapper.model.ModelInstance"
+        assert as_line.target == "mapper.model.ModelInstance"
+        assert line.target == "mapper.model.ModelInstance"
+
+    def test_replace(self, as_line, line):
+        converter = Converter(
+            "af",
+            [as_line, line]
+        )
+        assert converter.convert(
+            "af.ModelInstance\naf.Instance"
+        ) == "af.mapper.model.ModelInstance\naf.mapper.model.ModelInstance"
+             
+
+def main():
+    root_directory = Path(__file__).parent.parent
+
+    converter = Converter.from_prefix_and_source_directory(
+        prefix="af",
+        source_directory=root_directory / "autofit"
+    )
 
 
 if __name__ == "__main__":
-    root_directory = Path(__file__).parent.parent
-
-    converter = Converter(
-        source_directory=root_directory / "autofit"
-    )
+    main()

--- a/scripts/edenise.py
+++ b/scripts/edenise.py
@@ -1,123 +1,7 @@
 #!/usr/bin/env python
 
-import re
-import shutil
-from os import path, walk
-
-import pytest
-
-
-class Line:
-    def __init__(self, string):
-        if "*" in string:
-            print("Please ensure no imports in the __init__ contain a *")
-            exit(1)
-        self.string = string.replace("\n", "")
-
-    def __str__(self):
-        return f"{self.source} -> {self.target}"
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} {self}>"
-
-    @property
-    def is_import(self):
-        return self.string.startswith("from")
-
-    @property
-    def source(self):
-        match = re.match("from .* as (.+)", self.string)
-        if match is not None:
-            return match.group(1)
-        return re.match("from .* import (.+)", self.string).group(1)
-
-    @property
-    def target(self):
-        return self.string.replace(
-            f" as {self.source}",
-            ""
-        ).replace(
-            "from ",
-            ""
-        ).replace(
-            " import ",
-            "."
-        ).lstrip(
-            "."
-        )
-
-
-class Converter:
-    def __init__(self, prefix, lines):
-        self.prefix = prefix
-        self.lines = list(filter(
-            lambda line: line.is_import,
-            lines
-        ))
-
-    @classmethod
-    def from_prefix_and_source_directory(
-            cls,
-            prefix,
-            source_directory
-    ):
-        source_directory = source_directory
-        with open(
-                f"{source_directory}/__init__.py"
-        ) as f:
-            lines = map(Line, f.readlines())
-        return Converter(prefix, lines)
-
-    def convert(self, string):
-        for line in self.lines:
-            source = f"{self.prefix}.{line.source}"
-            target = f"{self.prefix}.{line.target}"
-            string = string.replace(
-                source,
-                target
-            )
-        return string
-
-
-@pytest.fixture(
-    name="as_line"
-)
-def make_as_line():
-    return Line(
-        "from .mapper.model import ModelInstance as Instance"
-    )
-
-
-@pytest.fixture(
-    name="line"
-)
-def make_line():
-    return Line(
-        "from .mapper.model import ModelInstance"
-    )
-
-
-# class Test:
-#     def test_line_is_import(self, as_line):
-#         assert as_line.is_import
-#         assert not Line(".mapper.model").is_import
-#
-#     def test_source(self, as_line, line):
-#         assert as_line.source == "Instance"
-#         assert line.source == "ModelInstance"
-#
-#     def test_target(self, as_line, line):
-#         assert as_line.target == "mapper.model.ModelInstance"
-#         assert line.target == "mapper.model.ModelInstance"
-#
-#     def test_replace(self, as_line, line):
-#         converter = Converter(
-#             "af",
-#             [as_line, line]
-#         )
-#         assert converter.convert(
-#             "af.ModelInstance\naf.Instance"
-#         ) == "af.mapper.model.ModelInstance\naf.mapper.model.ModelInstance"
+from os import path
+from autofit.tools import edenise
 
 
 def main():
@@ -125,33 +9,11 @@ def main():
 
     name = "autofit"
     prefix = "af"
-
-    target_directory = f"{root_directory}/../{name}_eden"
-
-    print(f"Creating {target_directory}...")
-    shutil.copytree(
+    edenise.edenise(
         root_directory,
-        target_directory,
-        symlinks=True
+        name,
+        prefix
     )
-
-    converter = Converter.from_prefix_and_source_directory(
-        prefix=prefix,
-        source_directory=f"{root_directory}/{name}"
-    )
-
-    for root, _, files in walk(f"{target_directory}/test_{name}"):
-        for file in files:
-            if file.endswith(".py"):
-                with open(f"{root}/{file}", "r+") as f:
-                    string = f.read()
-                    f.seek(0)
-                    f.write(
-                        converter.convert(
-                            string
-                        )
-                    )
-                    f.truncate()
 
 
 if __name__ == "__main__":

--- a/scripts/edenise.py
+++ b/scripts/edenise.py
@@ -12,7 +12,13 @@ class Line:
         if "*" in string:
             print("Please ensure no imports in the __init__ contain a *")
             exit(1)
-        self.string = string
+        self.string = string.replace("\n", "")
+
+    def __str__(self):
+        return f"{self.source} -> {self.target}"
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self}>"
 
     @property
     def is_import(self):
@@ -44,7 +50,10 @@ class Line:
 class Converter:
     def __init__(self, prefix, lines):
         self.prefix = prefix
-        self.lines = lines
+        self.lines = list(filter(
+            lambda line: line.is_import,
+            lines
+        ))
 
     @classmethod
     def from_prefix_and_source_directory(
@@ -88,27 +97,27 @@ def make_line():
     )
 
 
-class Test:
-    def test_line_is_import(self, as_line):
-        assert as_line.is_import
-        assert not Line(".mapper.model").is_import
-
-    def test_source(self, as_line, line):
-        assert as_line.source == "Instance"
-        assert line.source == "ModelInstance"
-
-    def test_target(self, as_line, line):
-        assert as_line.target == "mapper.model.ModelInstance"
-        assert line.target == "mapper.model.ModelInstance"
-
-    def test_replace(self, as_line, line):
-        converter = Converter(
-            "af",
-            [as_line, line]
-        )
-        assert converter.convert(
-            "af.ModelInstance\naf.Instance"
-        ) == "af.mapper.model.ModelInstance\naf.mapper.model.ModelInstance"
+# class Test:
+#     def test_line_is_import(self, as_line):
+#         assert as_line.is_import
+#         assert not Line(".mapper.model").is_import
+#
+#     def test_source(self, as_line, line):
+#         assert as_line.source == "Instance"
+#         assert line.source == "ModelInstance"
+#
+#     def test_target(self, as_line, line):
+#         assert as_line.target == "mapper.model.ModelInstance"
+#         assert line.target == "mapper.model.ModelInstance"
+#
+#     def test_replace(self, as_line, line):
+#         converter = Converter(
+#             "af",
+#             [as_line, line]
+#         )
+#         assert converter.convert(
+#             "af.ModelInstance\naf.Instance"
+#         ) == "af.mapper.model.ModelInstance\naf.mapper.model.ModelInstance"
 
 
 def main():

--- a/scripts/edenise.py
+++ b/scripts/edenise.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python
 
-from os import path
+from sys import argv
+
 from autofit.tools import edenise
 
 
 def main():
-    root_directory = f"{path.dirname(path.realpath(__file__))}/.."
-
-    name = "autofit"
-    prefix = "af"
-    edenise.edenise(
-        root_directory,
-        name,
-        prefix
-    )
+    try:
+        root_directory, name, prefix = argv[1:]
+        edenise.edenise(
+            root_directory,
+            name,
+            prefix
+        )
+    except ValueError:
+        print("Usage: ./edenise.py root_directory project_name import_prefix")
+        print("e.g.: ./edenise.py /path/to/autofit autofit af")
+        exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/edenise.py
+++ b/scripts/edenise.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+import re
+
+
+class Line:
+    def __init__(self, string):
+        self.string = string
+
+    @property
+    def is_import(self):
+        return self.string.startswith("from")
+
+    @property
+    def source(self):
+        return re.match(".* as (.+)", self.string).group(1)
+
+    @property
+    def target(self):
+        pass
+
+
+class Converter:
+    def __init__(self, source_directory):
+        self.source_directory = source_directory
+        with open(self._init_directory) as f:
+            lines = map(Line, f.readlines())
+
+    @property
+    def _init_directory(self):
+        return f"{self.source_directory}/__init__.py"
+
+
+@pytest.fixture(
+    name="as_line"
+)
+def make_as_line():
+    return Line(
+        "from .mapper.model import ModelInstance as Instance"
+    )
+
+
+class Test:
+    def test_line_is_import(self, as_line):
+        assert as_line.is_import
+        assert not Line(".mapper.model").is_import
+
+    def test_source(self, as_line):
+        assert as_line.source == "Instance"
+        # assert Line(
+        #     "from .mapper.model import ModelInstance"
+        # ).source == "ModelInstance"
+
+
+if __name__ == "__main__":
+    root_directory = Path(__file__).parent.parent
+
+    converter = Converter(
+        source_directory=root_directory / "autofit"
+    )

--- a/scripts/edenise.py
+++ b/scripts/edenise.py
@@ -1,7 +1,7 @@
+import re
 from pathlib import Path
 
 import pytest
-import re
 
 
 class Line:
@@ -14,7 +14,10 @@ class Line:
 
     @property
     def source(self):
-        return re.match(".* as (.+)", self.string).group(1)
+        match = re.match(".* as (.+)", self.string)
+        if match is not None:
+            return match.group(1)
+        return re.match(".* import (.+)", self.string).group(1)
 
     @property
     def target(self):
@@ -48,9 +51,9 @@ class Test:
 
     def test_source(self, as_line):
         assert as_line.source == "Instance"
-        # assert Line(
-        #     "from .mapper.model import ModelInstance"
-        # ).source == "ModelInstance"
+        assert Line(
+            "from .mapper.model import ModelInstance"
+        ).source == "ModelInstance"
 
 
 if __name__ == "__main__":

--- a/test_autofit/conftest.py
+++ b/test_autofit/conftest.py
@@ -3,7 +3,7 @@ from os import path
 import pytest
 
 import autofit as af
-from autoconf import conf
+from autofit import conf
 import shutil
 
 directory = path.dirname(path.realpath(__file__))

--- a/test_autofit/unit/mapper/model/test_model_mapper.py
+++ b/test_autofit/unit/mapper/model/test_model_mapper.py
@@ -4,12 +4,12 @@ import numpy as np
 import pytest
 
 import autofit as af
-from test_autofit.mock import MockClassGaussian
 import test_autofit.mock
 from autofit import exc
 from autofit.text import formatter as frm
 from test_autofit import mock
 from test_autofit.mock import GeometryProfile
+from test_autofit.mock import MockClassGaussian
 
 dataset_path = "{}/../".format(os.path.dirname(os.path.realpath(__file__)))
 
@@ -108,7 +108,7 @@ class TestGenerateModelInfo:
 
     def test_with_promise(self):
         mm = af.ModelMapper()
-        mm.promise = af.Promise(
+        mm.promise = af.prior.Promise(
             af.Phase(
                 phase_name="phase",
                 analysis_class=None
@@ -528,7 +528,6 @@ class TestModelInstancesRealClasses:
         assert log_priors == [0.125, 0.2]
 
     def test_random_vector_from_prior_within_limits(self):
-
         np.random.seed(1)
 
         mapper = af.ModelMapper()
@@ -864,7 +863,7 @@ def make_promise_mapper():
     mapper = af.ModelMapper()
     mapper.galaxy = af.PriorModel(
         mock.Galaxy,
-        redshift=af.Promise(
+        redshift=af.prior.Promise(
             None,
             None,
             is_instance=False,

--- a/test_autofit/unit/mapper/promise/test_iteration.py
+++ b/test_autofit/unit/mapper/promise/test_iteration.py
@@ -46,8 +46,8 @@ class TestIteration:
         promise_0 = phase.result.model.collection[0]
         promise_1 = phase.result.model.collection[1]
 
-        assert isinstance(promise_0, af.Promise)
-        assert isinstance(promise_1, af.Promise)
+        assert isinstance(promise_0, af.prior.Promise)
+        assert isinstance(promise_1, af.prior.Promise)
 
     def test_index_populate_model(self, phase, prior_0, prior_1, results_collection):
         promise_0 = phase.result.model.collection[0]
@@ -73,4 +73,4 @@ class TestIteration:
         promises = list(phase.result.model.collection)
 
         assert len(promises) == 2
-        assert all([isinstance(promise, af.Promise) for promise in promises])
+        assert all([isinstance(promise, af.prior.Promise) for promise in promises])

--- a/test_autofit/unit/mapper/promise/test_promise.py
+++ b/test_autofit/unit/mapper/promise/test_promise.py
@@ -174,7 +174,7 @@ class TestCase:
         assert model.prior_count == 0
 
     def test_model_promise(self, model_promise, phase):
-        assert isinstance(model_promise, af.Promise)
+        assert isinstance(model_promise, af.prior.Promise)
         assert model_promise.path == ("one", "redshift")
         assert model_promise.is_instance is False
         assert model_promise._phase is phase
@@ -190,7 +190,7 @@ class TestCase:
         assert result is None
 
     def test_instance_promise(self, instance_promise, phase):
-        assert isinstance(instance_promise, af.Promise)
+        assert isinstance(instance_promise, af.prior.Promise)
         assert instance_promise.path == ("one", "redshift")
         assert instance_promise.is_instance is True
         assert instance_promise._phase is phase
@@ -239,13 +239,13 @@ class TestCase:
     def test_embedded_results(self, phase, collection):
         hyper_result = phase.result.hyper_result
 
-        assert isinstance(hyper_result, af.PromiseResult)
+        assert isinstance(hyper_result, af.prior.PromiseResult)
 
         model_promise = hyper_result.model
         instance_promise = hyper_result.instance
 
-        assert isinstance(model_promise.hyper_galaxy, af.Promise)
-        assert isinstance(instance_promise.hyper_galaxy, af.Promise)
+        assert isinstance(model_promise.hyper_galaxy, af.prior.Promise)
+        assert isinstance(instance_promise.hyper_galaxy, af.prior.Promise)
 
         model = model_promise.populate(collection)
         instance = instance_promise.populate(collection)

--- a/test_autofit/unit/mapper/test_assertion.py
+++ b/test_autofit/unit/mapper/test_assertion.py
@@ -119,29 +119,29 @@ def make_model(collection):
 class TestPromiseAssertion:
     def test_less_than(self, promise_model, collection, model):
         promise = promise_model.axis_ratio < promise_model.phi
-        assert isinstance(promise, af.GreaterThanLessThanAssertion)
+        assert isinstance(promise, af.prior.GreaterThanLessThanAssertion)
 
         assertion = promise.populate(collection)
-        assert isinstance(assertion, af.GreaterThanLessThanAssertion)
+        assert isinstance(assertion, af.prior.GreaterThanLessThanAssertion)
 
     def test_greater_than(self, promise_model, collection, model):
         promise = promise_model.axis_ratio > promise_model.phi
-        assert isinstance(promise, af.GreaterThanLessThanAssertion)
+        assert isinstance(promise, af.prior.GreaterThanLessThanAssertion)
 
     def test_greater_than_equal(self, promise_model, collection, model):
         promise = promise_model.axis_ratio >= promise_model.phi
-        assert isinstance(promise, af.GreaterThanLessThanEqualAssertion)
+        assert isinstance(promise, af.prior.GreaterThanLessThanEqualAssertion)
 
     def test_integer_promise_assertion(self, promise_model, collection, model):
         promise = promise_model.axis_ratio > 1.0
-        assert isinstance(promise, af.GreaterThanLessThanAssertion)
+        assert isinstance(promise, af.prior.GreaterThanLessThanAssertion)
 
     def test_compound_assertion(self, promise_model, collection, model):
         promise = (1.0 < promise_model.axis_ratio) < 1.0
-        assert isinstance(promise, af.CompoundAssertion)
+        assert isinstance(promise, af.prior.CompoundAssertion)
 
         assertion = promise.populate(collection)
-        assert isinstance(assertion, af.CompoundAssertion)
+        assert isinstance(assertion, af.prior.CompoundAssertion)
 
 
 class TestModel:

--- a/test_autofit/unit/mapper/test_prior_parsing.py
+++ b/test_autofit/unit/mapper/test_prior_parsing.py
@@ -52,21 +52,21 @@ def make_absolute_width_dict():
 
 @pytest.fixture(name="relative_width_modifier")
 def make_relative_width_modifier(relative_width_dict):
-    return af.WidthModifier.from_dict(relative_width_dict)
+    return af.prior.WidthModifier.from_dict(relative_width_dict)
 
 
 @pytest.fixture(name="absolute_width_modifier")
 def make_absolute_width_modifier(absolute_width_dict):
-    return af.WidthModifier.from_dict(absolute_width_dict)
+    return af.prior.WidthModifier.from_dict(absolute_width_dict)
 
 
 class TestWidth:
     def test_relative(self, relative_width_modifier):
-        assert isinstance(relative_width_modifier, af.RelativeWidthModifier)
+        assert isinstance(relative_width_modifier, af.prior.RelativeWidthModifier)
         assert relative_width_modifier.value == 1.0
 
     def test_absolute(self, absolute_width_modifier):
-        assert isinstance(absolute_width_modifier, af.AbsoluteWidthModifier)
+        assert isinstance(absolute_width_modifier, af.prior.AbsoluteWidthModifier)
         assert absolute_width_modifier.value == 2.0
 
 

--- a/test_autofit/unit/optimize/nested_sampler/files/multinest/config/json_priors/mock.json
+++ b/test_autofit/unit/optimize/nested_sampler/files/multinest/config/json_priors/mock.json
@@ -612,9 +612,7 @@
         }
     },
     "Tracer": {
-        "grid": {
-            "type": "Deferred"
-        }
+        "grid.type": "Deferred"
     },
     "Circle": {
         "circumference": {

--- a/test_autofit/unit/optimize/nested_sampler/files/multinest/config/json_priors/test_autofit.json
+++ b/test_autofit/unit/optimize/nested_sampler/files/multinest/config/json_priors/test_autofit.json
@@ -1,33 +1,63 @@
 {
-    "mock.Tracer": {
-        "lens_galaxy": {
-            "type": "Uniform",
-            "lower_limit": 0.0,
-            "upper_limit": 1.0,
-            "width_modifier": {
-                "type": "Absolute",
-                "value": 0.2
+    "mock": {
+        "Tracer": {
+            "lens_galaxy": {
+                "type": "Uniform",
+                "lower_limit": 0.0,
+                "upper_limit": 1.0,
+                "width_modifier": {
+                    "type": "Absolute",
+                    "value": 0.2
+                },
+                "gaussian_limits": {
+                    "lower": 0.0,
+                    "upper": 1.0
+                }
             },
-            "gaussian_limits": {
-                "lower": 0.0,
-                "upper": 1.0
+            "source_galaxy": {
+                "type": "Uniform",
+                "lower_limit": 0.0,
+                "upper_limit": 1.0,
+                "width_modifier": {
+                    "type": "Absolute",
+                    "value": 0.2
+                },
+                "gaussian_limits": {
+                    "lower": 0.0,
+                    "upper": 1.0
+                }
+            },
+            "grid": {
+                "type": "Deferred"
             }
         },
-        "source_galaxy": {
-            "type": "Uniform",
-            "lower_limit": 0.0,
-            "upper_limit": 1.0,
-            "width_modifier": {
-                "type": "Absolute",
-                "value": 0.2
+        "MockClassNLOx2": {
+            "one": {
+                "type": "Uniform",
+                "lower_limit": 0.0,
+                "upper_limit": 1.0,
+                "width_modifier": {
+                    "type": "Absolute",
+                    "value": 0.2
+                },
+                "gaussian_limits": {
+                    "lower": 0.0,
+                    "upper": 1.0
+                }
             },
-            "gaussian_limits": {
-                "lower": 0.0,
-                "upper": 1.0
+            "two": {
+                "type": "Uniform",
+                "lower_limit": 0.0,
+                "upper_limit": 1.0,
+                "width_modifier": {
+                    "type": "Absolute",
+                    "value": 0.2
+                },
+                "gaussian_limits": {
+                    "lower": 0.0,
+                    "upper": 1.0
+                }
             }
-        },
-        "grid": {
-            "type": "Deferred"
         }
     }
 }

--- a/test_autofit/unit/optimize/nested_sampler/test_dynesty.py
+++ b/test_autofit/unit/optimize/nested_sampler/test_dynesty.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from autofit import Paths
-from autoconf import conf
+from autofit import conf
 import autofit as af
 import pickle
 from test_autofit.mock import MockClassNLOx4

--- a/test_autofit/unit/optimize/nested_sampler/test_multi_nest.py
+++ b/test_autofit/unit/optimize/nested_sampler/test_multi_nest.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 import pytest
 
-from autoconf import conf
+from autofit import conf
 import autofit as af
 from autofit import Paths
 from autofit.optimize.non_linear.nested_sampling import multi_nest as mn

--- a/test_autofit/unit/optimize/test_emcee.py
+++ b/test_autofit/unit/optimize/test_emcee.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from autoconf import conf
+from autofit import conf
 import autofit as af
 from autofit import Paths
 from test_autofit.mock import MockClassNLOx4

--- a/test_autofit/unit/optimize/test_non_linear.py
+++ b/test_autofit/unit/optimize/test_non_linear.py
@@ -4,7 +4,7 @@ import shutil
 import pytest
 
 import autofit as af
-from autoconf import conf
+from autofit import conf
 from autofit import Paths
 from autofit.optimize.non_linear.mock_nlo import MockSamples
 from test_autofit.mock import (

--- a/test_autofit/unit/tools/test_edenise.py
+++ b/test_autofit/unit/tools/test_edenise.py
@@ -34,6 +34,13 @@ class Test:
         assert as_line.target == "mapper.model.ModelInstance"
         assert line.target == "mapper.model.ModelInstance"
 
+    def test_phase_property_line(self):
+        line = Line(
+            "from .tools.phase_property import PhaseProperty"
+        )
+        assert line.source == "PhaseProperty"
+        assert line.target == "tools.phase_property.PhaseProperty"
+
     def test_replace(self, as_line, line):
         converter = Converter(
             "af",

--- a/test_autofit/unit/tools/test_edenise.py
+++ b/test_autofit/unit/tools/test_edenise.py
@@ -1,0 +1,44 @@
+import pytest
+
+from autofit.tools.edenise import Line, Converter
+
+
+@pytest.fixture(
+    name="as_line"
+)
+def make_as_line():
+    return Line(
+        "from .mapper.model import ModelInstance as Instance"
+    )
+
+
+@pytest.fixture(
+    name="line"
+)
+def make_line():
+    return Line(
+        "from .mapper.model import ModelInstance"
+    )
+
+
+class Test:
+    def test_line_is_import(self, as_line):
+        assert as_line.is_import
+        assert not Line(".mapper.model").is_import
+
+    def test_source(self, as_line, line):
+        assert as_line.source == "Instance"
+        assert line.source == "ModelInstance"
+
+    def test_target(self, as_line, line):
+        assert as_line.target == "mapper.model.ModelInstance"
+        assert line.target == "mapper.model.ModelInstance"
+
+    def test_replace(self, as_line, line):
+        converter = Converter(
+            "af",
+            [as_line, line]
+        )
+        assert converter.convert(
+            "af.ModelInstance\naf.Instance"
+        ) == "af.mapper.model.ModelInstance\naf.mapper.model.ModelInstance"


### PR DESCRIPTION
- Makes a copy of the project in the same directory suffixed with _eden
- Replaces references that use the project abbreviation with explicit paths in tests
- Wipes the top level \_\_init\_\_

```bash
python edenise.py /path/to/autofit autofit af
```