### PR TITLE
Feature/nuclear mode

### DIFF
--- a/autofit/non_linear/abstract_search.py
+++ b/autofit/non_linear/abstract_search.py
@@ -452,6 +452,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         info=None,
         pickle_files=None,
         log_likelihood_cap=None,
+        bypass_nuclear : bool = False
     ) -> Union["Result", List["Result"]]:
         """
         Fit a model, M with some function f that takes instances of the
@@ -570,7 +571,9 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
         self.logger.info("Removing zip file")
         self.paths.zip_remove()
-        self.paths.zip_remove_nuclear()
+
+        if not bypass_nuclear:
+            self.paths.zip_remove_nuclear()
 
         return result
 

--- a/autofit/non_linear/abstract_search.py
+++ b/autofit/non_linear/abstract_search.py
@@ -85,7 +85,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         searches.
 
         Parameters
-        -----------
+    ----------
         name
             The name of the search, controlling the last folder results are output.
         path_prefix

--- a/autofit/non_linear/abstract_search.py
+++ b/autofit/non_linear/abstract_search.py
@@ -571,6 +571,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         self.logger.info("Removing zip file")
         self.paths.zip_remove()
         self.paths.zip_remove_nuclear()
+
         return result
 
     @abstractmethod

--- a/autofit/non_linear/abstract_search.py
+++ b/autofit/non_linear/abstract_search.py
@@ -452,7 +452,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         info=None,
         pickle_files=None,
         log_likelihood_cap=None,
-        bypass_nuclear : bool = False
+        bypass_nuclear_if_on : bool = False
     ) -> Union["Result", List["Result"]]:
         """
         Fit a model, M with some function f that takes instances of the
@@ -478,6 +478,9 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         pickle_files : [str]
             Optional list of strings specifying the path and filename of .pickle files, that are copied to each
             model-fits pickles folder so they are accessible via the Aggregator.
+        bypass_nuclear_if_on
+            If nuclear mode is on (environment variable "PYAUTOFIT_NUCLEAR_MODE=1") passing this as True will
+            bypass it.
 
         Returns
         -------
@@ -572,7 +575,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         self.logger.info("Removing zip file")
         self.paths.zip_remove()
 
-        if not bypass_nuclear:
+        if not bypass_nuclear_if_on:
             self.paths.zip_remove_nuclear()
 
         return result

--- a/autofit/non_linear/abstract_search.py
+++ b/autofit/non_linear/abstract_search.py
@@ -570,6 +570,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
         self.logger.info("Removing zip file")
         self.paths.zip_remove()
+        self.paths.zip_remove_nuclear()
         return result
 
     @abstractmethod

--- a/autofit/non_linear/grid/grid_search/__init__.py
+++ b/autofit/non_linear/grid/grid_search/__init__.py
@@ -1,6 +1,7 @@
 import copy
 import csv
 import logging
+import os
 from os import path
 from typing import List, Tuple, Union, Type, Optional, Dict
 
@@ -190,6 +191,7 @@ class GridSearch:
         self.logger.info(
             "Running grid search..."
         )
+
         process_class = Process if self.parallel else Sequential
         # noinspection PyArgumentList
         return self._fit(
@@ -294,10 +296,12 @@ class GridSearch:
         return builder()
 
     def save_metadata(self):
+
         self.paths.save_parent_identifier()
         self.paths.save_unique_tag(
             is_grid_search=True
         )
+        self.paths.zip_remove_nuclear()
 
     def make_jobs(self, model, analysis, grid_priors, info: Optional[Dict] = None):
         grid_priors = model.sort_priors_alphabetically(

--- a/autofit/non_linear/grid/grid_search/job.py
+++ b/autofit/non_linear/grid/grid_search/job.py
@@ -49,7 +49,7 @@ class Job(AbstractJob):
             model=self.model,
             analysis=self.analysis,
             info=self.info,
-            bypass_nuclear=True
+            bypass_nuclear_if_on=True
         )
         result_list_row = [
             self.index,

--- a/autofit/non_linear/grid/grid_search/job.py
+++ b/autofit/non_linear/grid/grid_search/job.py
@@ -45,7 +45,12 @@ class Job(AbstractJob):
         self.info = info
 
     def perform(self):
-        result = self.search_instance.fit(model=self.model, analysis=self.analysis, info=self.info)
+        result = self.search_instance.fit(
+            model=self.model,
+            analysis=self.analysis,
+            info=self.info,
+            bypass_nuclear=True
+        )
         result_list_row = [
             self.index,
             *[

--- a/autofit/non_linear/nest/dynesty/plotter.py
+++ b/autofit/non_linear/nest/dynesty/plotter.py
@@ -10,6 +10,19 @@ class DynestyPlotter(SamplesPlotter):
     
     @staticmethod
     def log_plot_exception(plot_name : str):
+        """
+        Plotting the results of a ``dynesty`` model-fit before they have converged on an
+        accurate estimate of the posterior can lead the ``dynesty`` plotting routines
+        to raise a ``ValueError``.
+
+        This exception is caught in each of the plotting methods below, and this
+        function is used to log the behaviour.
+
+        Parameters
+        ----------
+        plot_name
+            The name of the ``dynesty`` plot which raised a ``ValueError``
+        """
 
         logger.info(
             f"Dynesty unable to produce {plot_name} visual: posterior estimate therefore"
@@ -19,6 +32,14 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def boundplot(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``boundplot``.
+        
+        This figure plots the bounding distribution used to propose either (1) live points
+        at a given iteration or (2) a specific dead point during
+        the course of a run, projected onto the two dimensions specified
+        by `dims`.
+        """
 
         dyplot.boundplot(
             results=self.samples.results_internal,
@@ -31,7 +52,14 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def cornerbound(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``cornerbound``.
 
+        This figure plots the bounding distribution used to propose either (1) live points
+        at a given iteration or (2) a specific dead point during
+        the course of a run, projected onto all pairs of dimensions.
+        """
+        
         dyplot.cornerbound(
             results=self.samples.results_internal,
             labels=self.model.parameter_labels_with_superscripts_latex,
@@ -43,7 +71,11 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def cornerplot(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``cornerplot``.
 
+        This figure plots a corner plot of the 1-D and 2-D marginalized posteriors.
+        """
         try:
 
             dyplot.cornerplot(
@@ -61,7 +93,11 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def cornerpoints(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``cornerpoints``.
 
+        This figure plots a (sub-)corner plot of (weighted) samples.
+        """
         try:
             dyplot.cornerpoints(
                 results=self.samples.results_internal,
@@ -78,7 +114,12 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def runplot(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``runplot``.
 
+        This figure plots live points, ln(likelihood), ln(weight), and ln(evidence)
+        as a function of ln(prior volume).
+        """
         try:
             dyplot.runplot(
                 results=self.samples.results_internal,
@@ -94,7 +135,11 @@ class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
     def traceplot(self, **kwargs):
+        """
+        Plots the in-built ``dynesty`` plot ``traceplot``.
 
+        This figure plots traces and marginalized posteriors for each parameter.
+        """
         try:
 
             dyplot.traceplot(

--- a/autofit/non_linear/nest/dynesty/plotter.py
+++ b/autofit/non_linear/nest/dynesty/plotter.py
@@ -1,8 +1,10 @@
 from dynesty import plotting as dyplot
+import logging
 
 from autofit.plot import SamplesPlotter
 from autofit.plot.samples_plotters import skip_plot_in_test_mode
 
+logger = logging.getLogger(__name__)
 
 class DynestyPlotter(SamplesPlotter):
 
@@ -33,14 +35,24 @@ class DynestyPlotter(SamplesPlotter):
     @skip_plot_in_test_mode
     def cornerplot(self, **kwargs):
 
-        dyplot.cornerplot(
-            results=self.samples.results_internal,
-            labels=self.model.parameter_labels_with_superscripts_latex,
-            **kwargs
-        )
+        try:
 
-        self.output.to_figure(structure=None, auto_filename="cornerplot")
-        self.close()
+            dyplot.cornerplot(
+                results=self.samples.results_internal,
+                labels=self.model.parameter_labels_with_superscripts_latex,
+                **kwargs
+            )
+
+            self.output.to_figure(structure=None, auto_filename="cornerplot")
+            self.close()
+
+        except ValueError:
+
+            logger.info(
+                "Dynesty unable to produce cornerplot visual: posterior estimate therefore"
+                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
+                "should be produced in later update, once posterior estimate is updated."
+            )
 
     @skip_plot_in_test_mode
     def cornerpoints(self, **kwargs):
@@ -53,10 +65,15 @@ class DynestyPlotter(SamplesPlotter):
             )
 
             self.output.to_figure(structure=None, auto_filename="cornerpoints")
-        except ValueError:
-            pass
+            self.close()
 
-        self.close()
+        except ValueError:
+
+            logger.info(
+                "Dynesty unable to produce cornerpoints visual: posterior estimate therefore"
+                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
+                "should be produced in later update, once posterior estimate is updated."
+            )
 
     @skip_plot_in_test_mode
     def runplot(self, **kwargs):
@@ -66,19 +83,35 @@ class DynestyPlotter(SamplesPlotter):
                 results=self.samples.results_internal,
                 **kwargs
             )
-        except ValueError:
-            pass
 
-        self.output.to_figure(structure=None, auto_filename="runplot")
-        self.close()
+            self.output.to_figure(structure=None, auto_filename="runplot")
+            self.close()
+
+        except ValueError:
+
+            logger.info(
+                "Dynesty unable to produce runplot visual: posterior estimate therefore"
+                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
+                "should be produced in later update, once posterior estimate is updated."
+            )
 
     @skip_plot_in_test_mode
     def traceplot(self, **kwargs):
 
-        dyplot.traceplot(
-            results=self.samples.results_internal,
-            **kwargs
-        )
+        try:
 
-        self.output.to_figure(structure=None, auto_filename="traceplot")
-        self.close()
+            dyplot.traceplot(
+                results=self.samples.results_internal,
+                **kwargs
+            )
+
+            self.output.to_figure(structure=None, auto_filename="traceplot")
+            self.close()
+
+        except ValueError:
+
+            logger.info(
+                "Dynesty unable to produce traceplot visual: posterior estimate therefore"
+                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
+                "should be produced in later update, once posterior estimate is updated."
+            )

--- a/autofit/non_linear/nest/dynesty/plotter.py
+++ b/autofit/non_linear/nest/dynesty/plotter.py
@@ -7,6 +7,15 @@ from autofit.plot.samples_plotters import skip_plot_in_test_mode
 logger = logging.getLogger(__name__)
 
 class DynestyPlotter(SamplesPlotter):
+    
+    @staticmethod
+    def log_plot_exception(plot_name : str):
+
+        logger.info(
+            f"Dynesty unable to produce {plot_name} visual: posterior estimate therefore"
+            "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
+            "should be produced in later update, once posterior estimate is updated."
+        )
 
     @skip_plot_in_test_mode
     def boundplot(self, **kwargs):
@@ -48,11 +57,7 @@ class DynestyPlotter(SamplesPlotter):
 
         except ValueError:
 
-            logger.info(
-                "Dynesty unable to produce cornerplot visual: posterior estimate therefore"
-                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
-                "should be produced in later update, once posterior estimate is updated."
-            )
+            self.log_plot_exception(plot_name="cornerplot")
 
     @skip_plot_in_test_mode
     def cornerpoints(self, **kwargs):
@@ -69,11 +74,7 @@ class DynestyPlotter(SamplesPlotter):
 
         except ValueError:
 
-            logger.info(
-                "Dynesty unable to produce cornerpoints visual: posterior estimate therefore"
-                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
-                "should be produced in later update, once posterior estimate is updated."
-            )
+            self.log_plot_exception(plot_name="cornerpoints")
 
     @skip_plot_in_test_mode
     def runplot(self, **kwargs):
@@ -89,11 +90,7 @@ class DynestyPlotter(SamplesPlotter):
 
         except ValueError:
 
-            logger.info(
-                "Dynesty unable to produce runplot visual: posterior estimate therefore"
-                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
-                "should be produced in later update, once posterior estimate is updated."
-            )
+            self.log_plot_exception(plot_name="runplot")
 
     @skip_plot_in_test_mode
     def traceplot(self, **kwargs):
@@ -110,8 +107,4 @@ class DynestyPlotter(SamplesPlotter):
 
         except ValueError:
 
-            logger.info(
-                "Dynesty unable to produce traceplot visual: posterior estimate therefore"
-                "not yet sufficient for this model-fit is not yet robust enough to do this. Visual"
-                "should be produced in later update, once posterior estimate is updated."
-            )
+            self.log_plot_exception(plot_name="traceplot")

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -250,24 +250,29 @@ class AbstractPaths(ABC):
         the results are populated in the same folder with different unique identifiers.
 
         By accident, one may perform runs where additional results are placed
-        in these folders which are not wanted for the subsequent analysis. Removing these
-        results from the directory can be cumbersome, as determining the unwanted results
-        based on their unique identifier requires visually inspecting them.
+        in these folders which are not wanted for the subsequent analysis.
+
+        Removing these results from the directory can be cumbersome, as determining
+        the unwanted results based on their unique identifier requires visually inspecting
+        them.
 
         These unwanted results can also make manipulating the results via the database
-        have issues.
+        problematic, as one may need to again filter based on unique identifier.
 
         When a run is performed in nuclear mode, all results in every folder are
-        deleted except the results corresponding to the unique idenfier of this run.
+        deleted except the results corresponding to the unique identifier of that run.
+
+        Therefore, provided the user is 100% certain that the run corresponds to the
+        results they want to keep, nuclear mode can be used to remove all unwanted results.
 
         For example, suppose a folder has 5 results, 4 of which are unwanted and 1 which is
         wanted. If nuclear mode runs, and the model-fit is set up correctly such that the
         identifier created corresponds to the wanted result, all 4 unwanted results
         will be deleted.
 
-        To enable nuclear mode, one should set the environment
-        variable ``PYAUTOFIT_NUCLEAR_MODE=1``. Nuclear model is dangerous, and must be
-        used with CAUTION AND CARE!
+        To enable nuclear mode, set the environment variable ``PYAUTOFIT_NUCLEAR_MODE=1``.
+
+        Nuclear model is dangerous, and must be used with CAUTION AND CARE!
         """
 
         if os.environ.get("PYAUTOFIT_NUCLEAR_MODE") == "1":

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -268,11 +268,8 @@ class AbstractPaths(ABC):
         To enable nuclear mode, one should set the environment
         variable ``PYAUTOFIT_NUCLEAR_MODE=1``. Nuclear model is dangerous, and must be
         used with CAUTION AND CARE!
-
-        Returns
-        -------
-
         """
+
         if os.environ.get("PYAUTOFIT_NUCLEAR_MODE") == "1" :
 
             file_path = os.path.split(self.output_path)[0]

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -244,6 +244,58 @@ class AbstractPaths(ABC):
         except FileNotFoundError:
             pass
 
+    def zip_remove_nuclear(self):
+        """
+        When multiple model-fits are performed using the same `path_prefix` and `name`,
+        the results are populated in the same folder with different unique identifiers.
+
+        By accident, one may perform runs where additional results are placed
+        in these folders which are not wanted for the subsequent analysis. Removing these
+        results from the directory can be cumbersome, as determining the unwanted results
+        based on their unique identifier requires visually inspecting them.
+
+        These unwanted results can also make manipulating the results via the database
+        have issues.
+
+        When a run is performed in nuclear mode, all results in every folder are
+        deleted except the results corresponding to the unique idenfier of this run.
+
+        For example, suppose a folder has 5 results, 4 of which are unwanted and 1 which is
+        wanted. If nuclear mode runs, and the model-fit is set up correctly such that the
+        identifier created corresponds to the wanted result, all 4 unwanted results
+        will be deleted.
+
+        To enable nuclear mode, one should set the environment
+        variable ``PYAUTOFIT_NUCLEAR_MODE=1``. Nuclear model is dangerous, and must be
+        used with CAUTION AND CARE!
+
+        Returns
+        -------
+
+        """
+        if os.environ.get("PYAUTOFIT_NUCLEAR_MODE") == "1" :
+
+            file_path = os.path.split(self.output_path)[0]
+
+            file_list = os.listdir(file_path)
+            file_list = [file for file in file_list if self.identifier not in file]
+
+            for file in file_list:
+
+                file_to_remove = path.join(file_path, file)
+
+                try:
+                    os.remove(file_to_remove)
+                    logger.info(f"NUCLEAR MODE -- Removed {file_to_remove}")
+                except (IsADirectoryError, FileNotFoundError):
+                    pass
+
+                try:
+                    shutil.rmtree(file_to_remove)
+                    logger.info(f"NUCLEAR MODE -- Removed {file_to_remove}")
+                except (NotADirectoryError, FileNotFoundError):
+                    pass
+
     def restore(self):
         """
         Copy files from the ``.zip`` file to the samples folder.

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -272,7 +272,7 @@ class AbstractPaths(ABC):
 
         To enable nuclear mode, set the environment variable ``PYAUTOFIT_NUCLEAR_MODE=1``.
 
-        Nuclear model is dangerous, and must be used with CAUTION AND CARE!
+        Nuclear mode is dangerous, and must be used with CAUTION AND CARE!
         """
 
         if os.environ.get("PYAUTOFIT_NUCLEAR_MODE") == "1":

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -270,7 +270,7 @@ class AbstractPaths(ABC):
         used with CAUTION AND CARE!
         """
 
-        if os.environ.get("PYAUTOFIT_NUCLEAR_MODE") == "1" :
+        if os.environ.get("PYAUTOFIT_NUCLEAR_MODE") == "1":
 
             file_path = os.path.split(self.output_path)[0]
 

--- a/docs/api/analysis.rst
+++ b/docs/api/analysis.rst
@@ -2,8 +2,9 @@
 Analysis
 ========
 
-The ``Analysis`` object is used to define the ``log_likelihood_function`` of your model-fitting problem, and acts
-as an interface between the data and the non-linear search.
+The ``Analysis`` object defines the ``log_likelihood_function`` of your model-fitting problem.
+
+It acts as an interface between the data, model and the non-linear search.
 
 **Examples / Tutorials:**
 

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -2,7 +2,7 @@
 Plotters
 ========
 
-The ``Plotter`` objects are used to create non-linear search specific visualization of every search algorithm supported
+Create figures and subplots of non-linear search specific visualization of every search algorithm supported
 by **PyAutoFit**.
 
 **Examples / Tutorials:**

--- a/docs/api/priors.rst
+++ b/docs/api/priors.rst
@@ -2,7 +2,7 @@
 Priors
 ======
 
-The priors of every model-fit are customized using `Prior` objects.
+The priors of parameters of every component of a mdoel, which is fitted to data, are customized using ``Prior`` objects.
 
 **Examples / Tutorials:**
 


### PR DESCRIPTION
        When multiple model-fits are performed using the same `path_prefix` and `name`,
        the results are populated in the same folder with different unique identifiers.

        By accident, one may perform runs where additional results are placed
        in these folders which are not wanted for the subsequent analysis.

        Removing these results from the directory can be cumbersome, as determining
        the unwanted results based on their unique identifier requires visually inspecting
        them.

        These unwanted results can also make manipulating the results via the database
        problematic, as one may need to again filter based on unique identifier.

        When a run is performed in nuclear mode, all results in every folder are
        deleted except the results corresponding to the unique identifier of that run.

        Therefore, provided the user is 100% certain that the run corresponds to the
        results they want to keep, nuclear mode can be used to remove all unwanted results.

        For example, suppose a folder has 5 results, 4 of which are unwanted and 1 which is
        wanted. If nuclear mode runs, and the model-fit is set up correctly such that the
        identifier created corresponds to the wanted result, all 4 unwanted results
        will be deleted.

        To enable nuclear mode, set the environment variable ``PYAUTOFIT_NUCLEAR_MODE=1``.

        Nuclear model is dangerous, and must be used with CAUTION AND CARE!