### PR TITLE
fix loading of samples when log_posterior present in file

### DIFF
--- a/autofit/non_linear/samples/sample.py
+++ b/autofit/non_linear/samples/sample.py
@@ -1,4 +1,5 @@
 import csv
+import inspect
 from copy import copy
 from typing import List, Tuple
 
@@ -32,12 +33,7 @@ class Sample:
             for key, value in (kwargs or dict()).items()
         }
 
-        # TODO : Understand issue https://github.com/rhayes777/PyAutoFit/issues/780
-        try:
-            self.kwargs.pop("log_posterior")
-        except KeyError:
-            pass
-
+        self.kwargs.pop("log_posterior")
 
     def model_dict(self) -> dict:
         """
@@ -250,6 +246,7 @@ def load_from_table(filename: str) -> List[Sample]:
 
     sample_args = (
         "log_likelihood",
+        "log_posterior",
         "log_prior",
         "weight",
     )
@@ -263,7 +260,11 @@ def load_from_table(filename: str) -> List[Sample]:
 
             samples.append(
                 Sample(
-                    **{key: value for key, value in d.items() if key in sample_args},
+                    **{
+                        key: value
+                        for key, value in d.items()
+                        if key in inspect.getfullargspec(Sample.__init__).args
+                    },
                     kwargs={
                         key: value for key, value in d.items() if key not in sample_args
                     },

--- a/autofit/non_linear/samples/sample.py
+++ b/autofit/non_linear/samples/sample.py
@@ -33,8 +33,6 @@ class Sample:
             for key, value in (kwargs or dict()).items()
         }
 
-        self.kwargs.pop("log_posterior")
-
     def model_dict(self) -> dict:
         """
         A dictionary mapping model paths to values for the sample


### PR DESCRIPTION
Resolves #780.

It seems some samples files have a log_posterior column which is not present in the sample class. This is filtered out so it is not added to kwargs
