### PR TITLE
feature/unit limits

### DIFF
--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -128,7 +128,8 @@ class Prior(Variable, ABC, ArithmeticMixin):
         """
         return self.value_for(
             random.uniform(
-                lower_limit, upper_limit
+                max(lower_limit, self.lower_unit_limit),
+                min(upper_limit, self.upper_unit_limit),
             )
         )
 

--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -49,6 +49,14 @@ class Prior(Variable, ABC, ArithmeticMixin):
                 "The upper limit of a prior must be greater than its lower limit"
             )
 
+    @property
+    def lower_unit_limit(self):
+        return self.message.cdf(self.lower_limit)
+
+    @property
+    def upper_unit_limit(self):
+        return self.message.cdf(self.upper_limit)
+
     def with_message(self, message):
         new = copy(self)
         new.message = message

--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -50,11 +50,17 @@ class Prior(Variable, ABC, ArithmeticMixin):
             )
 
     @property
-    def lower_unit_limit(self):
+    def lower_unit_limit(self) -> float:
+        """
+        The lower limit for this prior in unit vector space
+        """
         return self.message.cdf(self.lower_limit)
 
     @property
-    def upper_unit_limit(self):
+    def upper_unit_limit(self) -> float:
+        """
+        The upper limit for this prior in unit vector space
+        """
         return self.message.cdf(self.upper_limit)
 
     def with_message(self, message):

--- a/autofit/mapper/prior/gaussian.py
+++ b/autofit/mapper/prior/gaussian.py
@@ -31,6 +31,14 @@ class GaussianPrior(Prior):
             )
         )
 
+    @property
+    def lower_unit_limit(self):
+        return self.message.cdf(self.lower_limit)
+
+    @property
+    def upper_unit_limit(self):
+        return self.message.cdf(self.upper_limit)
+
     @classmethod
     def with_limits(
             cls,

--- a/autofit/mapper/prior/gaussian.py
+++ b/autofit/mapper/prior/gaussian.py
@@ -31,14 +31,6 @@ class GaussianPrior(Prior):
             )
         )
 
-    @property
-    def lower_unit_limit(self):
-        return self.message.cdf(self.lower_limit)
-
-    @property
-    def upper_unit_limit(self):
-        return self.message.cdf(self.upper_limit)
-
     @classmethod
     def with_limits(
             cls,

--- a/autofit/mapper/prior/uniform.py
+++ b/autofit/mapper/prior/uniform.py
@@ -34,11 +34,17 @@ class UniformPrior(Prior):
         )
 
     @property
-    def lower_unit_limit(self):
+    def lower_unit_limit(self) -> float:
+        """
+        The lower limit for this prior in unit vector space
+        """
         return 0.0
 
     @property
-    def upper_unit_limit(self):
+    def upper_unit_limit(self) -> float:
+        """
+        The upper limit for this prior in unit vector space
+        """
         return 1.0
 
     def logpdf(self, x):

--- a/autofit/mapper/prior/uniform.py
+++ b/autofit/mapper/prior/uniform.py
@@ -33,6 +33,14 @@ class UniformPrior(Prior):
             id_=id_,
         )
 
+    @property
+    def lower_unit_limit(self):
+        return 0.0
+
+    @property
+    def upper_unit_limit(self):
+        return 1.0
+
     def logpdf(self, x):
         # TODO: handle x as a numpy array
         if x == self.lower_limit:

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -662,17 +662,14 @@ class AbstractPriorModel(AbstractModel):
         """
         vector = []
 
-        while len(vector) < self.prior_count:
-            for prior in self.priors_ordered_by_id:
-                try:
-                    vector.append(prior.random(
-                        lower_limit=lower_limit,
-                        upper_limit=upper_limit,
-                    ))
-                except exc.PriorLimitException:
-                    pass
+        for prior in self.priors_ordered_by_id:
+            vector.append(prior.random(
+                lower_limit=lower_limit,
+                upper_limit=upper_limit,
+            ))
+
         return vector
-    
+
     def random_instance_from_priors_within_limits(
             self,
             lower_limit: float = 0.0,

--- a/test_autofit/mapper/model/test_model_mapper.py
+++ b/test_autofit/mapper/model/test_model_mapper.py
@@ -1,8 +1,10 @@
 import random
 
-import autofit as af
 import numpy as np
 import pytest
+
+import autofit as af
+
 
 @pytest.fixture(name="initial_model")
 def make_initial_model():
@@ -13,9 +15,6 @@ class TestParamNames:
     def test_has_prior(self):
         prior_model = af.PriorModel(af.m.MockClassx2)
         assert "one" == prior_model.name_for_prior(prior_model.one)
-
-
-
 
 
 class ExtendedMockClass(af.m.MockClassx2):
@@ -229,7 +228,6 @@ class TestInstances:
         assert model_map.mock_cls.tup == (1.0, 1.0)
 
     def test__multiple_classes(self):
-
         mapper = af.ModelMapper(
             mock_child_cls_0=af.m.MockChildTuplex3,
             mock_child_cls_1=af.m.MockChildTuplex2,
@@ -281,7 +279,6 @@ class TestInstances:
         assert model_map.mock_cls_2.two == 2.0
 
     def test__check_order_for_different_unit_values(self):
-
         mapper = af.ModelMapper(
             mock_cls_0=af.m.MockChildTuplex2,
             mock_cls_1=af.m.MockChildTuple,

--- a/test_autofit/mapper/prior/test_arithmetic.py
+++ b/test_autofit/mapper/prior/test_arithmetic.py
@@ -173,7 +173,7 @@ def test_log(
         multiplier * prior
     ).instance_from_unit_vector(
         [1.0]
-    ) == value
+    ) == pytest.approx(value)
 
 
 @pytest.mark.parametrize(

--- a/test_autofit/mapper/prior/test_limits.py
+++ b/test_autofit/mapper/prior/test_limits.py
@@ -1,6 +1,5 @@
-import pytest
-
 import numpy as np
+import pytest
 
 import autofit as af
 from autofit.exc import PriorLimitException
@@ -89,18 +88,22 @@ def test_all_priors(
     )
 
 
+@pytest.fixture(name="limitless_prior")
+def make_limitless_prior():
+    return af.GaussianPrior(
+        mean=1.0,
+        sigma=2.0,
+    )
+
+
 @pytest.mark.parametrize(
     "value",
     np.arange(0, 1, 0.1)
 )
-def test_invert_limits(value):
+def test_invert_limits(value, limitless_prior):
     value = float(value)
-    prior = af.GaussianPrior(
-        mean=1.0,
-        sigma=2.0,
-    )
-    assert prior.message.cdf(
-        prior.value_for(value)
+    assert limitless_prior.message.cdf(
+        limitless_prior.value_for(value)
     ) == pytest.approx(value)
 
 
@@ -127,3 +130,8 @@ def test_unit_limits():
         prior.value_for(
             prior.upper_unit_limit + EPSILON
         )
+
+
+def test_infinite_limits(limitless_prior):
+    assert limitless_prior.lower_unit_limit == 0.0
+    assert limitless_prior.upper_unit_limit == 1.0

--- a/test_autofit/mapper/prior/test_limits.py
+++ b/test_autofit/mapper/prior/test_limits.py
@@ -135,3 +135,12 @@ def test_unit_limits():
 def test_infinite_limits(limitless_prior):
     assert limitless_prior.lower_unit_limit == 0.0
     assert limitless_prior.upper_unit_limit == 1.0
+
+
+def test_uniform_prior():
+    uniform_prior = af.UniformPrior(
+        lower_limit=1.0,
+        upper_limit=2.0,
+    )
+    assert uniform_prior.lower_unit_limit == 0.0
+    assert uniform_prior.upper_unit_limit == 1.0

--- a/test_autofit/mapper/prior/test_limits.py
+++ b/test_autofit/mapper/prior/test_limits.py
@@ -1,5 +1,7 @@
 import pytest
 
+import numpy as np
+
 import autofit as af
 from autofit.exc import PriorLimitException
 
@@ -85,3 +87,43 @@ def test_all_priors(
         value,
         ignore_prior_limits=True
     )
+
+
+@pytest.mark.parametrize(
+    "value",
+    np.arange(0, 1, 0.1)
+)
+def test_invert_limits(value):
+    value = float(value)
+    prior = af.GaussianPrior(
+        mean=1.0,
+        sigma=2.0,
+    )
+    assert prior.message.cdf(
+        prior.value_for(value)
+    ) == pytest.approx(value)
+
+
+def test_unit_limits():
+    prior = af.GaussianPrior(
+        mean=1.0,
+        sigma=2.0,
+        lower_limit=-10,
+        upper_limit=5,
+    )
+    EPSILON = 0.00001
+    assert prior.value_for(
+        prior.lower_unit_limit
+    )
+    assert prior.value_for(
+        prior.upper_unit_limit - EPSILON
+    )
+
+    with pytest.raises(PriorLimitException):
+        prior.value_for(
+            prior.lower_unit_limit - EPSILON
+        )
+    with pytest.raises(PriorLimitException):
+        prior.value_for(
+            prior.upper_unit_limit + EPSILON
+        )


### PR DESCRIPTION
Uses the CDF to find the unit value limits of a prior from the physical limits. This allows for very efficient generation of random instances as a random value can be selected between the unit value limits.
