### PR TITLE
Superscript fix and search plotting exceptions

### DIFF
--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1723,7 +1723,7 @@ class AbstractPriorModel(AbstractModel):
 
         prior_paths = map(tuple_filter, prior_paths)
 
-        superscripts = [path[-2] if len(path) > 1 else path[0] for path in prior_paths]
+        superscripts = [path[-2] if len(path) > 1 else None for path in prior_paths]
 
         return [
             superscript if not superscript_overwrite else superscript_overwrite
@@ -1780,7 +1780,7 @@ class AbstractPriorModel(AbstractModel):
         """
 
         return [
-            f"{label}^{{\\rm {superscript}}}"
+            f"{label}^{{\\rm {superscript}}}" if superscript else f"{label}"
             for label, superscript in zip(self.parameter_labels, self.superscripts)
         ]
 

--- a/autofit/non_linear/search/nest/dynesty/plotter.py
+++ b/autofit/non_linear/search/nest/dynesty/plotter.py
@@ -9,7 +9,31 @@ def log_value_error(func):
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
+        """
+        Prevent an exception terminating the run if visualization fails due to convergence not yet being reached.
 
+        Searches attempt to perform visualization every `iterations_per_update`, however these visualization calls
+        may occur before the search has converged on enough of parameter to successfully perform visualization.
+
+        This can lead the search to raise an exception which terminates the Python script, when we instead
+        want the code to continue running, to continue the search and perform visualization on a subsequent iteration
+        once convergence has been achieved.
+
+        This wrapper catches these exceptions, logs them so the user can see visualization failed and then
+        continues the code without raising an exception in a way that terminates the script.
+
+        This wrapper is specific to Dynesty, which raises a `ValueError` when visualization is performed before
+        convergence has been achieved.
+
+        Parameters
+        ----------
+        self
+            An instance of a `SearchPlotter` class.
+        args
+            The arguments used to perform a visualization of the search.
+        kwargs
+            The keyword arguments used to perform a visualization of the search.
+        """
         try:
             return func(self, *args, **kwargs)
         except ValueError:

--- a/autofit/non_linear/search/nest/dynesty/plotter.py
+++ b/autofit/non_linear/search/nest/dynesty/plotter.py
@@ -1,9 +1,21 @@
 from dynesty import plotting as dyplot
+from functools import wraps
 
 from autofit.plot import SamplesPlotter
 
 from autofit.plot.samples_plotters import skip_plot_in_test_mode
-from autofit.plot.samples_plotters import log_value_error
+
+def log_value_error(func):
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+
+        try:
+            return func(self, *args, **kwargs)
+        except ValueError:
+            self.log_plot_exception(func.__name__)
+
+    return wrapper
 
 class DynestyPlotter(SamplesPlotter):
 

--- a/autofit/non_linear/search/nest/dynesty/plotter.py
+++ b/autofit/non_linear/search/nest/dynesty/plotter.py
@@ -8,6 +8,7 @@ from autofit.plot.samples_plotters import log_value_error
 class DynestyPlotter(SamplesPlotter):
 
     @skip_plot_in_test_mode
+    @log_value_error
     def boundplot(self, **kwargs):
         """
         Plots the in-built ``dynesty`` plot ``boundplot``.
@@ -28,6 +29,7 @@ class DynestyPlotter(SamplesPlotter):
         self.close()
 
     @skip_plot_in_test_mode
+    @log_value_error
     def cornerbound(self, **kwargs):
         """
         Plots the in-built ``dynesty`` plot ``cornerbound``.
@@ -54,6 +56,7 @@ class DynestyPlotter(SamplesPlotter):
 
         This figure plots a corner plot of the 1-D and 2-D marginalized posteriors.
         """
+
         dyplot.cornerplot(
             results=self.samples.results_internal,
             labels=self.model.parameter_labels_with_superscripts_latex,

--- a/autofit/non_linear/search/nest/ultranest/plotter.py
+++ b/autofit/non_linear/search/nest/ultranest/plotter.py
@@ -1,7 +1,19 @@
+from functools import wraps
 from autofit.plot import SamplesPlotter
 
 from autofit.plot.samples_plotters import skip_plot_in_test_mode
-from autofit.plot.samples_plotters import log_value_error
+
+def log_value_error(func):
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+
+        try:
+            return func(self, *args, **kwargs)
+        except KeyError:
+            self.log_plot_exception(func.__name__)
+
+    return wrapper
 
 class UltraNestPlotter(SamplesPlotter):
 

--- a/autofit/non_linear/search/nest/ultranest/plotter.py
+++ b/autofit/non_linear/search/nest/ultranest/plotter.py
@@ -7,7 +7,31 @@ def log_value_error(func):
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
+        """
+        Prevent an exception terminating the run if visualization fails due to convergence not yet being reached.
 
+        Searches attempt to perform visualization every `iterations_per_update`, however these visualization calls
+        may occur before the search has converged on enough of parameter to successfully perform visualization.
+
+        This can lead the search to raise an exception which terminates the Python script, when we instead
+        want the code to continue running, to continue the search and perform visualization on a subsequent iteration
+        once convergence has been achieved.
+
+        This wrapper catches these exceptions, logs them so the user can see visualization failed and then
+        continues the code without raising an exception in a way that terminates the script.
+
+        This wrapper is specific to UltraNest, which raises a `KeyError` when visualization is performed before
+        convergence has been achieved.
+
+        Parameters
+        ----------
+        self
+            An instance of a `SearchPlotter` class.
+        args
+            The arguments used to perform a visualization of the search.
+        kwargs
+            The keyword arguments used to perform a visualization of the search.
+        """
         try:
             return func(self, *args, **kwargs)
         except KeyError:

--- a/autofit/plot/samples_plotters.py
+++ b/autofit/plot/samples_plotters.py
@@ -7,18 +7,6 @@ from autofit.plot.output import Output
 
 logger = logging.getLogger(__name__)
 
-def log_value_error(func):
-
-    @wraps(func)
-    def wrapper(self, *args, **kwargs):
-
-        try:
-            return func(self, *args, **kwargs)
-        except ValueError:
-            self.log_plot_exception(func.__name__)
-
-    return wrapper
-
 def skip_plot_in_test_mode(func):
     """
     Skips visualization plots of non-linear searches if test mode is on.

--- a/autofit/plot/samples_plotters.py
+++ b/autofit/plot/samples_plotters.py
@@ -14,7 +14,7 @@ def log_value_error(func):
 
         try:
             return func(self, *args, **kwargs)
-        except (ValueError, KeyError, AttributeError, AssertionError):
+        except ValueError:
             self.log_plot_exception(func.__name__)
 
     return wrapper


### PR DESCRIPTION
If superscripts are blank strings or empty, the `parameter_labels_with_superscripts` now omits the superscript whereas previously it gave weird superscripts.

The exception associated with this was not caught due to the `log_value_error` decorator try / excepting them. This has now been made more specific.