### PR TITLE
Multiple hierarchical factor fits: fix for sorting of hierarchical_factor_set 

### DIFF
--- a/autofit/graphical/declarative/graph.py
+++ b/autofit/graphical/declarative/graph.py
@@ -268,7 +268,8 @@ class DeclarativeFactorGraph(FactorGraph):
                 ).distribution_model
             )
 
-        return sorted(hierarchical_factor_set)
+        name = lambda x: x.name
+        return sorted(hierarchical_factor_set, key=name)
 
     @property
     def info(self) -> str:


### PR DESCRIPTION
Previously, trying  to fit a hierarchical model with more than one hierarchical factor would return the following error:
![image](https://user-images.githubusercontent.com/60343271/162701022-4a9aecc4-14a2-42af-bb20-8abbae04bd99.png)
When fitting just one hierchical factor this error does not happen because sorted() does not need to compare between two factors. 

I added a way to correctly sort the hierarchical factor list by name so that it does not return an error. 
![image](https://user-images.githubusercontent.com/60343271/162701603-e1ea516d-1553-4fc1-a967-7b4c751461c9.png)
