### PR TITLE
collection instantiation

### DIFF
--- a/autofit/mapper/prior_model/collection.py
+++ b/autofit/mapper/prior_model/collection.py
@@ -148,7 +148,7 @@ class CollectionPriorModel(AbstractPriorModel):
             if isinstance(value, AbstractPriorModel):
                 value = value.instance_for_arguments(arguments)
             if isinstance(value, Prior):
-                value = value.value_for(arguments[value])
+                value = arguments[value]
             setattr(result, key, value)
         return result
 


### PR DESCRIPTION
value_for was applied twice to arguments when priors were directly associated with a collection
