### PR TITLE
feature/covariance model

### DIFF
--- a/autofit/interpolator/covariance.py
+++ b/autofit/interpolator/covariance.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy
-from typing import List
+from typing import List, Dict
 
 from autofit.non_linear.samples.pdf import SamplesPDF
 from .abstract import AbstractInterpolator
@@ -205,13 +205,14 @@ class CovarianceInterpolator(AbstractInterpolator):
     def get(
         self,
         value: Equality,
-        path_relationship_map=None,
+        path_relationship_map: Dict = None,
     ) -> float:
         """
         Calculate the value of the variable for a given value of the variable to which it is related
 
         Parameters
         ----------
+        path_relationship_map
         value
             The value to which the variables are related (e.g. time)
 
@@ -246,13 +247,14 @@ class CovarianceInterpolator(AbstractInterpolator):
         """
         return self._max_likelihood_samples_list().model
 
-    def model(self, path_relationship_map) -> Collection:
+    def model(self, path_relationship_map=None) -> Collection:
         """
         Create a model that describes the linear relationships between each variable and the variable to which it is
         related
         """
         models = []
         single_model = self._single_model
+        path_relationship_map = path_relationship_map or {}
         for prior in single_model.priors_ordered_by_id:
             path = single_model.path_for_prior(prior)
             if path in path_relationship_map:

--- a/autofit/interpolator/covariance.py
+++ b/autofit/interpolator/covariance.py
@@ -4,7 +4,7 @@ from typing import List, Dict
 
 from autofit.non_linear.samples.pdf import SamplesPDF
 from .abstract import AbstractInterpolator
-from .query import Equality
+from .query import Equality, InterpolatorPath
 from autofit.non_linear.analysis.analysis import Analysis
 from autofit.non_linear.nest.dynesty.static import DynestyStatic
 from autofit.mapper.prior_model.prior_model import Model
@@ -205,7 +205,7 @@ class CovarianceInterpolator(AbstractInterpolator):
     def get(
         self,
         value: Equality,
-        path_relationship_map: Dict = None,
+        path_relationship_map: Dict[InterpolatorPath, Model] = None,
     ) -> float:
         """
         Calculate the value of the variable for a given value of the variable to which it is related
@@ -213,6 +213,8 @@ class CovarianceInterpolator(AbstractInterpolator):
         Parameters
         ----------
         path_relationship_map
+            Specifies which model should be used for each relationship. Each parameter in the model
+            is described by a LinearRelationship with GaussianPriors by default.
         value
             The value to which the variables are related (e.g. time)
 

--- a/autofit/interpolator/query.py
+++ b/autofit/interpolator/query.py
@@ -14,6 +14,17 @@ class InterpolatorPath:
         """
         self.keys = keys
 
+    def __hash__(self):
+        return hash(tuple(self.keys))
+
+    def __repr__(self):
+        return f"InterpolatorPath({self.keys})"
+
+    def __eq__(self, other):
+        if isinstance(other, InterpolatorPath):
+            keys = other.keys
+        return self.keys == keys
+
     def __getattr__(self, item: str) -> "InterpolatorPath":
         """
         Add a new attribute name to the end of the path

--- a/autofit/interpolator/query.py
+++ b/autofit/interpolator/query.py
@@ -20,11 +20,6 @@ class InterpolatorPath:
     def __repr__(self):
         return f"InterpolatorPath({self.keys})"
 
-    def __eq__(self, other):
-        if isinstance(other, InterpolatorPath):
-            keys = other.keys
-        return self.keys == keys
-
     def __getattr__(self, item: str) -> "InterpolatorPath":
         """
         Add a new attribute name to the end of the path

--- a/test_autofit/interpolator/conftest.py
+++ b/test_autofit/interpolator/conftest.py
@@ -1,5 +1,7 @@
 import pytest
+
 import autofit as af
+from autofit.interpolator import CovarianceInterpolator
 
 
 @pytest.fixture(name="model_instance")
@@ -23,3 +25,37 @@ def make_instances(model_instance):
             )
         ),
     ]
+
+
+@pytest.fixture(name="interpolator")
+def make_interpolator():
+    samples_list = [
+        af.SamplesPDF(
+            model=af.Collection(
+                t=value,
+                gaussian=af.Model(
+                    af.Gaussian,
+                    centre=af.GaussianPrior(mean=1.0, sigma=1.0),
+                    normalization=af.GaussianPrior(mean=1.0, sigma=1.0),
+                    sigma=af.GaussianPrior(mean=1.0, sigma=1.0),
+                ),
+            ),
+            sample_list=[
+                af.Sample(
+                    log_likelihood=-i,
+                    log_prior=1.0,
+                    weight=1.0,
+                    kwargs={
+                        ("gaussian", "centre"): value + i,
+                        ("gaussian", "normalization"): value + i**2,
+                        ("gaussian", "sigma"): value + i**3,
+                    },
+                )
+                for i in range(3)
+            ],
+        )
+        for value in range(3)
+    ]
+    return CovarianceInterpolator(
+        samples_list,
+    )

--- a/test_autofit/interpolator/test_covariance.py
+++ b/test_autofit/interpolator/test_covariance.py
@@ -54,7 +54,7 @@ def test_linear_analysis_for_value(interpolator):
 
 
 def test_model(interpolator):
-    model = interpolator.model
+    model = interpolator.model()
     assert model.prior_count == 6
 
 

--- a/test_autofit/interpolator/test_covariance.py
+++ b/test_autofit/interpolator/test_covariance.py
@@ -5,40 +5,6 @@ from autofit.interpolator import CovarianceInterpolator
 import numpy as np
 
 
-@pytest.fixture(name="interpolator")
-def make_interpolator():
-    samples_list = [
-        af.SamplesPDF(
-            model=af.Collection(
-                t=value,
-                gaussian=af.Model(
-                    af.Gaussian,
-                    centre=af.GaussianPrior(mean=1.0, sigma=1.0),
-                    normalization=af.GaussianPrior(mean=1.0, sigma=1.0),
-                    sigma=af.GaussianPrior(mean=1.0, sigma=1.0),
-                ),
-            ),
-            sample_list=[
-                af.Sample(
-                    log_likelihood=-i,
-                    log_prior=1.0,
-                    weight=1.0,
-                    kwargs={
-                        ("gaussian", "centre"): value + i,
-                        ("gaussian", "normalization"): value + i**2,
-                        ("gaussian", "sigma"): value + i**3,
-                    },
-                )
-                for i in range(3)
-            ],
-        )
-        for value in range(3)
-    ]
-    return CovarianceInterpolator(
-        samples_list,
-    )
-
-
 def test_covariance_matrix(interpolator):
     assert np.allclose(
         interpolator.covariance_matrix(),

--- a/test_autofit/interpolator/test_specify_relationship.py
+++ b/test_autofit/interpolator/test_specify_relationship.py
@@ -1,0 +1,31 @@
+import pytest
+
+import autofit as af
+
+
+class MockRelationship:
+    def __call__(self, x):
+        return 1.0
+
+
+@pytest.fixture(name="path_relationship_map")
+def make_path_relationship_map(interpolator):
+    return {interpolator.gaussian.centre: af.Model(MockRelationship)}
+
+
+def test(interpolator, path_relationship_map):
+    interpolated = interpolator.get(
+        interpolator.t == 1.0,
+        path_relationship_map,
+    )
+    assert interpolated.gaussian.centre == 1.0
+
+
+def test_model(interpolator, path_relationship_map):
+    collection = interpolator.model(path_relationship_map)
+
+    assert MockRelationship in [model.cls for model in collection]
+
+
+def test_path_matching(path_relationship_map):
+    assert ("gaussian", "centre") in path_relationship_map

--- a/test_autofit/interpolator/test_specify_relationship.py
+++ b/test_autofit/interpolator/test_specify_relationship.py
@@ -25,7 +25,10 @@ def test(interpolator, path_relationship_map, t):
 def test_model(interpolator, path_relationship_map):
     collection = interpolator.model(path_relationship_map)
 
-    assert MockRelationship in [model.cls for model in collection]
+    classes = {model.cls for model in collection}
+
+    assert MockRelationship in classes
+    assert len(classes) == 2
 
 
 def test_path_matching(path_relationship_map):

--- a/test_autofit/interpolator/test_specify_relationship.py
+++ b/test_autofit/interpolator/test_specify_relationship.py
@@ -13,9 +13,10 @@ def make_path_relationship_map(interpolator):
     return {interpolator.gaussian.centre: af.Model(MockRelationship)}
 
 
-def test(interpolator, path_relationship_map):
+@pytest.mark.parametrize("t", range(3))
+def test(interpolator, path_relationship_map, t):
     interpolated = interpolator.get(
-        interpolator.t == 1.0,
+        interpolator.t == t,
         path_relationship_map,
     )
     assert interpolated.gaussian.centre == 1.0


### PR DESCRIPTION
Allows the model describing each relationship to be optionally specified when getting an interpolated instance.

```python
import autofit as af


interpolator = af.CovarianceInterpolator(samples_list)
instance = interpolator.get(
    interpolator.t == 1, 
    {interpolator.gaussian.centre: af.Model(af.LinearRelationship)}
)
