### PR TITLE
Bugfix/find mode

### DIFF
--- a/autofit/graphical/messages/abstract.py
+++ b/autofit/graphical/messages/abstract.py
@@ -770,6 +770,18 @@ class TransformedMessage(AbstractMessage):
     # TODO add code for analytic hessians when Jacobian is fixed e.g. for shifted messages
     logpdf_gradient_hessian = AbstractMessage.numerical_logpdf_gradient_hessian
 
+    @staticmethod
+    def _from_mode(
+            cls: "TransformedMessage",
+            mode: np.ndarray,
+            covariance: np.ndarray
+    ) -> "AbstractMessage":
+        mode, jac = cls._transform.transform_jac(mode)
+        covariance = jac.invquad(covariance)
+        if cls._depth > 1:
+            return TransformedMessage._from_mode(cls._Message, mode, covariance)
+        return mode, covariance
+
     @classmethod
     def from_mode(
             cls,
@@ -777,6 +789,5 @@ class TransformedMessage(AbstractMessage):
             covariance: np.ndarray,
             id_=None
     ) -> "AbstractMessage":
-        mode, jac = cls._transform.transform_jac(mode)
-        covariance = jac.invquad(covariance)
-        return cls._Message.from_mode(mode, covariance, id_=id_)
+        mode, covariance = TransformedMessage._from_mode(cls, mode, covariance)
+        return super(TransformedMessage, cls).from_mode(mode, covariance, id_=id_)

--- a/autofit/graphical/messages/abstract.py
+++ b/autofit/graphical/messages/abstract.py
@@ -770,6 +770,18 @@ class TransformedMessage(AbstractMessage):
     # TODO add code for analytic hessians when Jacobian is fixed e.g. for shifted messages
     logpdf_gradient_hessian = AbstractMessage.numerical_logpdf_gradient_hessian
 
+    @staticmethod
+    def _from_mode(
+            cls: "TransformedMessage",
+            mode: np.ndarray,
+            covariance: np.ndarray
+    ) -> "AbstractMessage":
+        mode, jac = cls._transform.transform_jac(mode)
+        covariance = jac.invquad(covariance)
+        if cls._depth > 1:
+            return TransformedMessage._from_mode(cls._Message, mode, covariance)
+        return mode, covariance
+
     @classmethod
     def from_mode(
             cls,
@@ -777,6 +789,5 @@ class TransformedMessage(AbstractMessage):
             covariance: np.ndarray,
             id_=None
     ) -> "AbstractMessage":
-        mode, jac = cls._transform.transform_jac(mode)
-        covariance = jac.invquad(covariance)
-        return cls.from_mode(mode, covariance, id_=id_)
+        mode, covariance = TransformedMessage._from_mode(cls, mode, covariance)
+        return super(TransformedMessage, cls).from_mode(mode, covariance, id_=id_)

--- a/autofit/graphical/messages/abstract.py
+++ b/autofit/graphical/messages/abstract.py
@@ -770,18 +770,6 @@ class TransformedMessage(AbstractMessage):
     # TODO add code for analytic hessians when Jacobian is fixed e.g. for shifted messages
     logpdf_gradient_hessian = AbstractMessage.numerical_logpdf_gradient_hessian
 
-    @staticmethod
-    def _from_mode(
-            cls: "TransformedMessage",
-            mode: np.ndarray,
-            covariance: np.ndarray
-    ) -> "AbstractMessage":
-        mode, jac = cls._transform.transform_jac(mode)
-        covariance = jac.invquad(covariance)
-        if cls._depth > 1:
-            return TransformedMessage._from_mode(cls._Message, mode, covariance)
-        return mode, covariance
-
     @classmethod
     def from_mode(
             cls,
@@ -790,4 +778,4 @@ class TransformedMessage(AbstractMessage):
             id_=None
     ) -> "AbstractMessage":
         mode, covariance = TransformedMessage._from_mode(cls, mode, covariance)
-        return super(TransformedMessage, cls).from_mode(mode, covariance, id_=id_)
+        return cls._Message.from_mode(mode, covariance, id_=id_)

--- a/autofit/graphical/messages/abstract.py
+++ b/autofit/graphical/messages/abstract.py
@@ -770,18 +770,6 @@ class TransformedMessage(AbstractMessage):
     # TODO add code for analytic hessians when Jacobian is fixed e.g. for shifted messages
     logpdf_gradient_hessian = AbstractMessage.numerical_logpdf_gradient_hessian
 
-    @staticmethod
-    def _from_mode(
-            cls: "TransformedMessage",
-            mode: np.ndarray,
-            covariance: np.ndarray
-    ) -> "AbstractMessage":
-        mode, jac = cls._transform.transform_jac(mode)
-        covariance = jac.invquad(covariance)
-        if cls._depth > 1:
-            return TransformedMessage._from_mode(cls._Message, mode, covariance)
-        return mode, covariance
-
     @classmethod
     def from_mode(
             cls,
@@ -790,4 +778,7 @@ class TransformedMessage(AbstractMessage):
             id_=None
     ) -> "AbstractMessage":
         mode, covariance = TransformedMessage._from_mode(cls, mode, covariance)
-        return super(TransformedMessage, cls).from_mode(mode, covariance, id_=id_)
+        # This will be of the type of the untransformed message
+        msg = cls._Message.from_mode(mode, covariance)
+        # Cast the message into the transformed message
+        return cls(*msg.parameters, id_=id_)

--- a/autofit/graphical/messages/abstract.py
+++ b/autofit/graphical/messages/abstract.py
@@ -777,5 +777,6 @@ class TransformedMessage(AbstractMessage):
             covariance: np.ndarray,
             id_=None
     ) -> "AbstractMessage":
-        mode, covariance = TransformedMessage._from_mode(cls, mode, covariance)
+        mode, jac = cls._transform.transform_jac(mode)
+        covariance = jac.invquad(covariance)
         return cls._Message.from_mode(mode, covariance, id_=id_)

--- a/test_autofit/graphical/functionality/test_messages.py
+++ b/test_autofit/graphical/functionality/test_messages.py
@@ -196,6 +196,10 @@ def test_transforms():
     for args in tests:
         check_transforms(*args)
 
+def test_transformed_from_mode():
+    m = graph.NormalMessage.shifted(scale=0.5).shifted(scale=4.).shifted(shift=-0.5).from_mode(0.0, 100)
+    assert np.isclose(m.mu, 0.25)
+    assert np.isclose(m.sigma, 20.)
 
 def test_multinomial_logit():
     mult_logit = transform.multinomial_logit_transform

--- a/test_autofit/graphical/functionality/test_messages.py
+++ b/test_autofit/graphical/functionality/test_messages.py
@@ -202,6 +202,21 @@ def test_transformed_from_mode():
     assert isinstance(m, M)
     assert np.isclose(m.mu, 0.25)
     assert np.isclose(m.sigma, 20.)
+    
+    M = graph.NormalMessage.shifted(
+        shift=-0.5, scale=0.2
+    ).transformed(
+        transform.log_transform
+    ).transformed(
+        transform.exp_transform
+    ).shifted(
+        shift=0.5, scale=2.5
+    )
+    m = M.from_mode(0.0, 100)
+    print(m, m.mu, m.sigma)
+    assert isinstance(m, M)
+    assert np.isclose(m.mu, 1.5)
+    assert np.isclose(m.sigma, 5.)
 
 def test_multinomial_logit():
     mult_logit = transform.multinomial_logit_transform

--- a/test_autofit/graphical/functionality/test_messages.py
+++ b/test_autofit/graphical/functionality/test_messages.py
@@ -197,7 +197,9 @@ def test_transforms():
         check_transforms(*args)
 
 def test_transformed_from_mode():
-    m = graph.NormalMessage.shifted(scale=0.5).shifted(scale=4.).shifted(shift=-0.5).from_mode(0.0, 100)
+    M = graph.NormalMessage.shifted(scale=0.5).shifted(scale=4.).shifted(shift=-0.5)
+    m = M.from_mode(0.0, 100)
+    assert isinstance(m, M)
     assert np.isclose(m.mu, 0.25)
     assert np.isclose(m.sigma, 20.)
 


### PR DESCRIPTION
The implementation of `.from_mode` in TransformedMessage should call the `.from_mode` function of the underlying message class to correctly set up the message, but instead calls itself - resulting in an infinite loop and eventual interpreter crash. This patch changes the function to dispatch to the correct class method, and adds some special-case code to correctly handle nested transforms.

Note that Message transformations are currently implemented by subclassing the original message class and, if the original message class does not inherit from it, mixing in the TransformedMessage class. Because of this, the `super(TransformedMessage, cls).from_mode` call will skip intermediate transforms and dispatch directly to the original message class - and so nested TransformedMessages must be handled explicitly.

Thoughts? Happy to make changes if needed.