### PR TITLE
Feature/test mode dynesty

### DIFF
--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -130,4 +130,4 @@ def save_abc(pickler, obj):
 
 conf.instance.register(__file__)
 
-__version__ = "2023.7.5.2"
+__version__ = "2023.9.18.4"

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -506,11 +506,11 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
         if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
 
-            from autofit.non_linear.search.nest.nautilus import Nautilus
+            from autofit.non_linear.search.nest.nautilus.search import Nautilus
 
             if isinstance(self, Nautilus):
 
-                from autofit.non_linear.search.nest.dynesty import DynestyStatic
+                from autofit.non_linear.search.nest.dynesty.search.static import DynestyStatic
 
                 search = DynestyStatic(
                     name=self.name,

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -506,14 +506,18 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
         if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
 
-            from autofit.non_linear.search.nest.dynesty import DynestyStatic
+            from autofit.non_linear.search.nest.nautilus import Nautilus
 
-            search = DynestyStatic(
-                name=self.name,
-                unique_tag=self.unique_tag,
-            )
+            if isinstance(self, Nautilus):
 
-            return search.fit(model=model, analysis=analysis, info=info)
+                from autofit.non_linear.search.nest.dynesty import DynestyStatic
+
+                search = DynestyStatic(
+                    name=self.name,
+                    unique_tag=self.unique_tag,
+                )
+
+                return search.fit(model=model, analysis=analysis, info=info)
 
         self.check_model(model=model)
 

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -503,6 +503,18 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         AssertionError
             If the model has 0 dimensions.
         """
+
+        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
+
+            from autofit.non_linear.search.nest.dynesty import DynestyStatic
+
+            search = DynestyStatic(
+                name=self.name,
+                unique_tag=self.unique_tag,
+            )
+
+            return search.fit(model=model, analysis=analysis, info=info)
+
         self.check_model(model=model)
 
         model = analysis.modify_model(model)


### PR DESCRIPTION
`Nautilus` does not have functionality to input the maximum number of iterations. This means it cannot be used in **PyAutoFit** test mode, where searches are skipped instantly.

Now that all workspaces use `Nautilus` by default, this poses a problem where they cannot be integration tested quickly.

This PR puts an if statement in such that if `Nautilus` is running in test mode, it is swapped out for `Dynesty`.