### PR TITLE
raise a config exception when prior configuration is missing at identifier generation

### DIFF
--- a/autofit/mapper/model_object.py
+++ b/autofit/mapper/model_object.py
@@ -38,6 +38,10 @@ class Identifier:
         value
             An object
         """
+        if isinstance(
+                value, Exception
+        ):
+            raise value
         if hasattr(value, "__dict__"):
             d = value.__dict__
             if hasattr(

--- a/test_autofit/mapper/model/test_regression.py
+++ b/test_autofit/mapper/model/test_regression.py
@@ -1,0 +1,21 @@
+import pytest
+
+import autofit as af
+from autoconf.exc import ConfigException
+from autofit.mapper.model_object import Identifier
+
+
+class SomeWeirdClass:
+    def __init__(self, argument):
+        self.argument = argument
+
+
+def test_config_error():
+    model = af.Model(
+        SomeWeirdClass
+    )
+
+    with pytest.raises(ConfigException):
+        print(Identifier([
+            model
+        ]))


### PR DESCRIPTION
Raise exception when generating identifier for missing config

closes #228
