### PR TITLE
feature/starting point initializer

### DIFF
--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -67,7 +67,7 @@ from .non_linear.analysis.analysis import Analysis
 from .non_linear.grid.grid_search import GridSearchResult
 from .non_linear.initializer import InitializerBall
 from .non_linear.initializer import InitializerPrior
-from .non_linear.initializer import StartingPointInitializer
+from .non_linear.initializer import SpecificRangeInitializer
 from .non_linear.mcmc.auto_correlations import AutoCorrelationsSettings
 from .non_linear.mcmc.emcee.emcee import Emcee
 from .non_linear.mcmc.zeus.zeus import Zeus

--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -67,6 +67,7 @@ from .non_linear.analysis.analysis import Analysis
 from .non_linear.grid.grid_search import GridSearchResult
 from .non_linear.initializer import InitializerBall
 from .non_linear.initializer import InitializerPrior
+from .non_linear.initializer import StartingPointInitializer
 from .non_linear.mcmc.auto_correlations import AutoCorrelationsSettings
 from .non_linear.mcmc.emcee.emcee import Emcee
 from .non_linear.mcmc.zeus.zeus import Zeus

--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -54,13 +54,16 @@ class Prior(Variable, ABC, ArithmeticMixin):
         """
         The lower limit for this prior in unit vector space
         """
-        return self.message.cdf(self.lower_limit)
+        return self.unit_value_for(self.lower_limit)
 
     @property
     def upper_unit_limit(self) -> float:
         """
         The upper limit for this prior in unit vector space
         """
+        return self.unit_value_for(self.upper_limit)
+
+    def unit_value_for(self, physical_value):
         return self.message.cdf(self.upper_limit)
 
     def with_message(self, message):

--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -67,7 +67,7 @@ class Prior(Variable, ABC, ArithmeticMixin):
         """
         Compute the unit value between 0 and 1 for the physical value.
         """
-        return self.message.cdf(self.upper_limit)
+        return self.message.cdf(physical_value)
 
     def with_message(self, message):
         new = copy(self)

--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -63,7 +63,10 @@ class Prior(Variable, ABC, ArithmeticMixin):
         """
         return self.unit_value_for(self.upper_limit)
 
-    def unit_value_for(self, physical_value):
+    def unit_value_for(self, physical_value: float) -> float:
+        """
+        Compute the unit value between 0 and 1 for the physical value.
+        """
         return self.message.cdf(self.upper_limit)
 
     def with_message(self, message):

--- a/autofit/mapper/prior/uniform.py
+++ b/autofit/mapper/prior/uniform.py
@@ -73,6 +73,13 @@ class UniformPrior(Prior):
         """
         return round(super().value_for(unit, ignore_prior_limits=ignore_prior_limits), 14)
 
+    def unit_value_for(self, physical_value: float) -> float:
+        """
+        Compute the unit value between 0 and 1 for the physical value between
+        the lower and upper limits.
+        """
+        return (physical_value - self.lower_limit) / (self.upper_limit - self.lower_limit)
+
     # noinspection PyUnusedLocal
     @staticmethod
     def log_prior_from_value(value):

--- a/autofit/mapper/prior/uniform.py
+++ b/autofit/mapper/prior/uniform.py
@@ -73,13 +73,6 @@ class UniformPrior(Prior):
         """
         return round(super().value_for(unit, ignore_prior_limits=ignore_prior_limits), 14)
 
-    def unit_value_for(self, physical_value: float) -> float:
-        """
-        Compute the unit value between 0 and 1 for the physical value between
-        the lower and upper limits.
-        """
-        return (physical_value - self.lower_limit) / (self.upper_limit - self.lower_limit)
-
     # noinspection PyUnusedLocal
     @staticmethod
     def log_prior_from_value(value):

--- a/autofit/messages/transformed.py
+++ b/autofit/messages/transformed.py
@@ -22,6 +22,11 @@ class TransformedMessage(AbstractMessage):
             id_=self.instance.id
         )
 
+    def cdf(self, x):
+        return self.instance.cdf(
+            self._transform.transform(x)
+        )
+
     @property
     def natural_parameters(self):
         return self.instance.natural_parameters

--- a/autofit/non_linear/initializer.py
+++ b/autofit/non_linear/initializer.py
@@ -8,8 +8,8 @@ import numpy as np
 
 from autoconf import conf
 from autofit import exc
-from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.mapper.prior.abstract import Prior
+from autofit.mapper.prior_model.abstract import AbstractPriorModel
 
 logger = logging.getLogger(
     __name__
@@ -29,8 +29,13 @@ class StartingPointInitializer(AbstractInitializer):
     def _generate_unit_parameter_list(self, model):
         unit_parameter_list = []
         for prior in model.priors_ordered_by_id:
-            lower, upper = map(prior.unit_value_for, self.parameter_dict[prior])
-            unit_parameter_list.append(random.uniform(lower, upper))
+            try:
+                lower, upper = map(prior.unit_value_for, self.parameter_dict[prior])
+                unit_parameter_list.append(random.uniform(lower, upper))
+            except KeyError as e:
+                raise KeyError(
+                    f"Range for {'.'.join(model.path_for_prior(prior))} not set in the StartingPointInitializer"
+                ) from e
 
         return unit_parameter_list
 

--- a/autofit/non_linear/initializer.py
+++ b/autofit/non_linear/initializer.py
@@ -164,6 +164,7 @@ class SpecificRangeInitializer(AbstractInitializer):
         for prior in model.priors_ordered_by_id:
             try:
                 lower, upper = map(prior.unit_value_for, self.parameter_dict[prior])
+                value = random.uniform(lower, upper)
             except KeyError:
                 logger.warning(
                     f"Range for {'.'.join(model.path_for_prior(prior))} not set in the SpecificRangeInitializer. "
@@ -172,7 +173,11 @@ class SpecificRangeInitializer(AbstractInitializer):
                 lower = self.lower_limit
                 upper = self.upper_limit
 
-            unit_parameter_list.append(random.uniform(lower, upper))
+                value = prior.unit_value_for(
+                    prior.random(lower, upper)
+                )
+
+            unit_parameter_list.append(value)
 
         return unit_parameter_list
 

--- a/autofit/non_linear/initializer.py
+++ b/autofit/non_linear/initializer.py
@@ -117,7 +117,7 @@ class AbstractInitializer(ABC):
         return unit_parameter_lists, parameter_lists, figure_of_merit_list
 
 
-class StartingPointInitializer(AbstractInitializer):
+class SpecificRangeInitializer(AbstractInitializer):
     def __init__(self, parameter_dict: Dict[Prior, Tuple[float, float]]):
         self.parameter_dict = parameter_dict
 
@@ -129,7 +129,7 @@ class StartingPointInitializer(AbstractInitializer):
                 unit_parameter_list.append(random.uniform(lower, upper))
             except KeyError as e:
                 raise KeyError(
-                    f"Range for {'.'.join(model.path_for_prior(prior))} not set in the StartingPointInitializer"
+                    f"Range for {'.'.join(model.path_for_prior(prior))} not set in the SpecificRangeInitializer"
                 ) from e
 
         return unit_parameter_list

--- a/autofit/non_linear/initializer.py
+++ b/autofit/non_linear/initializer.py
@@ -165,13 +165,13 @@ class SpecificRangeInitializer(AbstractInitializer):
             try:
                 lower, upper = map(prior.unit_value_for, self.parameter_dict[prior])
             except KeyError:
-                logger.debug(
+                logger.warning(
                     f"Range for {'.'.join(model.path_for_prior(prior))} not set in the SpecificRangeInitializer. "
                     f"Using defaults."
                 )
                 lower = self.lower_limit
                 upper = self.upper_limit
-                
+
             unit_parameter_list.append(random.uniform(lower, upper))
 
         return unit_parameter_list

--- a/autofit/non_linear/nest/abstract_nest.py
+++ b/autofit/non_linear/nest/abstract_nest.py
@@ -6,7 +6,7 @@ from autofit.database.sqlalchemy_ import sa
 from autofit.non_linear.abstract_search import IntervalCounter
 from autofit.non_linear.abstract_search import NonLinearSearch
 from autofit.non_linear.abstract_search import PriorPasser
-from autofit.non_linear.initializer import InitializerPrior
+from autofit.non_linear.initializer import InitializerPrior, AbstractInitializer, SpecificRangeInitializer
 
 
 class AbstractNest(NonLinearSearch):
@@ -18,6 +18,7 @@ class AbstractNest(NonLinearSearch):
             prior_passer: Optional[PriorPasser] = None,
             iterations_per_update: Optional[int] = None,
             session: Optional[sa.orm.Session] = None,
+            initializer: Optional[AbstractInitializer] = None,
             **kwargs
     ):
         """
@@ -39,12 +40,15 @@ class AbstractNest(NonLinearSearch):
         session
             An SQLAlchemy session instance so the results of the model-fit are written to an SQLite database.
         """
+        if isinstance(initializer, SpecificRangeInitializer):
+            raise ValueError("SpecificRangeInitializer cannot be used for nested sampling")
+
         super().__init__(
             name=name,
             path_prefix=path_prefix,
             unique_tag=unique_tag,
             prior_passer=prior_passer,
-            initializer=InitializerPrior(),
+            initializer=initializer or InitializerPrior(),
             iterations_per_update=iterations_per_update,
             session=session,
             **kwargs

--- a/autofit/non_linear/nest/abstract_nest.py
+++ b/autofit/non_linear/nest/abstract_nest.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-import numpy as np
-
 from autoconf import conf
 from autofit import exc
 from autofit.database.sqlalchemy_ import sa
@@ -39,7 +37,7 @@ class AbstractNest(NonLinearSearch):
         prior_passer
             Controls how priors are passed from the results of this `NonLinearSearch` to a subsequent non-linear search.
         session
-            An SQLalchemy session instance so the results of the model-fit are written to an SQLite database.
+            An SQLAlchemy session instance so the results of the model-fit are written to an SQLite database.
         """
         super().__init__(
             name=name,

--- a/autofit/non_linear/optimize/drawer/drawer.py
+++ b/autofit/non_linear/optimize/drawer/drawer.py
@@ -7,7 +7,7 @@ from autoconf import conf
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.optimize.abstract_optimize import AbstractOptimizer
 from autofit.non_linear.abstract_search import PriorPasser
-from autofit.non_linear.initializer import Initializer
+from autofit.non_linear.initializer import AbstractInitializer
 from autofit.non_linear.optimize.drawer.plotter import DrawerPlotter
 from autofit.non_linear.samples import Samples, Sample
 from autofit.plot.output import Output
@@ -25,7 +25,7 @@ class Drawer(AbstractOptimizer):
             path_prefix: Optional[str] = None,
             unique_tag: Optional[str] = None,
             prior_passer: Optional[PriorPasser] = None,
-            initializer: Optional[Initializer] = None,
+            initializer: Optional[AbstractInitializer] = None,
             iterations_per_update: int = None,
             session: Optional[sa.orm.Session] = None,
             **kwargs
@@ -51,7 +51,7 @@ class Drawer(AbstractOptimizer):
         the `Drawer` search may be sufficient to perform the overall modeling task, without the need of performing
         an actual parameter space search.
 
-        The drawer search itself is performed by simply reusing the functionality of the `Initializer` object.
+        The drawer search itself is performed by simply reusing the functionality of the `AbstractInitializer` object.
         Whereas this is normally used to initialize a non-linear search, for the drawer it performed all log
         likelihood evluations.
 

--- a/autofit/non_linear/optimize/lbfgs/lbfgs.py
+++ b/autofit/non_linear/optimize/lbfgs/lbfgs.py
@@ -6,7 +6,7 @@ from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.optimize.abstract_optimize import AbstractOptimizer
 from autofit.non_linear.abstract_search import Analysis
 from autofit.non_linear.abstract_search import PriorPasser
-from autofit.non_linear.initializer import Initializer
+from autofit.non_linear.initializer import AbstractInitializer
 from autofit.non_linear.optimize.lbfgs.samples import LBFGSSamples
 
 import copy
@@ -24,7 +24,7 @@ class LBFGS(AbstractOptimizer):
             path_prefix: Optional[str] = None,
             unique_tag: Optional[str] = None,
             prior_passer: Optional[PriorPasser] = None,
-            initializer: Optional[Initializer] = None,
+            initializer: Optional[AbstractInitializer] = None,
             iterations_per_update: int = None,
             session: Optional[sa.orm.Session] = None,
             **kwargs

--- a/autofit/non_linear/optimize/pyswarms/abstract.py
+++ b/autofit/non_linear/optimize/pyswarms/abstract.py
@@ -8,7 +8,7 @@ from autofit import exc
 from autofit.database.sqlalchemy_ import sa
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.abstract_search import PriorPasser
-from autofit.non_linear.initializer import Initializer
+from autofit.non_linear.initializer import AbstractInitializer
 from autofit.non_linear.optimize.abstract_optimize import AbstractOptimizer
 from autofit.non_linear.optimize.pyswarms.samples import PySwarmsSamples
 from autofit.plot import PySwarmsPlotter
@@ -22,7 +22,7 @@ class AbstractPySwarms(AbstractOptimizer):
             path_prefix: Optional[str] = None,
             unique_tag: Optional[str] = None,
             prior_passer: Optional[PriorPasser] = None,
-            initializer: Optional[Initializer] = None,
+            initializer: Optional[AbstractInitializer] = None,
             iterations_per_update: int = None,
             number_of_cores: int = None,
             session: Optional[sa.orm.Session] = None,

--- a/autofit/non_linear/optimize/pyswarms/globe.py
+++ b/autofit/non_linear/optimize/pyswarms/globe.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from autofit.database.sqlalchemy_ import sa
 from autofit.non_linear.abstract_search import PriorPasser
-from autofit.non_linear.initializer import Initializer
+from autofit.non_linear.initializer import AbstractInitializer
 from autofit.non_linear.optimize.pyswarms.abstract import AbstractPySwarms
 
 
@@ -20,7 +20,7 @@ class PySwarmsGlobal(AbstractPySwarms):
             path_prefix: Optional[str] = None,
             unique_tag: Optional[str] = None,
             prior_passer: Optional[PriorPasser] = None,
-            initializer: Optional[Initializer] = None,
+            initializer: Optional[AbstractInitializer] = None,
             iterations_per_update: int = None,
             number_of_cores: int = None,
             session: Optional[sa.orm.Session] = None,

--- a/test_autofit/non_linear/test_initializer.py
+++ b/test_autofit/non_linear/test_initializer.py
@@ -125,3 +125,23 @@ class TestInitializeBall:
         assert 3.199 < parameter_lists[1][3] < 3.201
 
         assert figure_of_merit_list == 2 * [1.0]
+
+
+def test_starting_point_initializer():
+    model = af.Model(
+        af.Gaussian,
+        centre=af.UniformPrior(1.0, 2.0),
+        normalization=af.UniformPrior(2.0, 3.0),
+        sigma=af.UniformPrior(-2.0, -1.0),
+    )
+    initializer = af.StartingPointInitializer({
+        model.centre: (1.0, 2.0),
+        model.normalization: (2.0, 3.0),
+        model.sigma: (-2.0, -1.0),
+    })
+
+    parameter_list = initializer._generate_unit_parameter_list(model)
+    assert len(parameter_list) == 3
+    for parameter in parameter_list:
+        assert 0.0 <= parameter <= 1.0
+

--- a/test_autofit/non_linear/test_initializer.py
+++ b/test_autofit/non_linear/test_initializer.py
@@ -208,3 +208,12 @@ def test_offset(model):
     assert len(parameter_list) == 3
     for parameter in parameter_list:
         assert 0.5 <= parameter <= 1.0
+
+
+def test_missing_parameter(model):
+    initializer = af.StartingPointInitializer({
+        model.centre: (1.5, 2.0),
+        model.normalization: (2.5, 3.0),
+    })
+    with pytest.raises(KeyError):
+        initializer._generate_unit_parameter_list(model)

--- a/test_autofit/non_linear/test_initializer.py
+++ b/test_autofit/non_linear/test_initializer.py
@@ -211,9 +211,18 @@ def test_offset(model):
 
 
 def test_missing_parameter(model):
-    initializer = af.SpecificRangeInitializer({
-        model.centre: (1.5, 2.0),
-        model.normalization: (2.5, 3.0),
-    })
-    with pytest.raises(KeyError):
-        initializer._generate_unit_parameter_list(model)
+    initializer = af.SpecificRangeInitializer(
+        {
+            model.centre: (1.5, 2.0),
+            model.normalization: (2.5, 3.0),
+        },
+        lower_limit=0.5,
+        upper_limit=0.5,
+    )
+    parameter_list = initializer._generate_unit_parameter_list(model)
+
+    assert len(parameter_list) == 3
+    for parameter in parameter_list:
+        assert 0.5 <= parameter <= 1.0
+
+    assert 0.5 in parameter_list

--- a/test_autofit/non_linear/test_initializer.py
+++ b/test_autofit/non_linear/test_initializer.py
@@ -185,7 +185,7 @@ def make_model():
 
 
 def test_starting_point_initializer(model):
-    initializer = af.StartingPointInitializer({
+    initializer = af.SpecificRangeInitializer({
         model.centre: (1.0, 2.0),
         model.normalization: (2.0, 3.0),
         model.sigma: (-2.0, -1.0),
@@ -198,7 +198,7 @@ def test_starting_point_initializer(model):
 
 
 def test_offset(model):
-    initializer = af.StartingPointInitializer({
+    initializer = af.SpecificRangeInitializer({
         model.centre: (1.5, 2.0),
         model.normalization: (2.5, 3.0),
         model.sigma: (-1.5, -1.0),
@@ -211,7 +211,7 @@ def test_offset(model):
 
 
 def test_missing_parameter(model):
-    initializer = af.StartingPointInitializer({
+    initializer = af.SpecificRangeInitializer({
         model.centre: (1.5, 2.0),
         model.normalization: (2.5, 3.0),
     })

--- a/test_autofit/non_linear/test_initializer.py
+++ b/test_autofit/non_linear/test_initializer.py
@@ -142,7 +142,7 @@ def test_invert_physical(unit_value, physical_value):
         lower_limit=0.0,
         upper_limit=1.0,
     )
-    assert prior.unit_value_for(unit_value) == physical_value
+    assert prior.unit_value_for(unit_value) == pytest.approx(physical_value)
 
 
 @pytest.mark.parametrize(
@@ -157,6 +157,22 @@ def test_invert_physical_offset(unit_value, physical_value):
     prior = af.UniformPrior(
         lower_limit=1.0,
         upper_limit=3.0,
+    )
+    assert prior.unit_value_for(unit_value) == pytest.approx(physical_value)
+
+
+@pytest.mark.parametrize(
+    "unit_value, physical_value",
+    [
+        (-float("inf"), 0.0),
+        (0.0, 0.5),
+        (float("inf"), 1.0),
+    ]
+)
+def test_invert_gaussian(unit_value, physical_value):
+    prior = af.GaussianPrior(
+        mean=0.0,
+        sigma=3.0,
     )
     assert prior.unit_value_for(unit_value) == physical_value
 

--- a/test_autofit/non_linear/test_initializer.py
+++ b/test_autofit/non_linear/test_initializer.py
@@ -10,7 +10,6 @@ class MockFitness:
 
 class TestInitializePrior:
     def test__prior__samples_sample_priors(self):
-
         model = af.PriorModel(af.m.MockClassx4)
         model.one = af.UniformPrior(lower_limit=0.099, upper_limit=0.101)
         model.two = af.UniformPrior(lower_limit=0.199, upper_limit=0.201)
@@ -44,7 +43,6 @@ class TestInitializePrior:
         assert figure_of_merit_list == [1.0, 1.0]
 
     def test__samples_in_test_model(self):
-
         model = af.PriorModel(af.m.MockClassx4)
         model.one = af.UniformPrior(lower_limit=0.099, upper_limit=0.101)
         model.two = af.UniformPrior(lower_limit=0.199, upper_limit=0.201)
@@ -80,7 +78,6 @@ class TestInitializePrior:
 
 class TestInitializeBall:
     def test__ball__samples_sample_centre_of_priors(self):
-
         model = af.PriorModel(af.m.MockClassx4)
         model.one = af.UniformPrior(lower_limit=0.0, upper_limit=1.0)
         model.two = af.UniformPrior(lower_limit=0.0, upper_limit=2.0)
@@ -177,13 +174,17 @@ def test_invert_gaussian(unit_value, physical_value):
     assert prior.unit_value_for(unit_value) == physical_value
 
 
-def test_starting_point_initializer():
-    model = af.Model(
+@pytest.fixture(name="model")
+def make_model():
+    return af.Model(
         af.Gaussian,
         centre=af.UniformPrior(1.0, 2.0),
         normalization=af.UniformPrior(2.0, 3.0),
         sigma=af.UniformPrior(-2.0, -1.0),
     )
+
+
+def test_starting_point_initializer(model):
     initializer = af.StartingPointInitializer({
         model.centre: (1.0, 2.0),
         model.normalization: (2.0, 3.0),
@@ -195,3 +196,15 @@ def test_starting_point_initializer():
     for parameter in parameter_list:
         assert 0.0 <= parameter <= 1.0
 
+
+def test_offset(model):
+    initializer = af.StartingPointInitializer({
+        model.centre: (1.5, 2.0),
+        model.normalization: (2.5, 3.0),
+        model.sigma: (-1.5, -1.0),
+    })
+
+    parameter_list = initializer._generate_unit_parameter_list(model)
+    assert len(parameter_list) == 3
+    for parameter in parameter_list:
+        assert 0.5 <= parameter <= 1.0

--- a/test_autofit/non_linear/test_initializer.py
+++ b/test_autofit/non_linear/test_initializer.py
@@ -1,3 +1,5 @@
+import pytest
+
 import autofit as af
 
 
@@ -125,6 +127,38 @@ class TestInitializeBall:
         assert 3.199 < parameter_lists[1][3] < 3.201
 
         assert figure_of_merit_list == 2 * [1.0]
+
+
+@pytest.mark.parametrize(
+    "unit_value, physical_value",
+    [
+        (0.0, 0.0),
+        (0.5, 0.5),
+        (1.0, 1.0),
+    ]
+)
+def test_invert_physical(unit_value, physical_value):
+    prior = af.UniformPrior(
+        lower_limit=0.0,
+        upper_limit=1.0,
+    )
+    assert prior.unit_value_for(unit_value) == physical_value
+
+
+@pytest.mark.parametrize(
+    "unit_value, physical_value",
+    [
+        (1.0, 0.0),
+        (2.0, 0.5),
+        (3.0, 1.0),
+    ]
+)
+def test_invert_physical_offset(unit_value, physical_value):
+    prior = af.UniformPrior(
+        lower_limit=1.0,
+        upper_limit=3.0,
+    )
+    assert prior.unit_value_for(unit_value) == physical_value
 
 
 def test_starting_point_initializer():


### PR DESCRIPTION
Introduce specific range initializer.

Specific ranges are specified in a dictionary:

```python
initializer = af.SpecificRangeInitializer({
    model.centre: (1.5, 2.0),
    model.normalization: (2.5, 3.0),
    model.sigma: (-1.5, -1.0),
})
```

If any values are omitted default limits are used. These limits may be specified but otherwise are 0.0 and 1.0.

```python
initializer = af.SpecificRangeInitializer(
    {
        model.centre: (1.5, 2.0),
    },
    lower_limit=0.0,
    upper_limit=1.0,
)
```


