### PR TITLE
feature/shrinking priors

### DIFF
--- a/autofit/graphical/expectation_propagation/ep_mean_field.py
+++ b/autofit/graphical/expectation_propagation/ep_mean_field.py
@@ -210,11 +210,15 @@ class EPMeanField(FactorGraph):
         """
         factor_mean_field = self._factor_mean_field.copy()
         factor_dist = factor_mean_field.pop(factor)
-        cavity_dist = MeanField({v: 1.0 for v in factor_dist.all_variables}).prod(
-            *factor_mean_field.values()
+        cavity_dist = MeanField({
+            v: 1.0
+            for v in factor_dist.all_variables
+        }).prod(
+            *factor_mean_field.values(),
+            default=factor_dist,
         )
 
-        model_dist = factor_dist.prod(cavity_dist)
+        model_dist = factor_dist.prod(cavity_dist, default=factor)
 
         return FactorApproximation(factor, cavity_dist, factor_dist, model_dist)
 

--- a/autofit/graphical/expectation_propagation/factor_optimiser.py
+++ b/autofit/graphical/expectation_propagation/factor_optimiser.py
@@ -1,6 +1,5 @@
 import logging
 from abc import ABC, abstractmethod
-from collections import defaultdict
 from typing import Tuple, Optional
 
 from autofit.graphical.expectation_propagation.ep_mean_field import EPMeanField
@@ -20,9 +19,8 @@ class AbstractFactorOptimiser(ABC):
     def __init__(self, initial_values=None, deltas=None, inplace=False, delta=1):
         self.initial_values = initial_values or {}
         self.inplace = inplace
-        self.deltas = defaultdict(lambda: delta)
-        if deltas:
-            self.deltas.update(deltas)
+        self.delta = delta
+        self.deltas = deltas or {}
 
     def update_model_approx(
             self,
@@ -32,7 +30,7 @@ class AbstractFactorOptimiser(ABC):
             status: Optional[Status] = Status(),
             delta: Optional[float] = None,
     ) -> Tuple[EPMeanField, Status]:
-        delta = delta or self.deltas[factor_approx.factor]
+        delta = delta or self.deltas.get(factor_approx.factor) or self.delta
         new_approx, status = model_approx.project_mean_field(
             new_model_dist,
             factor_approx,

--- a/autofit/graphical/mean_field.py
+++ b/autofit/graphical/mean_field.py
@@ -1,6 +1,5 @@
 import logging
 from collections import ChainMap, defaultdict
-from copy import copy
 from typing import Dict, Tuple, Optional, Union, Iterable
 
 import numpy as np
@@ -278,20 +277,8 @@ class MeanField(CollectionPriorModel, Dict[Variable, AbstractMessage], Factor):
     __mul__ = prod
 
     def __truediv__(self, other: "MeanField") -> "MeanField":
-        updated_dict = {}
-
-        for key, message in self.items():
-            try:
-                new_message = message / other.get(key, 1.0)
-            except exc.MessageException:
-                logger.exception(
-                    "Posterior wider than prior. Replacing prior with posterior."
-                )
-                new_message = copy(message)
-            updated_dict[key] = new_message
-
         return type(self)(
-            updated_dict,
+            {k: m / other.get(k, 1.0) for k, m in self.items()},
             self.log_norm - other.log_norm,
         )
 

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -46,13 +46,13 @@ class NormalMessage(AbstractMessage):
         if (np.array(sigma) < 0).any():
             raise exc.MessageException("Sigma cannot be negative")
 
-        _is_nan = np.isnan(sigma)
-        if isinstance(_is_nan, np.ndarray):
-            _is_nan = _is_nan.all()
-        if _is_nan:
-            raise exc.MessageException(
-                "nan parameter passed to NormalMessage"
-            )
+        # _is_nan = np.isnan(sigma)
+        # if isinstance(_is_nan, np.ndarray):
+        #     _is_nan = _is_nan.all()
+        # if _is_nan:
+        #     raise exc.MessageException(
+        #         "nan parameter passed to NormalMessage"
+        #     )
 
         super().__init__(
             mean,

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -46,13 +46,13 @@ class NormalMessage(AbstractMessage):
         if (np.array(sigma) < 0).any():
             raise exc.MessageException("Sigma cannot be negative")
 
-        # _is_nan = np.isnan(sigma)
-        # if isinstance(_is_nan, np.ndarray):
-        #     _is_nan = _is_nan.all()
-        # if _is_nan:
-        #     raise exc.MessageException(
-        #         "nan parameter passed to NormalMessage"
-        #     )
+        _is_nan = np.isnan(sigma)
+        if isinstance(_is_nan, np.ndarray):
+            _is_nan = _is_nan.all()
+        if _is_nan:
+            raise exc.MessageException(
+                "nan parameter passed to NormalMessage"
+            )
 
         super().__init__(
             mean,

--- a/autofit/non_linear/abstract_search.py
+++ b/autofit/non_linear/abstract_search.py
@@ -101,6 +101,8 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         session
             An SQLAlchemy session instance so the results of the model-fit are written to an SQLite database.
         """
+        super().__init__(delta=kwargs.get("delta", 1.0))
+
         from autofit.non_linear.paths.database import DatabasePaths
 
         path_prefix = path_prefix or ""
@@ -287,7 +289,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
         projection, status = factor_approx.project(
             new_model_dist,
-            delta=1
+            delta=self.delta
         )
 
         status.result = result

--- a/test_autofit/graphical/test_unification.py
+++ b/test_autofit/graphical/test_unification.py
@@ -243,3 +243,10 @@ def test_pickle_transformed_instantiated(
     dill.loads(
         dill.dumps(instance)
     )
+
+
+def test_set_delta():
+    dynesty = af.DynestyStatic(
+        delta=1.23
+    )
+    assert dynesty.delta == 1.23


### PR DESCRIPTION
- Default to using the single message available for the cavity distribution when a prior is not shared
- Allow the 'delta' variable to be tuned to slow down prior shrinking

```python
dynesty = af.DynestyStatic(delta=0.5)
