### PR TITLE
split methods which include latex

### DIFF
--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1639,10 +1639,13 @@ class AbstractPriorModel(AbstractModel):
 
     @property
     def parameter_names(self) -> List[str]:
-        """The param_names vector is a list each parameter's analysis_path, and is used
+        """
+        The param_names vector is a list each parameter's analysis_path, and is used
         for *corner.py* visualization.
+
         The parameter names are determined from the class instance names of the
-        model_mapper. Latex tags are properties of each model class."""
+        model_mapper. Latex tags are properties of each model class.
+        """
         return [parameter_name[-1] for parameter_name in self.unique_prior_paths]
 
     @property
@@ -1663,24 +1666,6 @@ class AbstractPriorModel(AbstractModel):
             parameter_labels.append(parameter_label)
 
         return parameter_labels
-
-    @property
-    def parameter_labels_with_superscripts_latex(self) -> List[str]:
-        """
-        Returns a list of the latex parameter label and superscript of every parameter in a model.
-
-        The parameter labels are defined for every parameter of every model component in the config file `label.ini`.
-        This file can also be used to overwrite superscripts, that are assigned based on the model component name.
-
-        This is used for displaying model results as text and for visualization, for example labelling parameters on a
-        cornerplot.
-        """
-
-        return [
-            f"${label}^{{\\rm {superscript}}}$"
-            for label, superscript in
-            zip(self.parameter_labels, self.superscripts)
-        ]
 
     @property
     def superscripts(self) -> List[str]:
@@ -1768,6 +1753,41 @@ class AbstractPriorModel(AbstractModel):
 
         return superscripts
 
+    @property
+    def parameter_labels_with_superscripts(self) -> List[str]:
+        """
+        Returns a list of the latex parameter label and superscript of every parameter in a model.
+
+        The parameter labels are defined for every parameter of every model component in the config file `label.ini`.
+        This file can also be used to overwrite superscripts, that are assigned based on the model component name.
+
+        This is used for displaying model results as text and for visualization, for example labelling parameters on a
+        cornerplot.
+        """
+
+        return [
+            f"{label}^{{\\rm {superscript}}}"
+            for label, superscript in
+            zip(self.parameter_labels, self.superscripts)
+        ]
+
+    @property
+    def parameter_labels_with_superscripts_latex(self) -> List[str]:
+        """
+        Returns a list of the latex parameter label and superscript of every parameter in a model.
+
+        The parameter labels are defined for every parameter of every model component in the config file `label.ini`.
+        This file can also be used to overwrite superscripts, that are assigned based on the model component name.
+
+        This is used for displaying model results as text and for visualization, for example labelling parameters on a
+        cornerplot.
+        """
+
+        return [
+            f"${label}$"
+            for label in
+            self.parameter_labels_with_superscripts
+        ]
 
 def transfer_classes(instance, mapper, model_classes=None):
     """

--- a/test_autofit/mapper/model/test_model_mapper.py
+++ b/test_autofit/mapper/model/test_model_mapper.py
@@ -129,6 +129,14 @@ class TestRegression:
         mm.one = af.m.MockClassRelativeWidth
         mm.two = af.m.MockClassx2NoSuperScript
 
+        assert mm.parameter_labels_with_superscripts == [
+            r"one_label^{\rm r}",
+            r"two_label^{\rm r}",
+            r"three_label^{\rm r}",
+            r"one_label^{\rm two}",
+            r"two_label^{\rm two}",
+        ]
+
         assert mm.parameter_labels_with_superscripts_latex == [
             r"$one_label^{\rm r}$",
             r"$two_label^{\rm r}$",


### PR DESCRIPTION
There are methods that create labels for plots of results.

This PR splits a method so that you can either have it as latex string (surroudned by $$) or not, because different visualization libraries expect different inptus.