### PR TITLE
Feature/lh timeout

### DIFF
--- a/autofit/config/general.yaml
+++ b/autofit/config/general.yaml
@@ -31,4 +31,5 @@ profiling:
   repeats: 1                        # The number of repeat function calls used to measure run-times when profiling.
 test:
   exception_override: false
+  lh_timeout_seconds:               # If a float is input, the log_likelihood_function call is timed out after this many seconds, to diagnose infinite loops. Default is None, meaning no timeout.
   parallel_profile: false

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 
 from autoconf import conf
@@ -6,10 +7,16 @@ from autofit import exc
 
 from timeout_decorator import timeout
 
-try:
-    timeout_seconds = conf.instance["general"]["test"]["lh_timeout_seconds"]
-except KeyError:
-    timeout_seconds = None
+def get_timeout_seconds():
+
+    try:
+        return conf.instance["general"]["test"]["lh_timeout_seconds"]
+    except KeyError:
+        pass
+
+logger = logging.getLogger(__name__)
+
+timeout_seconds = get_timeout_seconds()
 
 class Fitness:
     def __init__(

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -1,6 +1,10 @@
 import numpy as np
 
+from autoconf import conf
+
 from autofit import exc
+
+from timeout_decorator import timeout
 
 class Fitness:
     def __init__(
@@ -66,6 +70,7 @@ class Fitness:
         self.resample_figure_of_merit = resample_figure_of_merit
         self.convert_to_chi_squared = convert_to_chi_squared
 
+    @timeout(conf.instance["general"]["test"]["lh_timeout_seconds"])
     def __call__(self, parameters, *kwargs):
         """
         Interfaces with any non-linear in order to fit a model to the data and return a log likelihood via

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -6,6 +6,11 @@ from autofit import exc
 
 from timeout_decorator import timeout
 
+try:
+    timeout_seconds = conf.instance["general"]["test"]["lh_timeout_seconds"]
+except KeyError:
+    timeout_seconds = None
+
 class Fitness:
     def __init__(
             self,
@@ -70,7 +75,7 @@ class Fitness:
         self.resample_figure_of_merit = resample_figure_of_merit
         self.convert_to_chi_squared = convert_to_chi_squared
 
-    @timeout(conf.instance["general"]["test"]["lh_timeout_seconds"])
+    @timeout(timeout_seconds)
     def __call__(self, parameters, *kwargs):
         """
         Interfaces with any non-linear in order to fit a model to the data and return a log likelihood via

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -38,6 +38,8 @@ from autofit.non_linear.paths.null import NullPaths
 from autofit.graphical.declarative.abstract import PriorFactor
 from autofit.graphical.expectation_propagation import AbstractFactorOptimiser
 
+from autofit.non_linear.fitness import get_timeout_seconds
+
 logger = logging.getLogger(__name__)
 
 
@@ -596,6 +598,14 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
                 paths=self.paths,
                 model=model,
             )
+
+            timeout_seconds = get_timeout_seconds()
+
+            if timeout_seconds is not None:
+
+                logger.info(f"\n\n ***Log Likelihood Function timeout is "
+                            f"turned on and set to {timeout_seconds} seconds.***\n")
+
 
     def start_resume_fit(self, analysis: Analysis, model: AbstractPriorModel) -> Result:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ h5py>=2.10.0
 SQLAlchemy==1.3.20
 scipy<=1.10.0
 astunparse==1.6.3
+timeout-decorator==0.5.0
 xxhash==3.0.0

--- a/test_autofit/config/general.yaml
+++ b/test_autofit/config/general.yaml
@@ -31,4 +31,5 @@ test:
   check_preloads: false
   preloads_check_threshold: 1.0     # If the figure of merit of a fit with and without preloads is greater than this threshold, the check preload test fails and an exception raised for a model-fit.              # If True, perform a sanity check that the likelihood using preloads is identical to the likelihood not using preloads.
   exception_override: false
+  lh_timeout_seconds:               # If a float is input, the log_likelihood_function call is timed out after this many seconds, to diagnose infinite loops. Default is None, meaning no timeout.
   parallel_profile: false


### PR DESCRIPTION
Allows one to time-out a log likelihood function call in order to receive an error message enabling the diagnosis of infinite loops.

By default this is off, but it can be switched on by updating the following entry of the `general.yaml` config file:

```
test:
  lh_timeout_seconds:               # If a float is input, the log_likelihood_function call is timed out after this many seconds, to diagnose infinite loops. Default is None, meaning no timeout.
```