### PR TITLE
parameterization

### DIFF
--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -192,6 +192,28 @@ class AbstractPriorModel(AbstractModel):
             except AttributeError:
                 pass
 
+    @property
+    def parameterization(self) -> str:
+        """
+        Describes the path to each of the PriorModels, its class
+        and its number of free parameters
+        """
+        from .prior_model import PriorModel
+        tuples = self.path_instance_tuples_for_class(
+            PriorModel
+        )
+
+        strings = list()
+
+        for path, prior_model in tuples:
+            path = "->".join(path)
+            suffix = f"{prior_model.cls.__name__} (N={prior_model.prior_count})"
+            spaces = (90 - (len(path) + len(suffix) + 1)) * " "
+            strings.append(
+                f"{path}:{spaces}{suffix}"
+            )
+        return "\n".join(strings)
+
     def instance_from_unit_vector(self, unit_vector, assert_priors_in_limits=True):
         """
         Returns a ModelInstance, which has an attribute and class instance corresponding

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -206,7 +206,10 @@ class AbstractPriorModel(AbstractModel):
         strings = list()
 
         for path, prior_model in tuples:
-            path = "->".join(path)
+            if len(path) == 0:
+                path = "(root)"
+            else:
+                path = "->".join(path)
             suffix = f"{prior_model.cls.__name__} (N={prior_model.prior_count})"
             spaces = (90 - (len(path) + len(suffix) + 1)) * " "
             strings.append(

--- a/autofit/non_linear/paths/directory.py
+++ b/autofit/non_linear/paths/directory.py
@@ -185,6 +185,7 @@ class DirectoryPaths(AbstractPaths):
                 "model.info"
         ), "w+") as f:
             f.write(f"Total Free Parameters = {model.prior_count} \n\n")
+            f.write(f"{model.parameterization} \n\n")
             f.write(model.info)
 
     def _save_parameter_names_file(self, model):

--- a/test_autofit/mapper/test_parameterization.py
+++ b/test_autofit/mapper/test_parameterization.py
@@ -1,0 +1,14 @@
+import autofit as af
+
+
+def test_parameterization():
+    model = af.Collection(
+        collection=af.Collection(
+            gaussian=af.Model(af.Gaussian)
+        )
+    )
+
+    parameterization = model.parameterization
+    assert parameterization == (
+        'collection->gaussian:                                                       Gaussian (N=3)'
+    )

--- a/test_autofit/mapper/test_parameterization.py
+++ b/test_autofit/mapper/test_parameterization.py
@@ -12,3 +12,11 @@ def test_parameterization():
     assert parameterization == (
         'collection->gaussian:                                                       Gaussian (N=3)'
     )
+
+
+def test_root():
+    model = af.Model(af.Gaussian)
+    parameterization = model.parameterization
+    assert parameterization == (
+        '(root):                                                                     Gaussian (N=3)'
+    )


### PR DESCRIPTION
Adds parameterization to model.info in accordance with #268

Currently only adds for PriorModels. If a model has no name the path is just
