### PR TITLE
remove default root file handler

### DIFF
--- a/autofit/config/logging.yaml
+++ b/autofit/config/logging.yaml
@@ -7,11 +7,6 @@ handlers:
     level: INFO
     stream: ext://sys.stdout
     formatter: formatter
-  file:
-    class: logging.FileHandler
-    level: INFO
-    filename: root.log
-    formatter: formatter
 
 root:
   level: INFO


### PR DESCRIPTION
Should resolve #613

Note that this handler is still configured in some of the workspace projects
