### PR TITLE
feature/horror

### DIFF
--- a/autofit/mapper/prior_model/collection.py
+++ b/autofit/mapper/prior_model/collection.py
@@ -172,6 +172,8 @@ class CollectionPriorModel(AbstractPriorModel):
         """
         result = ModelInstance()
         for key, value in self.__dict__.items():
+            if key.startswith("_"):
+                continue
             if isinstance(value, AbstractPriorModel):
                 value = value.instance_for_arguments(arguments)
             elif isinstance(value, Prior):

--- a/autofit/non_linear/nest/dynesty/abstract.py
+++ b/autofit/non_linear/nest/dynesty/abstract.py
@@ -141,7 +141,7 @@ class AbstractDynesty(AbstractNest, ABC):
             self.logger.info("Existing Dynesty samples found, resuming non-linear search.")
 
         else:
-            if self.number_of_cores >= 1:
+            if self.number_of_cores > 1:
                 pool = self.make_sneaky_pool(
                     fitness_function
                 )

--- a/test_autofit/mapper/model/test_freeze.py
+++ b/test_autofit/mapper/model/test_freeze.py
@@ -81,3 +81,11 @@ def test_unfreeze(
     frozen_collection.unfreeze()
     frozen_collection["key"] = "value"
     frozen_collection[0].key = "value"
+
+
+def test_unfrozen_instance(
+        frozen_collection
+):
+    instance = frozen_collection.instance_from_prior_medians()
+    assert instance._frozen_cache == {}
+    assert instance._is_frozen is False


### PR DESCRIPTION
Fixes the horror bug observed in hyper.

Frozen cache is used to improve execution time by preventing multiple calls to expensive resursive functions in the model. When it is on results from those functions are cached. This cache was being passed to instances meaning that modified instances exhibited unexpected behaviours (i.e. updating the model would not cause the results of calling some functions to be updated). This is now resolved.
