### PR TITLE
output .is_grid_search for senstivity

### DIFF
--- a/autofit/non_linear/grid/sensitivity.py
+++ b/autofit/non_linear/grid/sensitivity.py
@@ -259,6 +259,8 @@ class Sensitivity:
         """
         self.logger.info("Running")
 
+        self.search.paths.save_unique_tag(is_grid_search=True)
+
         headers = [
             "index",
             *self._headers,
@@ -294,6 +296,10 @@ class Sensitivity:
                             result_.log_likelihood_difference,
                         ]
                     )
+
+        result = SensitivityResult(results)
+
+        self.search.paths.save_object("result", result)
 
         return SensitivityResult(results)
 

--- a/test_autofit/non_linear/grid/test_sensitivity/test_run.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/test_run.py
@@ -3,24 +3,21 @@ from pathlib import Path
 from autoconf.conf import with_config
 
 
-@with_config(
-    "general",
-    "model",
-    "ignore_prior_limits",
-    value=True
-)
-def test_sensitivity(
-        sensitivity
-):
+@with_config("general", "model", "ignore_prior_limits", value=True)
+def test_sensitivity(sensitivity):
     results = sensitivity.run()
     assert len(results) == 8
 
-    path = Path(
-        sensitivity.search.paths.output_path
-    ) / "results.csv"
+    output_path = Path(sensitivity.search.paths.output_path)
+
+    assert (output_path / ".is_grid_search").exists()
+    path = output_path / "results.csv"
     assert path.exists()
     with open(path) as f:
         all_lines = set(f)
-        assert 'index,centre,normalization,sigma,log_likelihood_base,log_likelihood_perturbed,log_likelihood_difference\n' in all_lines
-        assert '     0,  0.25,  0.25,  0.25,   2.0,   2.0,   0.0\n' in all_lines
-        assert '     1,  0.25,  0.25,  0.75,   2.0,   2.0,   0.0\n' in all_lines
+        assert (
+            "index,centre,normalization,sigma,log_likelihood_base,log_likelihood_perturbed,log_likelihood_difference\n"
+            in all_lines
+        )
+        assert "     0,  0.25,  0.25,  0.25,   2.0,   2.0,   0.0\n" in all_lines
+        assert "     1,  0.25,  0.25,  0.75,   2.0,   2.0,   0.0\n" in all_lines


### PR DESCRIPTION
Fixes loading sensitivity from  directories by using same conventions as grid search. This means that the script now attempts to print but fails as I chose slightly different naming for the sensitivity result fields:

log_likelihoods_base
log_likelihoods_perturbed
log_likelihood_differences
