### PR TITLE
Feature/dynesty plot exceptions

### DIFF
--- a/autofit/non_linear/nest/dynesty/plotter.py
+++ b/autofit/non_linear/nest/dynesty/plotter.py
@@ -10,6 +10,19 @@ class DynestyPlotter(SamplesPlotter):
     
     @staticmethod
     def log_plot_exception(plot_name : str):
+        """
+        Plotting the results of a ``dynesty`` model-fit before they have converged on an
+        accurate estimate of the posterior can lead the ``dynesty`` plotting routines
+        to raise a ``ValueError``.
+
+        This exception is caught in each of the plotting methods below, and this
+        function is used to log the behaviour.
+
+        Parameters
+        ----------
+        plot_name
+            The name of the ``dynesty`` plot which raised a ``ValueError``
+        """
 
         logger.info(
             f"Dynesty unable to produce {plot_name} visual: posterior estimate therefore"
@@ -19,6 +32,14 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def boundplot(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``boundplot``.
+        
+        This figure plots the bounding distribution used to propose either (1) live points
+        at a given iteration or (2) a specific dead point during
+        the course of a run, projected onto the two dimensions specified
+        by `dims`.
+        """
 
         dyplot.boundplot(
             results=self.samples.results_internal,
@@ -31,7 +52,14 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def cornerbound(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``cornerbound``.
 
+        This figure plots the bounding distribution used to propose either (1) live points
+        at a given iteration or (2) a specific dead point during
+        the course of a run, projected onto all pairs of dimensions.
+        """
+        
         dyplot.cornerbound(
             results=self.samples.results_internal,
             labels=self.model.parameter_labels_with_superscripts_latex,
@@ -43,7 +71,11 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def cornerplot(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``cornerplot``.
 
+        This figure plots a corner plot of the 1-D and 2-D marginalized posteriors.
+        """
         try:
 
             dyplot.cornerplot(
@@ -61,7 +93,11 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def cornerpoints(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``cornerpoints``.
 
+        This figure plots a (sub-)corner plot of (weighted) samples.
+        """
         try:
             dyplot.cornerpoints(
                 results=self.samples.results_internal,
@@ -78,7 +114,12 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def runplot(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``runplot``.
 
+        This figure plots live points, ln(likelihood), ln(weight), and ln(evidence)
+        as a function of ln(prior volume).
+        """
         try:
             dyplot.runplot(
                 results=self.samples.results_internal,
@@ -94,7 +135,11 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def traceplot(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``traceplot``.
 
+        This figure plots traces and marginalized posteriors for each parameter.
+        """
         try:
 
             dyplot.traceplot(

--- a/autofit/non_linear/nest/dynesty/plotter.py
+++ b/autofit/non_linear/nest/dynesty/plotter.py
@@ -1,8 +1,10 @@
 from dynesty import plotting as dyplot
+import logging
 
 from autofit.plot import SamplesPlotter
 from autofit.plot.samples_plotters import skip_plot_in_test_mode
 
+logger = logging.getLogger(__name__)
 
 class DynestyPlotter(SamplesPlotter):
 
@@ -33,14 +35,24 @@ class DynestyPlotter(SamplesPlotter):
     @skip_plot_in_test_mode
     def cornerplot(self, **kwargs):
 
-        dyplot.cornerplot(
-            results=self.samples.results_internal,
-            labels=self.model.parameter_labels_with_superscripts_latex,
-            **kwargs
-        )
+        try:
 
-        self.output.to_figure(structure=None, auto_filename="cornerplot")
-        self.close()
+            dyplot.cornerplot(
+                results=self.samples.results_internal,
+                labels=self.model.parameter_labels_with_superscripts_latex,
+                **kwargs
+            )
+
+            self.output.to_figure(structure=None, auto_filename="cornerplot")
+            self.close()
+
+        except ValueError:
+
+            logger.info(
+                "Dynesty unable to produce cornerplot visual: posterior estimate therefore"
+                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
+                "should be produced in later update, once posterior estimate is updated."
+            )
 
     @skip_plot_in_test_mode
     def cornerpoints(self, **kwargs):
@@ -53,10 +65,15 @@ class DynestyPlotter(SamplesPlotter):
             )
 
             self.output.to_figure(structure=None, auto_filename="cornerpoints")
-        except ValueError:
-            pass
+            self.close()
 
-        self.close()
+        except ValueError:
+
+            logger.info(
+                "Dynesty unable to produce cornerpoints visual: posterior estimate therefore"
+                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
+                "should be produced in later update, once posterior estimate is updated."
+            )
 
     @skip_plot_in_test_mode
     def runplot(self, **kwargs):
@@ -66,19 +83,35 @@ class DynestyPlotter(SamplesPlotter):
                 results=self.samples.results_internal,
                 **kwargs
             )
-        except ValueError:
-            pass
 
-        self.output.to_figure(structure=None, auto_filename="runplot")
-        self.close()
+            self.output.to_figure(structure=None, auto_filename="runplot")
+            self.close()
+
+        except ValueError:
+
+            logger.info(
+                "Dynesty unable to produce runplot visual: posterior estimate therefore"
+                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
+                "should be produced in later update, once posterior estimate is updated."
+            )
 
     @skip_plot_in_test_mode
     def traceplot(self, **kwargs):
 
-        dyplot.traceplot(
-            results=self.samples.results_internal,
-            **kwargs
-        )
+        try:
 
-        self.output.to_figure(structure=None, auto_filename="traceplot")
-        self.close()
+            dyplot.traceplot(
+                results=self.samples.results_internal,
+                **kwargs
+            )
+
+            self.output.to_figure(structure=None, auto_filename="traceplot")
+            self.close()
+
+        except ValueError:
+
+            logger.info(
+                "Dynesty unable to produce traceplot visual: posterior estimate therefore"
+                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
+                "should be produced in later update, once posterior estimate is updated."
+            )

--- a/autofit/non_linear/nest/dynesty/plotter.py
+++ b/autofit/non_linear/nest/dynesty/plotter.py
@@ -7,6 +7,15 @@ from autofit.plot.samples_plotters import skip_plot_in_test_mode
 logger = logging.getLogger(__name__)
 
 class DynestyPlotter(SamplesPlotter):
+    
+    @staticmethod
+    def log_plot_exception(plot_name : str):
+
+        logger.info(
+            f"Dynesty unable to produce {plot_name} visual: posterior estimate therefore"
+            "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
+            "should be produced in later update, once posterior estimate is updated."
+        )
 
     @skip_plot_in_test_mode
     def boundplot(self, **kwargs):
@@ -48,11 +57,7 @@ class DynestyPlotter(SamplesPlotter):
 
         except ValueError:
 
-            logger.info(
-                "Dynesty unable to produce cornerplot visual: posterior estimate therefore"
-                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
-                "should be produced in later update, once posterior estimate is updated."
-            )
+            self.log_plot_exception(plot_name="cornerplot")
 
     @skip_plot_in_test_mode
     def cornerpoints(self, **kwargs):
@@ -69,11 +74,7 @@ class DynestyPlotter(SamplesPlotter):
 
         except ValueError:
 
-            logger.info(
-                "Dynesty unable to produce cornerpoints visual: posterior estimate therefore"
-                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
-                "should be produced in later update, once posterior estimate is updated."
-            )
+            self.log_plot_exception(plot_name="cornerpoints")
 
     @skip_plot_in_test_mode
     def runplot(self, **kwargs):
@@ -89,11 +90,7 @@ class DynestyPlotter(SamplesPlotter):
 
         except ValueError:
 
-            logger.info(
-                "Dynesty unable to produce runplot visual: posterior estimate therefore"
-                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
-                "should be produced in later update, once posterior estimate is updated."
-            )
+            self.log_plot_exception(plot_name="runplot")
 
     @skip_plot_in_test_mode
     def traceplot(self, **kwargs):
@@ -110,8 +107,4 @@ class DynestyPlotter(SamplesPlotter):
 
         except ValueError:
 
-            logger.info(
-                "Dynesty unable to produce traceplot visual: posterior estimate therefore"
-                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
-                "should be produced in later update, once posterior estimate is updated."
-            )
+            self.log_plot_exception(plot_name="traceplot")

--- a/autofit/non_linear/nest/dynesty/plotter.py
+++ b/autofit/non_linear/nest/dynesty/plotter.py
@@ -1,10 +1,23 @@
 from dynesty import plotting as dyplot
+from functools import wraps
 import logging
 
 from autofit.plot import SamplesPlotter
 from autofit.plot.samples_plotters import skip_plot_in_test_mode
 
 logger = logging.getLogger(__name__)
+
+def log_value_error(func):
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+
+        try:
+            return func(self, *args, **kwargs)
+        except ValueError:
+            self.log_plot_exception(func.__name__)
+
+    return wrapper
 
 class DynestyPlotter(SamplesPlotter):
     
@@ -70,49 +83,41 @@ class DynestyPlotter(SamplesPlotter):
         self.close()
 
     @skip_plot_in_test_mode
+    @log_value_error
     def cornerplot(self, **kwargs):
         """
         Plots the in-built ``dynesty`` plot ``cornerplot``.
 
         This figure plots a corner plot of the 1-D and 2-D marginalized posteriors.
         """
-        try:
+        dyplot.cornerplot(
+            results=self.samples.results_internal,
+            labels=self.model.parameter_labels_with_superscripts_latex,
+            **kwargs
+        )
 
-            dyplot.cornerplot(
-                results=self.samples.results_internal,
-                labels=self.model.parameter_labels_with_superscripts_latex,
-                **kwargs
-            )
-
-            self.output.to_figure(structure=None, auto_filename="cornerplot")
-            self.close()
-
-        except ValueError:
-
-            self.log_plot_exception(plot_name="cornerplot")
+        self.output.to_figure(structure=None, auto_filename="cornerplot")
+        self.close()
 
     @skip_plot_in_test_mode
+    @log_value_error
     def cornerpoints(self, **kwargs):
         """
         Plots the in-built ``dynesty`` plot ``cornerpoints``.
 
         This figure plots a (sub-)corner plot of (weighted) samples.
         """
-        try:
-            dyplot.cornerpoints(
-                results=self.samples.results_internal,
-                labels=self.model.parameter_labels_with_superscripts_latex,
-                **kwargs
-            )
+        dyplot.cornerpoints(
+            results=self.samples.results_internal,
+            labels=self.model.parameter_labels_with_superscripts_latex,
+            **kwargs
+        )
 
-            self.output.to_figure(structure=None, auto_filename="cornerpoints")
-            self.close()
-
-        except ValueError:
-
-            self.log_plot_exception(plot_name="cornerpoints")
+        self.output.to_figure(structure=None, auto_filename="cornerpoints")
+        self.close()
 
     @skip_plot_in_test_mode
+    @log_value_error
     def runplot(self, **kwargs):
         """
         Plots the in-built ``dynesty`` plot ``runplot``.
@@ -120,36 +125,26 @@ class DynestyPlotter(SamplesPlotter):
         This figure plots live points, ln(likelihood), ln(weight), and ln(evidence)
         as a function of ln(prior volume).
         """
-        try:
-            dyplot.runplot(
-                results=self.samples.results_internal,
-                **kwargs
-            )
+        dyplot.runplot(
+            results=self.samples.results_internal,
+            **kwargs
+        )
 
-            self.output.to_figure(structure=None, auto_filename="runplot")
-            self.close()
-
-        except ValueError:
-
-            self.log_plot_exception(plot_name="runplot")
+        self.output.to_figure(structure=None, auto_filename="runplot")
+        self.close()
 
     @skip_plot_in_test_mode
+    @log_value_error
     def traceplot(self, **kwargs):
         """
         Plots the in-built ``dynesty`` plot ``traceplot``.
 
         This figure plots traces and marginalized posteriors for each parameter.
         """
-        try:
+        dyplot.traceplot(
+            results=self.samples.results_internal,
+            **kwargs
+        )
 
-            dyplot.traceplot(
-                results=self.samples.results_internal,
-                **kwargs
-            )
-
-            self.output.to_figure(structure=None, auto_filename="traceplot")
-            self.close()
-
-        except ValueError:
-
-            self.log_plot_exception(plot_name="traceplot")
+        self.output.to_figure(structure=None, auto_filename="traceplot")
+        self.close()


### PR DESCRIPTION
Adds try / except clauses for certain ``dynesty`` plots, which may raise an error if the plot occurs too early in a model-fit when the posterior is not yet estimated accurately.