### PR TITLE
assign an identifier to objects without an id when loading from the database

### DIFF
--- a/autofit/database/model/model.py
+++ b/autofit/database/model/model.py
@@ -191,6 +191,17 @@ class Object(Base):
                     child.name,
                     child()
                 )
+        from autofit import ModelObject
+        if isinstance(
+                instance,
+                ModelObject
+        ) and (
+                not hasattr(
+                    instance, "id"
+                ) or instance.id is None
+        ):
+            instance.id = instance.next_id()
+
         return instance
 
     def _add_children(

--- a/autofit/mapper/model_object.py
+++ b/autofit/mapper/model_object.py
@@ -7,6 +7,10 @@ from .identifier import Identifier
 class ModelObject:
     _ids = itertools.count()
 
+    @classmethod
+    def next_id(cls):
+        return next(cls._ids)
+
     def __init__(
             self,
             id_=None,
@@ -23,7 +27,7 @@ class ModelObject:
             A label which can optionally be set for visualising this object in a
             graph.
         """
-        self.id = next(self._ids) if id_ is None else id_
+        self.id = id_ or self.next_id()
         self._label = label
 
     @property

--- a/test_autofit/database/test_serialize.py
+++ b/test_autofit/database/test_serialize.py
@@ -92,6 +92,12 @@ class TestPriors:
         )
 
 
+def test_none_id(model):
+    model.id = None
+    model = db.Object.from_object(model)()
+    assert model.id is not None
+
+
 class TestCollection:
     def test_serialize(
             self,


### PR DESCRIPTION
Should resolve issue where hashing fails for objects that had a None id once loaded from the database
