### PR TITLE
default value for model dist when exception thrown

### DIFF
--- a/autofit/graphical/expectation_propagation/optimiser.py
+++ b/autofit/graphical/expectation_propagation/optimiser.py
@@ -123,6 +123,7 @@ def factor_step(factor_approx, optimiser):
         status = Status(
             False, (f"Factor: {factor} experienced error {e}",), StatusFlag.FAILURE,
         )
+        new_model_dist = factor_approx.model_dist
 
     factor_logger.debug(status)
     return new_model_dist, status


### PR DESCRIPTION
Default value for model dist to prevent unbound parameter when exception thrown
