### PR TITLE
feature/declarative global

### DIFF
--- a/autofit/config/general.ini
+++ b/autofit/config/general.ini
@@ -13,3 +13,6 @@ ignore_prior_limits = False
 
 [test]
 test_mode = False
+
+[analysis]
+n_cores = 1

--- a/autofit/non_linear/analysis.py
+++ b/autofit/non_linear/analysis.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from abc import ABC
 from itertools import count
 from multiprocessing import Process
@@ -192,7 +193,7 @@ class AnalysisPool:
             n_cores
         )
 
-        analyses_per_process = int(
+        analyses_per_process = math.ceil(
             self.n_analyses / n_processes
         )
 

--- a/autofit/non_linear/analysis.py
+++ b/autofit/non_linear/analysis.py
@@ -49,6 +49,11 @@ class Analysis(ABC):
         -------
         A class that computes log likelihood based on both analyses
         """
+        if isinstance(
+                other,
+                CombinedAnalysis
+        ):
+            return other + self
         return CombinedAnalysis(
             self, other
         )
@@ -78,6 +83,23 @@ class CombinedAnalysis(Analysis):
             ).map
         else:
             self.map = map
+
+    def __len__(self):
+        return len(self.analyses)
+
+    def __add__(self, other):
+        if isinstance(
+                other,
+                CombinedAnalysis
+        ):
+            return CombinedAnalysis(
+                *self.analyses,
+                *other.analyses
+            )
+        return CombinedAnalysis(
+            *self.analyses,
+            other
+        )
 
     def log_likelihood_function(
             self,

--- a/autofit/non_linear/analysis.py
+++ b/autofit/non_linear/analysis.py
@@ -1,11 +1,21 @@
 from abc import ABC
+import logging
+from abc import ABC
+from itertools import count
 from multiprocessing import Pool
+from multiprocessing import Process
+from multiprocessing.queues import Queue
 
 from autoconf import conf
 from autofit.mapper.prior_model.collection import CollectionPriorModel
+from autofit.non_linear.parallel.sneaky import StopCommand
 from autofit.non_linear.paths.abstract import AbstractPaths
 from autofit.non_linear.result import Result
 from autofit.non_linear.samples import OptimizerSamples
+
+logger = logging.getLogger(
+    __name__
+)
 
 
 class Analysis(ABC):
@@ -129,6 +139,153 @@ class CombinedAnalysis(Analysis):
             inverse,
             self.analyses
         ))
+
+
+class AnalysisProcess(Process):
+    _id = count()
+
+    def __init__(
+            self,
+            analyses,
+            analysis_queues
+    ):
+        super().__init__()
+        self.analyses = analyses
+        self.analysis_queues = analysis_queues
+        self.queue = Queue()
+
+        self.name = f"analysis_process_{next(self._id)}"
+
+        self.logger = logging.getLogger(
+            self.name
+        )
+
+    def _run(self):
+        while True:
+            for analysis, queue in zip(
+                    self.analyses,
+                    self.analysis_queues
+            ):
+                instance = queue.get()
+
+                if instance is StopCommand:
+                    return
+
+                try:
+                    self.queue.put(
+                        analysis.log_likelihood_function(
+                            instance
+                        )
+                    )
+                except Exception as e:
+                    self.queue.put(e)
+
+    def run(self):
+        """
+        Run this process, completing each job in the job_queue and
+        passing the result to the queue.
+        """
+
+        self.logger.debug("starting")
+
+        self._run()
+
+        self.logger.debug("terminating")
+        self.queue.close()
+
+
+class AnalysisPool:
+    def __init__(
+            self,
+            analyses,
+            n_cores
+    ):
+        self.analyses = analyses
+        self.n_cores = n_cores
+
+        self.n_analyses = len(analyses)
+        n_processes = min(
+            self.n_analyses,
+            n_cores
+        )
+
+        analyses_per_process = int(
+            self.n_analyses / n_processes
+        )
+
+        self.processes = list()
+        self.analysis_queues = list()
+
+        for n in range(
+                n_processes
+        ):
+            analyses_ = analyses[
+                        n * analyses_per_process: (n + 1) * analyses_per_process
+                        ]
+            analysis_queues_ = [
+                Queue()
+                for _
+                in analyses_
+            ]
+            process = AnalysisProcess(
+                analyses=analyses_,
+                analysis_queues=analysis_queues_
+            )
+            self.analysis_queues.extend(analysis_queues_)
+
+            self.processes.append(
+                process
+            )
+            process.start()
+
+    def __del__(self):
+        """
+        Called when the map goes out of scope.
+
+        Tell each process to terminate with a StopCommand and then join
+        each process with a timeout of one second.
+        """
+        logger.debug(
+            "Deconstructing SneakyMap"
+        )
+
+        logger.debug(
+            "Terminating processes..."
+        )
+        for analysis_queue in self.analysis_queues:
+            analysis_queue.put(StopCommand)
+
+        logger.debug(
+            "Joining processes..."
+        )
+        for process in self.processes:
+            try:
+                process.join(0.5)
+            except Exception as e:
+                logger.exception(e)
+
+    def __call__(self, instance):
+        log_likelihood = 0
+
+        count_ = 0
+
+        for queue in self.analysis_queues:
+            queue.put(instance)
+
+        while count_ < self.n_analyses:
+            for process in self.processes:
+                result = process.queue.get()
+
+                if isinstance(
+                        result,
+                        Exception
+                ):
+                    raise result
+
+                log_likelihood += result
+                count_ += 1
+
+        return log_likelihood
 
 
 class Inverse:

--- a/autofit/non_linear/analysis.py
+++ b/autofit/non_linear/analysis.py
@@ -7,6 +7,11 @@ from autofit.non_linear.samples import OptimizerSamples
 
 
 class Analysis(ABC):
+    """
+    Protocol for an analysis. Defines methods that can or
+    must be implemented to define a class that compute the
+    likelihood that some instance fits some data.
+    """
 
     def log_likelihood_function(self, instance):
         raise NotImplementedError()
@@ -23,3 +28,70 @@ class Analysis(ABC):
 
     def make_result(self, samples, model, search):
         return Result(samples=samples, model=model, search=search)
+
+    def __add__(
+            self,
+            other: "Analysis"
+    ) -> "CombinedAnalysis":
+        """
+        Analyses can be added together. The resultant
+        log likelihood function returns the sum of the
+        underlying log likelihood functions.
+
+        Parameters
+        ----------
+        other
+            Another analysis class
+
+        Returns
+        -------
+        A class that computes log likelihood based on both analyses
+        """
+        return CombinedAnalysis(
+            self, other
+        )
+
+
+class CombinedAnalysis(Analysis):
+    def __init__(self, *analyses: Analysis):
+        """
+        Computes the summed log likelihood of multiple analyses
+        applied to a single model.
+
+        Parameters
+        ----------
+        analyses
+        """
+        self.analyses = analyses
+
+    def log_likelihood_function(
+            self,
+            instance
+    ) -> float:
+        """
+        Compute the summed log likelihood of all analyses
+        applied to the instance
+
+        Parameters
+        ----------
+        instance
+            An instance of a model for some location in
+            parameter space
+
+        Returns
+        -------
+        The summed log likelihood across all contained
+        log likelihoods
+        """
+
+        def compute_log_likelihood(
+                analysis
+        ):
+            return analysis.log_likelihood_function(
+                instance
+            )
+
+        return sum(map(
+            compute_log_likelihood,
+            self.analyses
+        ))

--- a/autofit/non_linear/analysis/__init__.py
+++ b/autofit/non_linear/analysis/__init__.py
@@ -1,0 +1,1 @@
+from .analysis import Analysis

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -1,0 +1,121 @@
+import logging
+from abc import ABC
+
+from autoconf import conf
+from autofit.mapper.prior_model.collection import CollectionPriorModel
+from autofit.non_linear.analysis.multiprocessing import AnalysisPool
+from autofit.non_linear.paths.abstract import AbstractPaths
+from autofit.non_linear.result import Result
+from autofit.non_linear.samples import OptimizerSamples
+
+logger = logging.getLogger(
+    __name__
+)
+
+
+class Analysis(ABC):
+    """
+    Protocol for an analysis. Defines methods that can or
+    must be implemented to define a class that compute the
+    likelihood that some instance fits some data.
+    """
+
+    def log_likelihood_function(self, instance):
+        raise NotImplementedError()
+
+    def visualize(self, paths: AbstractPaths, instance, during_analysis):
+        pass
+
+    def save_attributes_for_aggregator(self, paths: AbstractPaths):
+        pass
+
+    def save_results_for_aggregator(self, paths: AbstractPaths, model: CollectionPriorModel,
+                                    samples: OptimizerSamples):
+        pass
+
+    def make_result(self, samples, model, search):
+        return Result(samples=samples, model=model, search=search)
+
+    def __add__(
+            self,
+            other: "Analysis"
+    ) -> "CombinedAnalysis":
+        """
+        Analyses can be added together. The resultant
+        log likelihood function returns the sum of the
+        underlying log likelihood functions.
+
+        Parameters
+        ----------
+        other
+            Another analysis class
+
+        Returns
+        -------
+        A class that computes log likelihood based on both analyses
+        """
+        if isinstance(
+                other,
+                CombinedAnalysis
+        ):
+            return other + self
+        return CombinedAnalysis(
+            self, other
+        )
+
+
+class CombinedAnalysis(Analysis):
+    def __init__(self, *analyses: Analysis):
+        """
+        Computes the summed log likelihood of multiple analyses
+        applied to a single model.
+
+        Parameters
+        ----------
+        analyses
+        """
+        self.analyses = analyses
+
+        n_cores = conf.instance[
+            "general"
+        ][
+            "analysis"
+        ][
+            "n_cores"
+        ]
+
+        if n_cores > 1:
+            self.log_likelihood_function = AnalysisPool(
+                analyses,
+                n_cores
+            )
+        else:
+            self.log_likelihood_function = lambda instance: sum(
+                analysis.log_likelihood_function(
+                    instance
+                )
+                for analysis in analyses
+            )
+
+    def __len__(self):
+        return len(self.analyses)
+
+    def __add__(self, other):
+        if isinstance(
+                other,
+                CombinedAnalysis
+        ):
+            return CombinedAnalysis(
+                *self.analyses,
+                *other.analyses
+            )
+        return CombinedAnalysis(
+            *self.analyses,
+            other
+        )
+
+    def log_likelihood_function(
+            self,
+            instance
+    ) -> float:
+        pass

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -70,6 +70,13 @@ class CombinedAnalysis(Analysis):
         Computes the summed log likelihood of multiple analyses
         applied to a single model.
 
+        Either analyses are performed sequentially and summed,
+        or they are mapped out to processes.
+
+        If the number of cores is greater than one then the
+        analyses are distributed across a number of processes
+        equal to the number of cores.
+
         Parameters
         ----------
         analyses
@@ -100,7 +107,21 @@ class CombinedAnalysis(Analysis):
     def __len__(self):
         return len(self.analyses)
 
-    def __add__(self, other):
+    def __add__(self, other: Analysis):
+        """
+        Adding anything to a CombinedAnalysis results in another
+        analysis containing all underlying analyses (no combined
+        analysis children)
+
+        Parameters
+        ----------
+        other
+            Some analysis
+
+        Returns
+        -------
+        An overarching analysis
+        """
         if isinstance(
                 other,
                 CombinedAnalysis
@@ -118,4 +139,17 @@ class CombinedAnalysis(Analysis):
             self,
             instance
     ) -> float:
-        pass
+        """
+        The implementation of this function is decided in the constructor
+        based on the number of cores available
+
+        Parameters
+        ----------
+        instance
+            An instance of a model
+
+        Returns
+        -------
+        The likelihood that model corresponds to the data encapsulated
+        by the child analyses
+        """

--- a/autofit/non_linear/analysis/multiprocessing.py
+++ b/autofit/non_linear/analysis/multiprocessing.py
@@ -144,6 +144,8 @@ class AnalysisPool:
 
         while count_ < self.n_analyses:
             for process in self.processes:
+                if process.queue.empty():
+                    continue
                 result = process.queue.get()
 
                 if isinstance(

--- a/autofit/non_linear/analysis/multiprocessing.py
+++ b/autofit/non_linear/analysis/multiprocessing.py
@@ -1,128 +1,14 @@
 import logging
 import math
-from abc import ABC
 from itertools import count
 from multiprocessing import Process
 from multiprocessing import Queue
 
-from autoconf import conf
-from autofit.mapper.prior_model.collection import CollectionPriorModel
 from autofit.non_linear.parallel.sneaky import StopCommand
-from autofit.non_linear.paths.abstract import AbstractPaths
-from autofit.non_linear.result import Result
-from autofit.non_linear.samples import OptimizerSamples
 
 logger = logging.getLogger(
     __name__
 )
-
-
-class Analysis(ABC):
-    """
-    Protocol for an analysis. Defines methods that can or
-    must be implemented to define a class that compute the
-    likelihood that some instance fits some data.
-    """
-
-    def log_likelihood_function(self, instance):
-        raise NotImplementedError()
-
-    def visualize(self, paths: AbstractPaths, instance, during_analysis):
-        pass
-
-    def save_attributes_for_aggregator(self, paths: AbstractPaths):
-        pass
-
-    def save_results_for_aggregator(self, paths: AbstractPaths, model: CollectionPriorModel,
-                                    samples: OptimizerSamples):
-        pass
-
-    def make_result(self, samples, model, search):
-        return Result(samples=samples, model=model, search=search)
-
-    def __add__(
-            self,
-            other: "Analysis"
-    ) -> "CombinedAnalysis":
-        """
-        Analyses can be added together. The resultant
-        log likelihood function returns the sum of the
-        underlying log likelihood functions.
-
-        Parameters
-        ----------
-        other
-            Another analysis class
-
-        Returns
-        -------
-        A class that computes log likelihood based on both analyses
-        """
-        if isinstance(
-                other,
-                CombinedAnalysis
-        ):
-            return other + self
-        return CombinedAnalysis(
-            self, other
-        )
-
-
-class CombinedAnalysis(Analysis):
-    def __init__(self, *analyses: Analysis):
-        """
-        Computes the summed log likelihood of multiple analyses
-        applied to a single model.
-
-        Parameters
-        ----------
-        analyses
-        """
-        self.analyses = analyses
-
-        n_cores = conf.instance[
-            "general"
-        ][
-            "analysis"
-        ][
-            "n_cores"
-        ]
-
-        if n_cores > 1:
-            self.log_likelihood_function = AnalysisPool(
-                analyses,
-                n_cores
-            )
-        else:
-            self.log_likelihood_function = lambda instance: sum(
-                analysis.log_likelihood_function(
-                    instance
-                )
-                for analysis in analyses
-            )
-
-    def __len__(self):
-        return len(self.analyses)
-
-    def __add__(self, other):
-        if isinstance(
-                other,
-                CombinedAnalysis
-        ):
-            return CombinedAnalysis(
-                *self.analyses,
-                *other.analyses
-            )
-        return CombinedAnalysis(
-            *self.analyses,
-            other
-        )
-
-    def log_likelihood_function(
-            self,
-            instance
-    ) -> float:
-        pass
 
 
 class AnalysisProcess(Process):

--- a/autofit/non_linear/analysis/multiprocessing.py
+++ b/autofit/non_linear/analysis/multiprocessing.py
@@ -19,6 +19,18 @@ class AnalysisProcess(Process):
             analyses,
             analysis_queues
     ):
+        """
+        A process that performs one or more analyses on each
+        instance passed to it
+
+        Parameters
+        ----------
+        analyses
+            A list of analyses this process performs
+        analysis_queues
+            A list of queues by which instances are passed, one
+            for each analysis
+        """
         super().__init__()
         self.analyses = analyses
         self.analysis_queues = analysis_queues
@@ -31,6 +43,10 @@ class AnalysisProcess(Process):
         )
 
     def _run(self):
+        """
+        Private run function permitting process to be stopped using a return
+        when a StopCommand is passed
+        """
         while True:
             for analysis, queue in zip(
                     self.analyses,
@@ -67,9 +83,22 @@ class AnalysisProcess(Process):
 class AnalysisPool:
     def __init__(
             self,
-            analyses,
-            n_cores
+            analyses: list,
+            n_cores: int
     ):
+        """
+        A pool which distributes analysis evenly across
+        n_cores processes.
+
+        Callable as a log-likelihood function.
+
+        Parameters
+        ----------
+        analyses
+            A list of analyses to be performed in parallel
+        n_cores
+            The number of cores available to perform analyses over
+        """
         self.analyses = analyses
         self.n_cores = n_cores
 
@@ -134,7 +163,20 @@ class AnalysisPool:
             except Exception as e:
                 logger.exception(e)
 
-    def __call__(self, instance):
+    def __call__(self, instance) -> float:
+        """
+        Evaluate the likelihood of an instance according to several
+        analyses, in parallel.
+
+        Parameters
+        ----------
+        instance
+            Some instance
+
+        Returns
+        -------
+        The total log likelihood
+        """
         log_likelihood = 0
 
         count_ = 0

--- a/autofit/non_linear/parallel/process.py
+++ b/autofit/non_linear/parallel/process.py
@@ -183,3 +183,10 @@ class Process(multiprocessing.Process):
             process.join(timeout=1.0)
 
         logger.debug("Joining processes")
+
+
+class StopCommand:
+    """
+    A command that can be passed into a process queue to gracefully stop
+    the process
+    """

--- a/autofit/non_linear/parallel/sneaky.py
+++ b/autofit/non_linear/parallel/sneaky.py
@@ -5,7 +5,7 @@ from typing import Iterable
 from dynesty.dynesty import _function_wrapper
 from emcee.ensemble import _FunctionWrapper
 
-from .process import AbstractJob, Process, StopCommand, AbstractPool
+from .process import AbstractJob, Process, StopCommand
 
 logger = logging.getLogger(
     __name__
@@ -155,7 +155,7 @@ class SneakyProcess(Process):
         self.job_queue.close()
 
 
-class SneakyPool(AbstractPool):
+class SneakyPool:
     def __init__(
             self,
             processes: int,

--- a/test_autofit/non_linear/test_analysis.py
+++ b/test_autofit/non_linear/test_analysis.py
@@ -19,3 +19,13 @@ def test_two_cores():
     assert (Analysis() + Analysis()).log_likelihood_function(
         None
     ) == -2
+
+
+def test_still_flat():
+    analysis = (Analysis() + Analysis()) + Analysis()
+
+    assert len(analysis) == 3
+
+    analysis = Analysis() + (Analysis() + Analysis())
+
+    assert len(analysis) == 3

--- a/test_autofit/non_linear/test_analysis.py
+++ b/test_autofit/non_linear/test_analysis.py
@@ -1,5 +1,8 @@
+import pytest
+
 import autofit as af
 from autoconf.conf import with_config
+from autofit.non_linear.analysis import AnalysisPool
 
 
 class Analysis(af.Analysis):
@@ -13,14 +16,33 @@ def test_add_analysis():
     ) == -2
 
 
+def test_analysis_pool():
+    pool = AnalysisPool(
+        3 * [Analysis()],
+        2
+    )
+
+    process_1, process_2 = pool.processes
+
+    assert len(process_1.analyses) == 2
+    assert len(process_2.analyses) == 1
+
+
 @with_config(
     "general", "analysis", "n_cores",
     value=2
 )
-def test_two_cores():
-    assert (Analysis() + Analysis()).log_likelihood_function(
+@pytest.mark.parametrize(
+    "number",
+    list(range(1, 10))
+)
+def test_two_cores(number):
+    analysis = Analysis()
+    for _ in range(number - 1):
+        analysis += Analysis()
+    assert analysis.log_likelihood_function(
         None
-    ) == -2
+    ) == -number
 
 
 def test_still_flat():

--- a/test_autofit/non_linear/test_analysis.py
+++ b/test_autofit/non_linear/test_analysis.py
@@ -1,5 +1,5 @@
 import autofit as af
-from autoconf import conf
+from autoconf.conf import with_config
 
 
 class Analysis(af.Analysis):
@@ -13,9 +13,11 @@ def test_add_analysis():
     ) == -2
 
 
+@with_config(
+    "general", "analysis", "n_cores",
+    value=2
+)
 def test_two_cores():
-    conf.instance["general"]["analysis"]["n_cores"] = 2
-
     assert (Analysis() + Analysis()).log_likelihood_function(
         None
     ) == -2

--- a/test_autofit/non_linear/test_analysis.py
+++ b/test_autofit/non_linear/test_analysis.py
@@ -1,0 +1,12 @@
+import autofit as af
+
+
+class Analysis(af.Analysis):
+    def log_likelihood_function(self, instance):
+        return -1
+
+
+def test_add_analysis():
+    assert (Analysis() + Analysis()).log_likelihood_function(
+        None
+    ) == -2

--- a/test_autofit/non_linear/test_analysis.py
+++ b/test_autofit/non_linear/test_analysis.py
@@ -2,7 +2,7 @@ import pytest
 
 import autofit as af
 from autoconf.conf import with_config
-from autofit.non_linear.analysis import AnalysisPool
+from autofit.non_linear.analysis.multiprocessing import AnalysisPool
 
 
 class Analysis(af.Analysis):

--- a/test_autofit/non_linear/test_analysis.py
+++ b/test_autofit/non_linear/test_analysis.py
@@ -1,4 +1,5 @@
 import autofit as af
+from autoconf import conf
 
 
 class Analysis(af.Analysis):
@@ -7,6 +8,14 @@ class Analysis(af.Analysis):
 
 
 def test_add_analysis():
+    assert (Analysis() + Analysis()).log_likelihood_function(
+        None
+    ) == -2
+
+
+def test_two_cores():
+    conf.instance["general"]["analysis"]["n_cores"] = 2
+
     assert (Analysis() + Analysis()).log_likelihood_function(
         None
     ) == -2


### PR DESCRIPTION
Allows analysis instances to be added:

```python
combined_analysis = analysis_1 + analysis_2
```

If general/analysis/n_cores > 1 then multiprocessing pool.map is used to parallelise evaluation.

Currently sneaky pool is not used as it swaps out arguments based on type. Here analyses would need to be distributed across processes. Will look at that now but might be 'out of scope' for this afternoon...... 
