### PR TITLE
Example analysis now uses dataset prefix

### DIFF
--- a/autofit/example/analysis.py
+++ b/autofit/example/analysis.py
@@ -167,5 +167,7 @@ class Analysis(af.Analysis):
             The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
             visualization, and the pickled objects used by the aggregator output by this function.
         """
-        paths.save_json(name="data", object_dict=self.data.tolist())
-        paths.save_json(name="noise_map", object_dict=self.noise_map.tolist())
+        paths.save_json(name="data", object_dict=self.data.tolist(), prefix="dataset")
+        paths.save_json(name="noise_map", object_dict=self.noise_map.tolist(), prefix="dataset")
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ h5py>=2.10.0
 SQLAlchemy==1.3.20
 scipy<=1.10.0
 astunparse==1.6.3
+threadpoolctl==3.1.0
 timeout-decorator==0.5.0
 xxhash==3.0.0


### PR DESCRIPTION
When the example `Analysis` outputs the `data.json` and `noise_map.json` to the `files` folder, it now does so in a folder called `dataset` using the `prefix` input.

This means that integration tests will test for `prefix` functionality when loading results (e.g. via the database).