### PR TITLE
joined loading of pickles

### DIFF
--- a/autofit/database/model/fit.py
+++ b/autofit/database/model/fit.py
@@ -218,7 +218,8 @@ class Fit(Base):
         )
 
     pickles: List[Pickle] = relationship(
-        "Pickle"
+        "Pickle",
+        lazy="joined"
     )
 
     def __getitem__(self, item: str):


### PR DESCRIPTION
Use joined loading of pickles to speed up .value function

Note that this may result in excessive memory when fits are queried by the aggregator
