### PR TITLE
save_results_for_aggregator now uses result

### DIFF
--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -1,3 +1,8 @@
+import abc
+import pickle
+
+from dill import register
+
 from .non_linear.grid.grid_search import GridSearch as SearchGridSearch
 from . import conf
 from . import exc
@@ -93,6 +98,12 @@ from autofit.mapper.prior.arithmetic.compound import AbsolutePrior as Abs
 
 from . import example as ex
 from . import database as db
+
+
+@register(abc.ABCMeta)
+def save_abc(pickler, obj):
+    pickle._Pickler.save_type(pickler, obj)
+    
 
 conf.instance.register(__file__)
 

--- a/autofit/non_linear/abstract_search.py
+++ b/autofit/non_linear/abstract_search.py
@@ -508,7 +508,16 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
                 model=model, analysis=analysis, during_analysis=False
             )
 
-            analysis.save_results_for_aggregator(paths=self.paths, model=model, samples=samples)
+            result = analysis.make_result(
+                samples=samples,
+                model=model,
+                sigma=self.prior_passer.sigma,
+                use_errors=self.prior_passer.use_errors,
+                use_widths=self.prior_passer.use_widths,
+            )
+
+            analysis.save_results_for_aggregator(paths=self.paths, result=result)
+
             self.paths.save_object("samples", samples)
 
         else:
@@ -517,6 +526,14 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
                 samples = self.paths.load_object("samples")
             except Exception:
                 samples = self.samples_via_results_from(model=model)
+
+            result = analysis.make_result(
+                samples=samples,
+                model=model,
+                sigma=self.prior_passer.sigma,
+                use_errors=self.prior_passer.use_errors,
+                use_widths=self.prior_passer.use_widths,
+            )
 
             if self.force_pickle_overwrite:
                 self.logger.info(
@@ -527,17 +544,10 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
                     self.paths.save_object("results", samples.results)
                 except AttributeError:
                     self.paths.save_object("results", samples.results_internal)
-                analysis.save_results_for_aggregator(paths=self.paths, model=model, samples=samples)
+
+                analysis.save_results_for_aggregator(paths=self.paths, result=result)
 
         self.paths.samples_to_csv(samples=samples)
-
-        result = analysis.make_result(
-            samples=samples,
-            model=model,
-            sigma=self.prior_passer.sigma,
-            use_errors=self.prior_passer.use_errors,
-            use_widths=self.prior_passer.use_widths,
-        )
 
         analysis = analysis.modify_after_fit(paths=self.paths, model=model, result=result)
 

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -2,10 +2,8 @@ import logging
 from abc import ABC
 
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
-from autofit.mapper.prior_model.collection import CollectionPriorModel
 from autofit.non_linear.paths.abstract import AbstractPaths
 from autofit.non_linear.result import Result
-from autofit.non_linear.samples import Samples
 
 logger = logging.getLogger(
     __name__
@@ -49,8 +47,7 @@ class Analysis(ABC):
     def save_attributes_for_aggregator(self, paths: AbstractPaths):
         pass
 
-    def save_results_for_aggregator(self, paths: AbstractPaths, model: CollectionPriorModel,
-                                    samples: Samples):
+    def save_results_for_aggregator(self, paths: AbstractPaths, result:Result):
         pass
 
     def modify_before_fit(self, paths: AbstractPaths, model: AbstractPriorModel):

--- a/autofit/non_linear/analysis/combined.py
+++ b/autofit/non_linear/analysis/combined.py
@@ -5,10 +5,9 @@ from autoconf import conf
 from autofit.mapper.prior.abstract import Prior
 from autofit.mapper.prior.tuple_prior import TuplePrior
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
-from autofit.mapper.prior_model.collection import CollectionPriorModel
 from autofit.non_linear.analysis.multiprocessing import AnalysisPool
 from autofit.non_linear.paths.abstract import AbstractPaths
-from autofit.non_linear.samples import Samples
+from autofit.non_linear.result import Result
 from .analysis import Analysis
 
 logger = logging.getLogger(
@@ -132,14 +131,12 @@ class CombinedAnalysis(Analysis):
     def save_results_for_aggregator(
             self,
             paths: AbstractPaths,
-            model: CollectionPriorModel,
-            samples: Samples
+            result:Result
     ):
         def func(child_paths, analysis):
             analysis.save_results_for_aggregator(
                 paths=child_paths,
-                model=model,
-                samples=samples
+                result=result
             )
 
         self._for_each_analysis(

--- a/test_autofit/analysis/test_free_parameter.py
+++ b/test_autofit/analysis/test_free_parameter.py
@@ -110,6 +110,14 @@ def make_result(
     )
 
 
+@pytest.fixture(
+    autouse=True
+)
+def do_remove_output(remove_output):
+    yield
+    remove_output()
+
+
 def test_result_type(result, Result):
     assert isinstance(result, Result)
 

--- a/test_autofit/conftest.py
+++ b/test_autofit/conftest.py
@@ -38,25 +38,41 @@ def make_output_directory(
 
 
 @pytest.fixture(
+    name="remove_output"
+)
+def make_remove_output(
+        output_directory
+):
+    def remove_output():
+        try:
+            for item in os.listdir(output_directory):
+                if item != "non_linear":
+                    item_path = output_directory / item
+                    if item_path.is_dir():
+                        shutil.rmtree(
+                            item_path,
+                            ignore_errors=True,
+                        )
+                    else:
+                        os.remove(
+                            item_path
+                        )
+        except FileExistsError:
+            pass
+
+    return remove_output
+
+
+@pytest.fixture(
     autouse=True,
     scope="session"
 )
-def remove_output(
-        output_directory
+def do_remove_output(
+        output_directory,
+        remove_output
 ):
     yield
-    for item in os.listdir(output_directory):
-        if item != "non_linear":
-            item_path = output_directory / item
-            if item_path.is_dir():
-                shutil.rmtree(
-                    item_path,
-                    ignore_errors=True,
-                )
-            else:
-                os.remove(
-                    item_path
-                )
+    remove_output()
 
 
 class PlotPatch:

--- a/test_autofit/conftest.py
+++ b/test_autofit/conftest.py
@@ -38,7 +38,8 @@ def make_output_directory(
 
 
 @pytest.fixture(
-    name="remove_output"
+    name="remove_output",
+    scope="session"
 )
 def make_remove_output(
         output_directory


### PR DESCRIPTION
Makes it so a method which outputs results as pickles for the database uses the `Result` object.

The following unit test currently fails, which I dont know how to fix:

```
combined_analysis = <autofit.non_linear.analysis.free_parameter.FreeParameterAnalysis object at 0x7ff939022700>
model = <PriorModel Gaussian (centre, UniformPrior, lower_limit = 0.0, upper_limit = 1.0), (normalization, UniformPrior, lower_limit = 0.0, upper_limit = 1.0), (sigma, UniformPrior, lower_limit = 0.0, upper_limit = 1.0)>

    @pytest.fixture(
        name="result"
    )
    def make_result(
            combined_analysis,
            model,
    ):
        optimizer = MockOptimizer()
>       return optimizer.fit(
            model,
            combined_analysis
        )

test_autofit/analysis/test_free_parameter.py:107:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
autofit/non_linear/abstract_search.py:530: in fit
    result = analysis.make_result(
autofit/non_linear/analysis/indexed.py:102: in make_result
    child_results = [
autofit/non_linear/analysis/indexed.py:104: in <listcomp>
    samples.subsamples(model),
autofit/non_linear/samples/samples.py:503: in subsamples
    copied.sample_list = [
autofit/non_linear/samples/samples.py:504: in <listcomp>
    sample.subsample(path_map)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <autofit.non_linear.samples.sample.Sample object at 0x7ff93907c610>, path_map = {(): ('centre',)}

    def subsample(self, path_map):
        arg_dict = {}
        for paths, new_path in path_map.items():
            for path in paths:
                if path in self.kwargs:
                    arg_dict[new_path] = self.kwargs[path]
                    break
            else:
>               raise KeyError(f"No path from {paths} in sample")
E               KeyError: 'No path from () in sample'

autofit/non_linear/samples/sample.py:112: KeyError
```