### PR TITLE
change abc import to remove warning

### DIFF
--- a/autofit/mapper/identifier.py
+++ b/autofit/mapper/identifier.py
@@ -1,5 +1,5 @@
 import inspect
-from collections import Iterable
+from collections.abc import Iterable
 from hashlib import md5
 from typing import Optional
 


### PR DESCRIPTION
The old import syntax was raising a depreciation warning when we ran unit tests.