### PR TITLE
check model method which is overwritten in MockSeach

### DIFF
--- a/autofit/non_linear/abstract_search.py
+++ b/autofit/non_linear/abstract_search.py
@@ -466,10 +466,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         AssertionError
             If the model has 0 dimensions.
         """
-        if model.prior_count == 0:
-            raise AssertionError(
-                "Model has no priors! Cannot fit a 0 dimension model."
-            )
+        self.check_model(model=model)
 
         self.logger.info(
             "Starting search"
@@ -547,6 +544,12 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
     @abstractmethod
     def _fit(self, model, analysis, log_likelihood_cap=None):
         pass
+
+    def check_model(self, model):
+        if model.prior_count == 0:
+            raise AssertionError(
+                "Model has no priors! Cannot fit a 0 dimension model."
+            )
 
     @property
     def _class_config(self):

--- a/autofit/non_linear/mock/mock_search.py
+++ b/autofit/non_linear/mock/mock_search.py
@@ -67,6 +67,9 @@ class MockSearch(NonLinearSearch):
         self.save_for_aggregator = save_for_aggregator
         self.return_sensitivity_results = return_sensitivity_results
 
+    def check_model(self, model):
+        pass
+
     @property
     def config_type(self):
         return conf.instance["non_linear"]["mock"]


### PR DESCRIPTION
There were some tests failing in PyAutoLens because the number of free parameters is 0, leading to a recent implemented check to fail.

These tests use MockSearch, and thus do not need a non-zero number of free parameters.