### PR TITLE
Feature/visualization fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ The following links are useful for new starters:
 
 - `The PyAutoFit readthedocs <https://pyautofit.readthedocs.io/en/latest>`_, which includes an `installation guide <https://pyautofit.readthedocs.io/en/latest/installation/overview.html>`_ and an overview of **PyAutoFit**'s core features.
 
-- `The autofit_workspace GitHub repository <https://github.com/Jammy2211/autofit_workspace>`_, which includes example scripts and the `HowToFit Jupyter notebook tutorials <https://github.com/Jammy2211/autofit_workspace/tree/master/notebooks/howtofit>`_ which give new users a step-by-step introduction to **PyAutoFit**.
+- `The autofit_workspace GitHub repository <https://github.com/Jammy2211/autofit_workspace>`_, which includes example scripts and the `HowToFit Jupyter notebook lectures <https://github.com/Jammy2211/autofit_workspace/tree/master/notebooks/howtofit>`_ which give new users a step-by-step introduction to **PyAutoFit**.
 
 Why PyAutoFit?
 --------------

--- a/autofit/non_linear/abstract_search.py
+++ b/autofit/non_linear/abstract_search.py
@@ -742,24 +742,31 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         """
         return self._class_config[section][attribute_name]
 
-    def perform_update(self, model, analysis, during_analysis):
+    def perform_update(self, model : Collection, analysis : Analysis, during_analysis : bool):
         """
-        Perform an update of the `NonLinearSearch` results, which occurs every *iterations_per_update* of the
-        non-linear search. The update performs the following tasks:
+        Perform an update of the non-linear search's model-fitting results.
 
-        1) Visualize the maximum log likelihood model.
-        2) Output the model results to the model.reults file.
+        This occurs every `iterations_per_update` of the non-linear search and once it is complete.
+
+        The update performs the following tasks (if the settings indicate they should be performed):
+
+        1) Visualize the search results (e.g. a cornerplot).
+        2) Visualize the maximum log likelihood model using model-specific visualization implented via the `Analysis`
+           object.
+        3) Perform profiling of the analysis object `log_likelihood_function` and ouptut run-time information.
+        4) Output the `search.summary` file which contains information on model-fitting so far.
+        5) Output the `model.results` file which contains a concise text summary of the model results so far.
 
         Parameters
         ----------
-        model : ModelMapper
+        model
             The model which generates instances for different points in parameter space.
-        analysis : Analysis
+        analysis
             Contains the data and the log likelihood function which fits an instance of the model to the data, returning
             the log likelihood the `NonLinearSearch` maximizes.
         during_analysis
             If the update is during a non-linear search, in which case tasks are only performed after a certain number
-             of updates and only a subset of visualization may be performed.
+            of updates and only a subset of visualization may be performed.
         """
 
         self.iterations += self.iterations_per_update
@@ -810,7 +817,30 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         return samples
 
     def perform_visualization(self, model, analysis, during_analysis):
+        """
+        Perform visualization of the non-linear search's model-fitting results.
 
+        This occurs every `iterations_per_update` of the non-linear search, when the search is complete and can
+        also be forced to occur even though a search is completed on a rerun, to update the visualization
+        with different `matplotlib` settings.
+
+        The update performs the following tasks (if the settings indicate they should be performed):
+
+        1) Visualize the search results (e.g. a cornerplot).
+        2) Visualize the maximum log likelihood model using model-specific visualization implented via the `Analysis`
+           object.
+
+        Parameters
+        ----------
+        model
+            The model which generates instances for different points in parameter space.
+        analysis
+            Contains the data and the log likelihood function which fits an instance of the model to the data, returning
+            the log likelihood the `NonLinearSearch` maximizes.
+        during_analysis
+            If the update is during a non-linear search, in which case tasks are only performed after a certain number
+            of updates and only a subset of visualization may be performed.
+        """
         try:
             samples = self.samples_from(model=model)
         except FileNotFoundError:

--- a/docs/science_examples/astronomy.rst
+++ b/docs/science_examples/astronomy.rst
@@ -9,7 +9,7 @@ off of our astronomy software `PyAutoLens <https://github.com/Jammy2211/PyAutoLe
 
 The schematic below depicts a strong gravitational lens:
 
-.. image:: https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/lensing/schematic.jpg
+.. image:: https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1_lensing/schematic.jpg
   :width: 600
   :alt: Alternative text
 


### PR DESCRIPTION
The `force_visualize_overwrite` config option now works as expected, allowing users to update visuals of complete results via a config override.

This required me to separate visualization from `perform_update`.