### PR TITLE
feature/mapper by path

### DIFF
--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -796,12 +796,29 @@ class AbstractPriorModel(AbstractModel):
             arguments
         )
 
+    def path_for_name(self, name):
+        exploded = tuple(name.split("_"))
+        for path, _ in self.path_priors_tuples:
+            exploded_path = tuple(
+                string
+                for part in path
+                for string
+                in part.split(
+                    "_"
+                )
+            )
+            if exploded_path == exploded:
+                return path
+        raise AssertionError(
+            f"No path was found matching {name}"
+        )
+
     def instance_from_prior_name_arguments(
             self,
             prior_name_arguments
     ):
         return self.instance_from_path_arguments({
-            tuple(name.split("_")): value
+            self.path_for_name(name): value
             for name, value
             in prior_name_arguments.items()
         })

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -796,6 +796,16 @@ class AbstractPriorModel(AbstractModel):
             arguments
         )
 
+    def instance_from_prior_name_arguments(
+            self,
+            prior_name_arguments
+    ):
+        return self.instance_from_path_arguments({
+            tuple(name.split("_")): value
+            for name, value
+            in prior_name_arguments.items()
+        })
+
     def instance_from_path_arguments(self, path_arguments):
         arguments = {
             self.object_for_path(

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -796,6 +796,18 @@ class AbstractPriorModel(AbstractModel):
             arguments
         )
 
+    def instance_from_path_arguments(self, path_arguments):
+        arguments = {
+            self.object_for_path(
+                path
+            ): value
+            for path, value
+            in path_arguments.items()
+        }
+        return self._instance_for_arguments(
+            arguments
+        )
+
     @property
     def prior_count(self):
         return len(self.unique_prior_tuples)

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -5,7 +5,7 @@ import logging
 from functools import wraps
 from numbers import Number
 from random import random
-from typing import Tuple, Optional
+from typing import Tuple, Optional, Dict
 
 import numpy as np
 
@@ -796,7 +796,36 @@ class AbstractPriorModel(AbstractModel):
             arguments
         )
 
-    def path_for_name(self, name):
+    def path_for_name(
+            self,
+            name: str
+    ) -> Tuple[str, ...]:
+        """
+        Find the path to a prior in the model that matches
+        a given name.
+
+        For example, name_of_model_name_of_prior could match
+        (name_of_model, name_of_prior). Unfortunately it is
+        possible for ambiguity to occur. For example, another
+        valid path could be (name, of_model, name_of_prior)
+        in which case there is no way to determine which path
+        actually matches the name.
+
+        Parameters
+        ----------
+        name
+            A name for a prior where names of models and the
+            name of the prior have been joined by underscores.
+
+        Returns
+        -------
+        A path to that model
+
+        Raises
+        ------
+        AssertionError
+            Iff no matching path is found
+        """
         exploded = tuple(name.split("_"))
         for path, _ in self.path_priors_tuples:
             exploded_path = tuple(
@@ -815,15 +844,49 @@ class AbstractPriorModel(AbstractModel):
 
     def instance_from_prior_name_arguments(
             self,
-            prior_name_arguments
+            prior_name_arguments: Dict[str, float]
     ):
+        """
+        Instantiate the model from the names of priors and
+        corresponding values.
+
+        Parameters
+        ----------
+        prior_name_arguments
+            The names of priors where names of models and the
+            name of the prior have been joined by underscores,
+            mapped to corresponding values.
+
+        Returns
+        -------
+        An instance of the model
+        """
         return self.instance_from_path_arguments({
             self.path_for_name(name): value
             for name, value
             in prior_name_arguments.items()
         })
 
-    def instance_from_path_arguments(self, path_arguments):
+    def instance_from_path_arguments(
+            self,
+            path_arguments: Dict[Tuple[str], float]
+    ):
+        """
+        Create an instance from a dictionary mapping paths to tuples
+        to corresponding values.
+
+        Parameters
+        ----------
+        path_arguments
+            A dictionary mapping paths to priors to corresponding values.
+            Note that, for linked priors, each path only needs to be
+            specified once. If multiple paths for the same prior are
+            specified then the value for the last path will be used.
+
+        Returns
+        -------
+        An instance of the model
+        """
         arguments = {
             self.object_for_path(
                 path

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -5,7 +5,7 @@ import logging
 from functools import wraps
 from numbers import Number
 from random import random
-from typing import Tuple, Optional, Dict
+from typing import Tuple, Optional, Dict, List
 
 import numpy as np
 
@@ -967,6 +967,18 @@ class AbstractPriorModel(AbstractModel):
     def path_priors_tuples(self):
         path_priors_tuples = self.path_instance_tuples_for_class(Prior)
         return sorted(path_priors_tuples, key=lambda item: item[1].id)
+
+    @property
+    def paths(self) -> List[Tuple[str, ...]]:
+        """
+        A list of paths to all the priors in the model, ordered by their
+        ids
+        """
+        return [
+            path
+            for path, _
+            in self.path_priors_tuples
+        ]
 
     def path_for_prior(self, prior: Prior) -> Optional[Tuple[str]]:
         """

--- a/autofit/non_linear/samples.py
+++ b/autofit/non_linear/samples.py
@@ -181,8 +181,8 @@ class Sample:
         The instance corresponding to this sample
         """
         try:
-            return model.instance_from_vector(
-                self.parameter_lists_for_model(model)
+            return model.instance_from_prior_name_arguments(
+                self.kwargs
             )
         except KeyError:
             paths = model.model_component_and_parameter_names

--- a/test_autofit/database/paths/test_samples.py
+++ b/test_autofit/database/paths/test_samples.py
@@ -34,9 +34,11 @@ def make_sample():
         log_likelihood=1.0,
         log_prior=1.0,
         weight=0.5,
-        centre=1.0,
-        intensity=2.0,
-        sigma=3.0
+        kwargs=dict(
+            centre=1.0,
+            intensity=2.0,
+            sigma=3.0
+        )
     )
 
 

--- a/test_autofit/mapper/test_by_path.py
+++ b/test_autofit/mapper/test_by_path.py
@@ -109,3 +109,4 @@ class TestInstanceFromPriorNames:
                    "gaussian_component",
                    "centre"
                )
+

--- a/test_autofit/mapper/test_id.py
+++ b/test_autofit/mapper/test_id.py
@@ -7,40 +7,55 @@ import autofit as af
     name="model"
 )
 def make_model():
-    return af.Model(
-        af.Gaussian
+    return af.Collection(
+        gaussian=af.Model(
+            af.Gaussian
+        )
     )
 
 
-def test_instance_from_path_arguments(
-        model
-):
-    instance = model.instance_from_path_arguments({
-        ("centre",): 1,
-        ("intensity",): 2,
-        ("sigma",): 3
-    })
-    assert instance.centre == 1
-    assert instance.intensity == 2
-    assert instance.sigma == 3
+class TestInstanceFromPathArguments:
+    def test(
+            self,
+            model
+    ):
+        instance = model.instance_from_path_arguments({
+            ("gaussian", "centre"): 0.1,
+            ("gaussian", "intensity"): 0.2,
+            ("gaussian", "sigma"): 0.3
+        })
+        assert instance.gaussian.centre == 0.1
+        assert instance.gaussian.intensity == 0.2
+        assert instance.gaussian.sigma == 0.3
+
+    def test_prior_linking(
+            self,
+            model
+    ):
+        model.gaussian.centre = model.gaussian.intensity
+        instance = model.instance_from_path_arguments({
+            ("gaussian", "centre",): 0.1,
+            ("gaussian", "sigma",): 0.3
+        })
+        assert instance.gaussian.centre == 0.1
+        assert instance.gaussian.intensity == 0.1
+        assert instance.gaussian.sigma == 0.3
+
+        instance = model.instance_from_path_arguments({
+            ("gaussian", "intensity",): 0.2,
+            ("gaussian", "sigma",): 0.3
+        })
+        assert instance.gaussian.centre == 0.2
+        assert instance.gaussian.intensity == 0.2
+        assert instance.gaussian.sigma == 0.3
 
 
-def test_prior_linking(
-        model
-):
-    model.centre = model.intensity
-    instance = model.instance_from_path_arguments({
-        ("centre",): 1,
-        ("sigma",): 3
+def test_instance_from_prior_names(model):
+    instance = model.instance_from_prior_name_arguments({
+        "gaussian_centre": 0.1,
+        "gaussian_intensity": 0.2,
+        "gaussian_sigma": 0.3
     })
-    assert instance.centre == 1
-    assert instance.intensity == 1
-    assert instance.sigma == 3
-
-    instance = model.instance_from_path_arguments({
-        ("intensity",): 2,
-        ("sigma",): 3
-    })
-    assert instance.centre == 2
-    assert instance.intensity == 2
-    assert instance.sigma == 3
+    assert instance.gaussian.centre == 0.1
+    assert instance.gaussian.intensity == 0.2
+    assert instance.gaussian.sigma == 0.3

--- a/test_autofit/mapper/test_id.py
+++ b/test_autofit/mapper/test_id.py
@@ -1,0 +1,46 @@
+import pytest
+
+import autofit as af
+
+
+@pytest.fixture(
+    name="model"
+)
+def make_model():
+    return af.Model(
+        af.Gaussian
+    )
+
+
+def test_instance_from_path_arguments(
+        model
+):
+    instance = model.instance_from_path_arguments({
+        ("centre",): 1,
+        ("intensity",): 2,
+        ("sigma",): 3
+    })
+    assert instance.centre == 1
+    assert instance.intensity == 2
+    assert instance.sigma == 3
+
+
+def test_prior_linking(
+        model
+):
+    model.centre = model.intensity
+    instance = model.instance_from_path_arguments({
+        ("centre",): 1,
+        ("sigma",): 3
+    })
+    assert instance.centre == 1
+    assert instance.intensity == 1
+    assert instance.sigma == 3
+
+    instance = model.instance_from_path_arguments({
+        ("intensity",): 2,
+        ("sigma",): 3
+    })
+    assert instance.centre == 2
+    assert instance.intensity == 2
+    assert instance.sigma == 3

--- a/test_autofit/mapper/test_id.py
+++ b/test_autofit/mapper/test_id.py
@@ -50,12 +50,42 @@ class TestInstanceFromPathArguments:
         assert instance.gaussian.sigma == 0.3
 
 
-def test_instance_from_prior_names(model):
-    instance = model.instance_from_prior_name_arguments({
-        "gaussian_centre": 0.1,
-        "gaussian_intensity": 0.2,
-        "gaussian_sigma": 0.3
-    })
-    assert instance.gaussian.centre == 0.1
-    assert instance.gaussian.intensity == 0.2
-    assert instance.gaussian.sigma == 0.3
+@pytest.fixture(
+    name="underscore_model"
+)
+def make_underscore_model():
+    return af.Collection(
+        gaussian_component=af.Model(
+            af.Gaussian
+        )
+    )
+
+
+class TestInstanceFromPriorNames:
+    def test(self, model):
+        instance = model.instance_from_prior_name_arguments({
+            "gaussian_centre": 0.1,
+            "gaussian_intensity": 0.2,
+            "gaussian_sigma": 0.3
+        })
+        assert instance.gaussian.centre == 0.1
+        assert instance.gaussian.intensity == 0.2
+        assert instance.gaussian.sigma == 0.3
+
+    def test_underscored_names(self, underscore_model):
+        instance = underscore_model.instance_from_prior_name_arguments({
+            "gaussian_component_centre": 0.1,
+            "gaussian_component_intensity": 0.2,
+            "gaussian_component_sigma": 0.3
+        })
+        assert instance.gaussian_component.centre == 0.1
+        assert instance.gaussian_component.intensity == 0.2
+        assert instance.gaussian_component.sigma == 0.3
+
+    def test_path_for_name(self, underscore_model):
+        assert underscore_model.path_for_name(
+            "gaussian_component_centre"
+        ) == (
+                   "gaussian_component",
+                   "centre"
+               )

--- a/test_autofit/mapper/test_id.py
+++ b/test_autofit/mapper/test_id.py
@@ -82,6 +82,26 @@ class TestInstanceFromPriorNames:
         assert instance.gaussian_component.intensity == 0.2
         assert instance.gaussian_component.sigma == 0.3
 
+    def test_prior_linking(self, underscore_model):
+        underscore_model.gaussian_component.intensity = (
+            underscore_model.gaussian_component.centre
+        )
+        instance = underscore_model.instance_from_prior_name_arguments({
+            "gaussian_component_centre": 0.1,
+            "gaussian_component_sigma": 0.3
+        })
+        assert instance.gaussian_component.centre == 0.1
+        assert instance.gaussian_component.intensity == 0.1
+        assert instance.gaussian_component.sigma == 0.3
+
+        instance = underscore_model.instance_from_prior_name_arguments({
+            "gaussian_component_intensity": 0.2,
+            "gaussian_component_sigma": 0.3
+        })
+        assert instance.gaussian_component.centre == 0.2
+        assert instance.gaussian_component.intensity == 0.2
+        assert instance.gaussian_component.sigma == 0.3
+
     def test_path_for_name(self, underscore_model):
         assert underscore_model.path_for_name(
             "gaussian_component_centre"


### PR DESCRIPTION
Recovery of model instances from samples relied on prior ordering. Now it uses the name of the prior. This is still a bit dodgy but backwards compatible.

That is, a prior with path model.sub_model.prior gets a name model_sub_model_prior in samples. This is matched back to the path. The risk is that (in theory) two priors could have the same effective name. However, this would have been an issue regardless.

The better solution is to change kwargs to use paths instead of strings. I'm concerned this will break backwards compatibility but I'm going to try it...
