### PR TITLE
Feature/null path search internal

### DIFF
--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -7,6 +7,7 @@ from autoconf import conf
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.paths.abstract import AbstractPaths
 from autofit.non_linear.paths.database import DatabasePaths
+from autofit.non_linear.paths.null import NullPaths
 from autofit.non_linear.result import Result
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ class Analysis(ABC):
         if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
             return False
 
-        if isinstance(paths, DatabasePaths):
+        if isinstance(paths, DatabasePaths) or isinstance(paths, NullPaths):
             return False
 
         if conf.instance["general"]["output"]["force_visualize_overwrite"]:

--- a/autofit/non_linear/mock/mock_search.py
+++ b/autofit/non_linear/mock/mock_search.py
@@ -133,7 +133,7 @@ class MockSearch(NonLinearSearch):
             samples=samples,
         )
 
-    def perform_update(self, model, analysis, during_analysis):
+    def perform_update(self, model, analysis, during_analysis, search_internal=None):
         if self.samples is not None and not self.return_sensitivity_results:
             self.paths.samples_to_csv(self.samples)
             return self.samples

--- a/autofit/non_linear/paths/null.py
+++ b/autofit/non_linear/paths/null.py
@@ -87,6 +87,10 @@ class NullPaths(AbstractPaths):
     def load_search_internal(self):
         pass
 
+    @property
+    def search_internal_path(self):
+        pass
+
     def load_samples(self):
         pass
 

--- a/autofit/non_linear/paths/null.py
+++ b/autofit/non_linear/paths/null.py
@@ -99,3 +99,6 @@ class NullPaths(AbstractPaths):
 
     def load_samples_info(self):
         pass
+
+    def zip_remove(self):
+        pass

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -512,10 +512,12 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
                 from autofit.non_linear.search.nest.dynesty.search.static import DynestyStatic
 
+                from pathlib import Path
+
                 search = DynestyStatic(
                     name=self.name,
                     unique_tag=self.unique_tag,
-                    path_prefix=self.paths.path_prefix,
+                    path_prefix=Path(self.paths.path_prefix),
                     number_of_cores=self.number_of_cores,
                 )
 

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -357,8 +357,22 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         return self._logger
 
     @property
-    def timer(self):
-        return Timer(self.paths.search_internal_path)
+    def timer(self) -> Optional[Timer]:
+        """
+        Returns the timer of the search, which is used to output informaiton such as how long the search took and
+        how much parallelization sped up the search time.
+
+        If the search is running in `NullPaths` mode, meaning that no output is written to the hard-disk, the timer
+        is disabled and a `None` is returned.
+
+        Returns
+        -------
+        An object which times the non-linear search.
+        """
+        try:
+            return Timer(self.paths.search_internal_path)
+        except Timer:
+            pass
 
     @property
     def paths(self) -> Optional[AbstractPaths]:

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -670,7 +670,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         and errors on the model parameters.
         """
         if self.is_master:
-            if not isinstance(self.paths, DatabasePaths):
+            if not isinstance(self.paths, DatabasePaths) and not isinstance(self.paths, NullPaths):
                 self.timer.start()
 
         model.freeze()

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -1025,7 +1025,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         except (FileNotFoundError, NotImplementedError, AttributeError):
             return self.samples_via_csv_from(model=model)
 
-    def samples_via_internal_from(self, model: AbstractPriorModel):
+    def samples_via_internal_from(self, model: AbstractPriorModel, search_internal=None):
         raise NotImplementedError
 
     def samples_via_csv_from(self, model: AbstractPriorModel) -> Samples:

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -371,7 +371,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         """
         try:
             return Timer(self.paths.search_internal_path)
-        except Timer:
+        except TypeError:
             pass
 
     @property

--- a/autofit/non_linear/search/mcmc/emcee/search.py
+++ b/autofit/non_linear/search/mcmc/emcee/search.py
@@ -222,11 +222,19 @@ class Emcee(AbstractMCMC):
 
         search_internal = self.backend
 
-        discard = int(3.0 * np.max(self.auto_correlations.times))
-        thin = int(np.max(self.auto_correlations.times) / 2.0)
-        samples_after_burn_in = search_internal.get_chain(
-            discard=discard, thin=thin, flat=True
+        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
+
+            samples_after_burn_in = search_internal.get_chain(
+            discard=5, thin=5, flat=True
         )
+
+        else:
+
+            discard = int(3.0 * np.max(self.auto_correlations.times))
+            thin = int(np.max(self.auto_correlations.times) / 2.0)
+            samples_after_burn_in = search_internal.get_chain(
+                discard=discard, thin=thin, flat=True
+            )
 
         parameter_lists = samples_after_burn_in.tolist()
 

--- a/autofit/non_linear/search/mcmc/emcee/search.py
+++ b/autofit/non_linear/search/mcmc/emcee/search.py
@@ -193,7 +193,10 @@ class Emcee(AbstractMCMC):
             if iterations_remaining > 0:
 
                 self.perform_update(
-                    model=model, analysis=analysis, during_analysis=True
+                    model=model,
+                    analysis=analysis,
+                    search_internal=search_internal,
+                    during_analysis=True
                 )
         return search_internal
 
@@ -240,8 +243,10 @@ class Emcee(AbstractMCMC):
 
         else:
 
-            discard = int(3.0 * np.max(self.auto_correlations.times))
-            thin = int(np.max(self.auto_correlations.times) / 2.0)
+            auto_correlations = self.auto_correlations_from(search_internal=search_internal)
+
+            discard = int(3.0 * np.max(auto_correlations.times))
+            thin = int(np.max(auto_correlations.times) / 2.0)
             samples_after_burn_in = search_internal.get_chain(
                 discard=discard, thin=thin, flat=True
             )

--- a/autofit/non_linear/search/mcmc/emcee/search.py
+++ b/autofit/non_linear/search/mcmc/emcee/search.py
@@ -112,19 +112,24 @@ class Emcee(AbstractMCMC):
 
         pool = self.make_sneaky_pool(fitness)
 
-        sampler = emcee.EnsembleSampler(
+        try:
+            backend = emcee.backends.HDFBackend(filename=self.backend_filename)
+        except TypeError:
+            backend = None
+
+        search_internal = emcee.EnsembleSampler(
             nwalkers=self.config_dict_search["nwalkers"],
             ndim=model.prior_count,
             log_prob_fn=fitness.__call__,
-            backend=emcee.backends.HDFBackend(filename=self.backend_filename),
+            backend=backend,
             pool=pool,
         )
 
         try:
-            state = sampler.get_last_sample()
-            samples = self.samples_from(model=model)
+            state = search_internal.get_last_sample()
+            samples = self.samples_from(model=model, search_internal=search_internal)
 
-            total_iterations = sampler.iteration
+            total_iterations = search_internal.iteration
 
             if samples.converged:
                 iterations_remaining = 0
@@ -141,12 +146,12 @@ class Emcee(AbstractMCMC):
                 parameter_lists,
                 log_posterior_list,
             ) = self.initializer.samples_from_model(
-                total_points=sampler.nwalkers,
+                total_points=search_internal.nwalkers,
                 model=model,
                 fitness=fitness,
             )
 
-            state = np.zeros(shape=(sampler.nwalkers, model.prior_count))
+            state = np.zeros(shape=(search_internal.nwalkers, model.prior_count))
 
             self.logger.info(
                 "Starting new Emcee non-linear search (no previous samples found)."
@@ -164,7 +169,7 @@ class Emcee(AbstractMCMC):
             else:
                 iterations = self.iterations_per_update
 
-            for sample in sampler.sample(
+            for sample in search_internal.sample(
                 initial_state=state,
                 iterations=iterations,
                 progress=True,
@@ -173,15 +178,15 @@ class Emcee(AbstractMCMC):
             ):
                 pass
 
-            state = sampler.get_last_sample()
+            state = search_internal.get_last_sample()
 
             total_iterations += iterations
             iterations_remaining = self.config_dict_run["nsteps"] - total_iterations
 
-            samples = self.samples_from(model=model)
+            samples = self.samples_from(model=model, search_internal=search_internal)
 
             if self.auto_correlation_settings.check_for_convergence:
-                if sampler.iteration > self.auto_correlation_settings.check_size:
+                if search_internal.iteration > self.auto_correlation_settings.check_size:
                     if samples.converged:
                         iterations_remaining = 0
 
@@ -190,21 +195,26 @@ class Emcee(AbstractMCMC):
                 self.perform_update(
                     model=model, analysis=analysis, during_analysis=True
                 )
+        return search_internal
 
-    @property
-    def samples_info(self):
-        search_internal = self.backend
+    def samples_info_from(self, search_internal=None):
+
+        search_internal = search_internal or self.backend
+
+        auto_correlations = self.auto_correlations_from(search_internal=search_internal)
+
+        time = self.timer.time if self.timer else None
 
         return {
-            "check_size": self.auto_correlations.check_size,
-            "required_length": self.auto_correlations.required_length,
-            "change_threshold": self.auto_correlations.change_threshold,
+            "check_size": auto_correlations.check_size,
+            "required_length": auto_correlations.required_length,
+            "change_threshold": auto_correlations.change_threshold,
             "total_walkers": len(search_internal.get_chain()[0, :, 0]),
             "total_steps": len(search_internal.get_log_prob()),
-            "time": self.timer.time,
+            "time": time
         }
 
-    def samples_via_internal_from(self, model):
+    def samples_via_internal_from(self, model, search_internal=None):
         """
         Returns a `Samples` object from the emcee internal results.
 
@@ -220,7 +230,7 @@ class Emcee(AbstractMCMC):
             Maps input vectors of unit parameter values to physical values and model instances via priors.
         """
 
-        search_internal = self.backend
+        search_internal = search_internal or self.backend
 
         if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
 
@@ -264,15 +274,15 @@ class Emcee(AbstractMCMC):
         return SamplesMCMC(
             model=model,
             sample_list=sample_list,
-            samples_info=self.samples_info,
+            samples_info=self.samples_info_from(search_internal=search_internal),
             search_internal=search_internal,
             auto_correlation_settings=self.auto_correlation_settings,
-            auto_correlations=self.auto_correlations,
+            auto_correlations=self.auto_correlations_from(search_internal=search_internal),
         )
 
-    @property
-    def auto_correlations(self):
-        search_internal = self.backend
+    def auto_correlations_from(self, search_internal=None):
+
+        search_internal = search_internal or self.backend
 
         times = search_internal.get_autocorr_time(tol=0)
 

--- a/autofit/non_linear/search/mcmc/emcee/search.py
+++ b/autofit/non_linear/search/mcmc/emcee/search.py
@@ -206,15 +206,13 @@ class Emcee(AbstractMCMC):
 
         auto_correlations = self.auto_correlations_from(search_internal=search_internal)
 
-        time = self.timer.time if self.timer else None
-
         return {
             "check_size": auto_correlations.check_size,
             "required_length": auto_correlations.required_length,
             "change_threshold": auto_correlations.change_threshold,
             "total_walkers": len(search_internal.get_chain()[0, :, 0]),
             "total_steps": len(search_internal.get_log_prob()),
-            "time": time
+            "time": self.timer.time if self.timer else None
         }
 
     def samples_via_internal_from(self, model, search_internal=None):

--- a/autofit/non_linear/search/mcmc/zeus/search.py
+++ b/autofit/non_linear/search/mcmc/zeus/search.py
@@ -235,10 +235,9 @@ class Zeus(AbstractMCMC):
                     model=model, analysis=analysis, during_analysis=True
                 )
 
-    @property
-    def samples_info(self):
+    def samples_info_from(self, search_internal = None):
 
-        search_internal = self.paths.load_search_internal()
+        search_internal = search_internal or self.paths.load_search_internal()
 
         return {
             "check_size": self.auto_correlations.check_size,

--- a/autofit/non_linear/search/mcmc/zeus/search.py
+++ b/autofit/non_linear/search/mcmc/zeus/search.py
@@ -245,7 +245,7 @@ class Zeus(AbstractMCMC):
             "change_threshold": self.auto_correlations.change_threshold,
             "total_walkers": len(search_internal.get_chain()[0, :, 0]),
             "total_steps": int(search_internal.ncall_total),
-            "time": self.timer.time,
+            "time": self.timer.time if self.timer else None,
         }
 
     def samples_via_internal_from(self, model, search_internal=None):

--- a/autofit/non_linear/search/mcmc/zeus/search.py
+++ b/autofit/non_linear/search/mcmc/zeus/search.py
@@ -264,7 +264,7 @@ class Zeus(AbstractMCMC):
             Maps input vectors of unit parameter values to physical values and model instances via priors.
         """
 
-        search_internal = self.paths.load_search_internal()
+        search_internal = search_internal or self.paths.load_search_internal()
 
         discard = int(3.0 * np.max(self.auto_correlations.times))
         thin = int(np.max(self.auto_correlations.times) / 2.0)

--- a/autofit/non_linear/search/mcmc/zeus/search.py
+++ b/autofit/non_linear/search/mcmc/zeus/search.py
@@ -248,7 +248,7 @@ class Zeus(AbstractMCMC):
             "time": self.timer.time,
         }
 
-    def samples_via_internal_from(self, model):
+    def samples_via_internal_from(self, model, search_internal=None):
         """
         Returns a `Samples` object from the zeus internal results.
 

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -218,7 +218,7 @@ class AbstractDynesty(AbstractNest, ABC):
         model
             Maps input vectors of unit parameter values to physical values and model instances via priors.
         """
-        search_internal = self.sampler.results
+        search_internal = search_internal or self.sampler.results
 
         parameter_lists = search_internal.samples.tolist()
         log_prior_list = model.log_prior_list_from(parameter_lists=parameter_lists)

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -159,7 +159,7 @@ class AbstractDynesty(AbstractNest, ABC):
                         queue_size=self.number_of_cores,
                     )
 
-                    finished = self.run_sampler(search_internal=search_internal)
+                    finished = self.run_search_internal(search_internal=search_internal)
 
             except RuntimeError:
 
@@ -182,7 +182,7 @@ class AbstractDynesty(AbstractNest, ABC):
                     queue_size=None,
                 )
 
-                finished = self.run_sampler(search_internal=search_internal)
+                finished = self.run_search_internal(search_internal=search_internal)
 
             if not finished:
 
@@ -282,7 +282,7 @@ class AbstractDynesty(AbstractNest, ABC):
             return int(iterations), int(total_iterations)
         return self.iterations_per_update, int(total_iterations)
 
-    def run_sampler(self, search_internal: Union[NestedSampler, DynamicNestedSampler]):
+    def run_search_internal(self, search_internal: Union[NestedSampler, DynamicNestedSampler]):
         """
         Run the Dynesty sampler, which could be either the static of dynamic sampler.
 

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -26,12 +26,11 @@ def prior_transform(cube, model):
 
     return cube
 
-
 class AbstractDynesty(AbstractNest, ABC):
     def __init__(
             self,
-            name: str = "",
-            path_prefix: str = "",
+            name: Optional[str] = None,
+            path_prefix: Optional[str] = None,
             unique_tag: Optional[str] = None,
             iterations_per_update: int = None,
             number_of_cores: int = None,
@@ -378,7 +377,7 @@ class AbstractDynesty(AbstractNest, ABC):
     @property
     def checkpoint_file(self) -> str:
         """
-        The path to the file used by dynesty for checkpointing.
+        The path to the file used for checkpointing.
 
         If autofit is not outputting results to hard-disk (e.g. paths is `NullPaths`), this function is bypassed.
         """

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -192,10 +192,9 @@ class AbstractDynesty(AbstractNest, ABC):
             obj=sampler.results,
         )
 
-    @property
-    def samples_info(self):
+    def samples_info_from(self, search_internal = None):
 
-        search_internal = self.sampler.results
+        search_internal = search_internal or self.sampler.results
 
         return {
             "log_evidence": np.max(search_internal.logz),

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -286,6 +286,11 @@ class AbstractDynesty(AbstractNest, ABC):
         """
 
         if isinstance(self.paths, NullPaths):
+
+            maxcall = self.config_dict_run.get("maxcall")
+
+            if maxcall is not None:
+                return maxcall, maxcall
             return int(1e99), int(1e99)
 
         try:

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -151,7 +151,7 @@ class AbstractDynesty(AbstractNest, ABC):
                         ptform_args=(model,),
                 ) as pool:
 
-                    search_internal = self.sampler_from(
+                    search_internal = self.search_internal_from(
                         model=model,
                         fitness=fitness,
                         checkpoint_exists=checkpoint_exists,
@@ -174,7 +174,7 @@ class AbstractDynesty(AbstractNest, ABC):
                         """
                     )
 
-                search_internal = self.sampler_from(
+                search_internal = self.search_internal_from(
                     model=model,
                     fitness=fitness,
                     checkpoint_exists=checkpoint_exists,
@@ -315,7 +315,7 @@ class AbstractDynesty(AbstractNest, ABC):
                 **config_dict_run,
             )
 
-        iterations_after_run = np.sum(sampler.results.ncall)
+        iterations_after_run = np.sum(search_internal.results.ncall)
 
         return (
                 total_iterations == iterations_after_run
@@ -412,7 +412,7 @@ class AbstractDynesty(AbstractNest, ABC):
 
         return live_points
 
-    def sampler_from(
+    def search_internal_from(
             self,
             model: AbstractPriorModel,
             fitness,

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -334,6 +334,9 @@ class AbstractDynesty(AbstractNest, ABC):
 
         iterations_after_run = np.sum(search_internal.results.ncall)
 
+        if isinstance(self.paths, NullPaths):
+            return True
+
         return (
                 total_iterations == iterations_after_run
                 or total_iterations == self.config_dict_run.get("maxcall")
@@ -466,7 +469,10 @@ class AbstractDynesty(AbstractNest, ABC):
 
     def remove_state_files(self):
 
-        os.remove(self.checkpoint_file)
+        try:
+            os.remove(self.checkpoint_file)
+        except TypeError:
+            pass
 
     @property
     def number_live_points(self):

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -212,7 +212,7 @@ class AbstractDynesty(AbstractNest, ABC):
         return {
             "log_evidence": np.max(search_internal.results.logz),
             "total_samples": int(np.sum(search_internal.results.ncall)),
-            "time": self.timer.time,
+            "time": self.timer.time if self.timer else None,
             "number_live_points": self.number_live_points
         }
 

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -192,7 +192,7 @@ class AbstractDynesty(AbstractNest, ABC):
             obj=sampler.results,
         )
 
-    def samples_info_from(self, search_internal = None):
+    def samples_info_from(self, search_internal=None):
 
         search_internal = search_internal or self.sampler.results
 
@@ -242,7 +242,7 @@ class AbstractDynesty(AbstractNest, ABC):
         return SamplesNest(
             model=model,
             sample_list=sample_list,
-            samples_info=self.samples_info,
+            samples_info=self.samples_info_from(search_internal=search_internal),
             search_internal=search_internal,
         )
 

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -203,7 +203,7 @@ class AbstractDynesty(AbstractNest, ABC):
             "number_live_points": self.number_live_points
         }
 
-    def samples_via_internal_from(self, model):
+    def samples_via_internal_from(self, model, search_internal=None):
         """
         Returns a `Samples` object from the dynesty internal results. 
         

--- a/autofit/non_linear/search/nest/dynesty/search/dynamic.py
+++ b/autofit/non_linear/search/nest/dynesty/search/dynamic.py
@@ -69,7 +69,7 @@ class DynestyDynamic(AbstractDynesty):
     def search_internal(self):
         return DynamicNestedSampler.restore(self.checkpoint_file)
 
-    def sampler_from(
+    def search_internal_from(
             self,
             model: AbstractPriorModel,
             fitness,

--- a/autofit/non_linear/search/nest/dynesty/search/dynamic.py
+++ b/autofit/non_linear/search/nest/dynesty/search/dynamic.py
@@ -66,7 +66,7 @@ class DynestyDynamic(AbstractDynesty):
         self.logger.debug("Creating DynestyDynamic Search")
 
     @property
-    def sampler(self):
+    def search_internal(self):
         return DynamicNestedSampler.restore(self.checkpoint_file)
 
     def sampler_from(
@@ -102,7 +102,7 @@ class DynestyDynamic(AbstractDynesty):
 
         try:
 
-            sampler = DynamicNestedSampler.restore(
+            search_internal = DynamicNestedSampler.restore(
                 fname=self.checkpoint_file,
                 pool=pool
             )
@@ -111,7 +111,7 @@ class DynestyDynamic(AbstractDynesty):
 
             self.check_pool(uses_pool=uses_pool, pool=pool)
 
-            return sampler
+            return search_internal
 
         except FileNotFoundError:
 

--- a/autofit/non_linear/search/nest/dynesty/search/dynamic.py
+++ b/autofit/non_linear/search/nest/dynesty/search/dynamic.py
@@ -113,7 +113,7 @@ class DynestyDynamic(AbstractDynesty):
 
             return search_internal
 
-        except FileNotFoundError:
+        except (FileNotFoundError, TypeError):
 
             if pool is not None:
 

--- a/autofit/non_linear/search/nest/dynesty/search/static.py
+++ b/autofit/non_linear/search/nest/dynesty/search/static.py
@@ -74,7 +74,7 @@ class DynestyStatic(AbstractDynesty):
     def search_internal(self):
         return StaticSampler.restore(self.checkpoint_file)
 
-    def sampler_from(
+    def search_internal_from(
         self,
         model: AbstractPriorModel,
         fitness,

--- a/autofit/non_linear/search/nest/dynesty/search/static.py
+++ b/autofit/non_linear/search/nest/dynesty/search/static.py
@@ -71,7 +71,7 @@ class DynestyStatic(AbstractDynesty):
         self.logger.debug("Creating DynestyStatic Search")
 
     @property
-    def sampler(self):
+    def search_internal(self):
         return StaticSampler.restore(self.checkpoint_file)
 
     def sampler_from(
@@ -106,13 +106,13 @@ class DynestyStatic(AbstractDynesty):
         """
 
         if checkpoint_exists:
-            sampler = StaticSampler.restore(fname=self.checkpoint_file, pool=pool)
+            search_internal = StaticSampler.restore(fname=self.checkpoint_file, pool=pool)
 
             uses_pool = self.read_uses_pool()
 
             self.check_pool(uses_pool=uses_pool, pool=pool)
 
-            return sampler
+            return search_internal
 
         else:
             live_points = self.live_points_init_from(

--- a/autofit/non_linear/search/nest/nautilus/plotter.py
+++ b/autofit/non_linear/search/nest/nautilus/plotter.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 
 from autofit.plot import SamplesPlotter
 
@@ -10,6 +11,10 @@ class NautilusPlotter(SamplesPlotter):
 
         This figure plots a corner plot of the 1-D and 2-D marginalized posteriors.
         """
+
+        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
+            return
+
         import corner
         import matplotlib.pyplot as plt
 

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -347,7 +347,7 @@ class Nautilus(abstract_nest.AbstractNest):
             "number_live_points": search_internal_dict["number_live_points"]
         }
 
-    def samples_via_internal_from(self, model: AbstractPriorMode, search_internal=None):
+    def samples_via_internal_from(self, model: AbstractPriorModel, search_internal=None):
         """
         Returns a `Samples` object from the ultranest internal results.
 

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -336,10 +336,9 @@ class Nautilus(abstract_nest.AbstractNest):
             obj=search_internal,
         )
 
-    @property
-    def samples_info(self):
+    def samples_info_from(self, search_internal = None):
 
-        search_internal_dict = self.paths.load_search_internal()
+        search_internal_dict = search_internal or self.paths.load_search_internal()
 
         return {
             "log_evidence": search_internal_dict["log_evidence"],

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -343,7 +343,7 @@ class Nautilus(abstract_nest.AbstractNest):
         return {
             "log_evidence": search_internal_dict["log_evidence"],
             "total_samples": search_internal_dict["total_samples"],
-            "time": self.timer.time,
+            "time": self.timer.time if self.timer else None,
             "number_live_points": search_internal_dict["number_live_points"]
         }
 

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -347,7 +347,7 @@ class Nautilus(abstract_nest.AbstractNest):
             "number_live_points": search_internal_dict["number_live_points"]
         }
 
-    def samples_via_internal_from(self, model: AbstractPriorModel):
+    def samples_via_internal_from(self, model: AbstractPriorMode, search_internal=None):
         """
         Returns a `Samples` object from the ultranest internal results.
 

--- a/autofit/non_linear/search/nest/ultranest/plotter.py
+++ b/autofit/non_linear/search/nest/ultranest/plotter.py
@@ -34,7 +34,7 @@ def log_value_error(func):
         """
         try:
             return func(self, *args, **kwargs)
-        except KeyError:
+        except (KeyError, AssertionError):
             self.log_plot_exception(func.__name__)
 
     return wrapper

--- a/autofit/non_linear/search/nest/ultranest/search.py
+++ b/autofit/non_linear/search/nest/ultranest/search.py
@@ -133,7 +133,12 @@ class UltraNest(abstract_nest.AbstractNest):
 
         log_dir = self.paths.search_internal_path
 
-        if os.path.exists(log_dir / "chains"):
+        try:
+            checkpoint_exists = os.path.exists(log_dir / "chains")
+        except TypeError:
+            checkpoint_exists = False
+
+        if checkpoint_exists:
             self.logger.info(
                 "Resuming UltraNest non-linear search (previous samples found)."
             )
@@ -197,7 +202,12 @@ class UltraNest(abstract_nest.AbstractNest):
 
             if not finished:
 
-                self.perform_update(model=model, analysis=analysis, during_analysis=True)
+                self.perform_update(
+                    model=model,
+                    analysis=analysis,
+                    during_analysis=True,
+                    search_internal=search_internal
+                )
 
         return search_internal
 
@@ -228,7 +238,7 @@ class UltraNest(abstract_nest.AbstractNest):
             Maps input vectors of unit parameter values to physical values and model instances via priors.
         """
 
-        search_internal = search_internal or self.paths.load_search_internal()
+        search_internal = search_internal.results or self.paths.load_search_internal()
 
         parameters = search_internal["weighted_samples"]["points"]
         log_likelihood_list = search_internal["weighted_samples"]["logl"]

--- a/autofit/non_linear/search/nest/ultranest/search.py
+++ b/autofit/non_linear/search/nest/ultranest/search.py
@@ -27,8 +27,8 @@ class UltraNest(abstract_nest.AbstractNest):
 
     def __init__(
             self,
-            name: str = "",
-            path_prefix: str = "",
+            name: Optional[str] = None,
+            path_prefix: Optional[str] = None,
             unique_tag: Optional[str] = None,
             iterations_per_update: int = None,
             number_of_cores: int = None,

--- a/autofit/non_linear/search/nest/ultranest/search.py
+++ b/autofit/non_linear/search/nest/ultranest/search.py
@@ -199,10 +199,9 @@ class UltraNest(abstract_nest.AbstractNest):
 
                 self.perform_update(model=model, analysis=analysis, during_analysis=True)
 
-    @property
-    def samples_info(self):
+    def samples_info_from(self, search_internal=None):
 
-        search_internal = self.paths.load_search_internal()
+        search_internal = search_internal or self.paths.load_search_internal()
 
         return {
             "log_evidence": search_internal["logz"],

--- a/autofit/non_linear/search/nest/ultranest/search.py
+++ b/autofit/non_linear/search/nest/ultranest/search.py
@@ -210,7 +210,7 @@ class UltraNest(abstract_nest.AbstractNest):
             "number_live_points": self.config_dict_run["min_num_live_points"]
         }
 
-    def samples_via_internal_from(self, model: AbstractPriorModel):
+    def samples_via_internal_from(self, model: AbstractPriorModel, search_internal=None):
         """
         Returns a `Samples` object from the ultranest internal results.
 

--- a/autofit/non_linear/search/nest/ultranest/search.py
+++ b/autofit/non_linear/search/nest/ultranest/search.py
@@ -206,7 +206,7 @@ class UltraNest(abstract_nest.AbstractNest):
         return {
             "log_evidence": search_internal["logz"],
             "total_samples": search_internal["ncall"],
-            "time": self.timer.time,
+            "time": self.timer.time if self.timer else None,
             "number_live_points": self.config_dict_run["min_num_live_points"]
         }
 

--- a/autofit/non_linear/search/nest/ultranest/search.py
+++ b/autofit/non_linear/search/nest/ultranest/search.py
@@ -199,6 +199,8 @@ class UltraNest(abstract_nest.AbstractNest):
 
                 self.perform_update(model=model, analysis=analysis, during_analysis=True)
 
+        return search_internal
+
     def samples_info_from(self, search_internal=None):
 
         search_internal = search_internal or self.paths.load_search_internal()
@@ -246,7 +248,7 @@ class UltraNest(abstract_nest.AbstractNest):
         return SamplesNest(
             model=model,
             sample_list=sample_list,
-            samples_info=self.samples_info,
+            samples_info=self.samples_info_from(search_internal=search_internal),
             search_internal=search_internal,
         )
 

--- a/autofit/non_linear/search/nest/ultranest/search.py
+++ b/autofit/non_linear/search/nest/ultranest/search.py
@@ -142,7 +142,7 @@ class UltraNest(abstract_nest.AbstractNest):
                 "Starting new UltraNest non-linear search (no previous samples found)."
             )
 
-        sampler = ultranest.ReactiveNestedSampler(
+        search_internal = ultranest.ReactiveNestedSampler(
             param_names=model.parameter_names,
             loglike=fitness.__call__,
             transform=prior_transform,
@@ -150,14 +150,14 @@ class UltraNest(abstract_nest.AbstractNest):
             **self.config_dict_search
         )
 
-        sampler.stepsampler = self.stepsampler
+        search_internal.stepsampler = self.stepsampler
 
         finished = False
 
         while not finished:
 
             try:
-                total_iterations = sampler.ncall
+                total_iterations = search_internal.ncall
             except AttributeError:
                 total_iterations = 0
 
@@ -178,16 +178,16 @@ class UltraNest(abstract_nest.AbstractNest):
 
                 config_dict_run["update_interval_ncall"] = iterations
 
-                sampler.run(
+                search_internal.run(
                     max_ncalls=iterations,
                     **config_dict_run
                 )
 
             self.paths.save_search_internal(
-                  obj=sampler.results,
+                  obj=search_internal.results,
               )
 
-            iterations_after_run = sampler.ncall
+            iterations_after_run = search_internal.ncall
 
             if (
                     total_iterations == iterations_after_run

--- a/autofit/non_linear/search/nest/ultranest/search.py
+++ b/autofit/non_linear/search/nest/ultranest/search.py
@@ -226,7 +226,7 @@ class UltraNest(abstract_nest.AbstractNest):
             Maps input vectors of unit parameter values to physical values and model instances via priors.
         """
 
-        search_internal = self.paths.load_search_internal()
+        search_internal = search_internal or self.paths.load_search_internal()
 
         parameters = search_internal["weighted_samples"]["points"]
         log_likelihood_list = search_internal["weighted_samples"]["logl"]

--- a/autofit/non_linear/search/optimize/drawer/search.py
+++ b/autofit/non_linear/search/optimize/drawer/search.py
@@ -127,7 +127,8 @@ class Drawer(AbstractOptimizer):
 
         search_internal = {
             "parameter_lists" : parameter_lists,
-            "log_posterior_list" : log_posterior_list
+            "log_posterior_list" : log_posterior_list,
+            "time": self.timer.time
         }
 
         self.paths.save_search_internal(
@@ -164,7 +165,11 @@ class Drawer(AbstractOptimizer):
             weight_list=weight_list,
         )
 
-        return Samples(model=model, sample_list=sample_list)
+        return Samples(
+            model=model,
+            sample_list=sample_list,
+            samples_info=search_internal_dict,
+        )
 
     def plot_results(
         self,

--- a/autofit/non_linear/search/optimize/lbfgs/search.py
+++ b/autofit/non_linear/search/optimize/lbfgs/search.py
@@ -185,7 +185,7 @@ class LBFGS(AbstractOptimizer):
 
         self.logger.info("L-BFGS sampling complete.")
 
-    def samples_via_internal_from(self, model: AbstractPriorModel):
+    def samples_via_internal_from(self, model: AbstractPriorModel, search_internal=None):
         """
         Returns a `Samples` object from the LBFGS internal results.
 

--- a/autofit/non_linear/search/optimize/pyswarms/search/abstract.py
+++ b/autofit/non_linear/search/optimize/pyswarms/search/abstract.py
@@ -203,7 +203,7 @@ class AbstractPySwarms(AbstractOptimizer):
 
         while total_iterations < self.config_dict_run["iters"]:
 
-            pso = self.sampler_from(
+            pso = self.search_internal_from(
                 model=model,
                 fitness=fitness,
                 bounds=bounds,
@@ -292,7 +292,7 @@ class AbstractPySwarms(AbstractOptimizer):
             "iters": 1,
         }
 
-    def sampler_from(self, model, fitness, bounds, init_pos):
+    def search_internal_from(self, model, fitness, bounds, init_pos):
         raise NotImplementedError()
 
     def plot_results(self, samples):

--- a/autofit/non_linear/search/optimize/pyswarms/search/abstract.py
+++ b/autofit/non_linear/search/optimize/pyswarms/search/abstract.py
@@ -237,7 +237,7 @@ class AbstractPySwarms(AbstractOptimizer):
 
                 init_pos = pso.pos_history[-1]
 
-    def samples_via_internal_from(self, model):
+    def samples_via_internal_from(self, model, search_internal=None):
         """
         Returns a `Samples` object from the pyswarms internal results.
 

--- a/autofit/non_linear/search/optimize/pyswarms/search/abstract.py
+++ b/autofit/non_linear/search/optimize/pyswarms/search/abstract.py
@@ -165,7 +165,7 @@ class AbstractPySwarms(AbstractOptimizer):
                 "Resuming PySwarms non-linear search (previous samples found)."
             )
 
-        except FileNotFoundError:
+        except (FileNotFoundError, TypeError):
 
             unit_parameter_lists, parameter_lists, log_posterior_list = self.initializer.samples_from_model(
                 total_points=self.config_dict_search["n_particles"],
@@ -203,7 +203,7 @@ class AbstractPySwarms(AbstractOptimizer):
 
         while total_iterations < self.config_dict_run["iters"]:
 
-            pso = self.search_internal_from(
+            search_internal = self.search_internal_from(
                 model=model,
                 fitness=fitness,
                 bounds=bounds,
@@ -216,26 +216,31 @@ class AbstractPySwarms(AbstractOptimizer):
 
             if iterations > 0:
 
-                pso.optimize(objective_func=fitness.__call__, iters=iterations)
+                search_internal.optimize(objective_func=fitness.__call__, iters=iterations)
 
                 total_iterations += iterations
 
-                search_internal = {
-                    "search_internal" : pso.pos_history,
+                search_internal_dict = {
+                    "search_internal" : search_internal.pos_history,
                     "total_iterations": total_iterations,
-                    "log_posterior_list": [-0.5 * cost for cost in pso.cost_history],
-                    "time" : self.timer.time
+                    "log_posterior_list": [-0.5 * cost for cost in search_internal.cost_history],
+                    "time": self.timer.time if self.timer else None,
                 }
 
                 self.paths.save_search_internal(
-                    obj=search_internal,
+                    obj=search_internal_dict,
                 )
 
                 self.perform_update(
-                    model=model, analysis=analysis, during_analysis=True
+                    model=model,
+                    analysis=analysis,
+                    during_analysis=True,
+                    search_internal=search_internal
                 )
 
-                init_pos = pso.pos_history[-1]
+                init_pos = search_internal.pos_history[-1]
+
+        return search_internal
 
     def samples_via_internal_from(self, model, search_internal=None):
         """
@@ -252,19 +257,32 @@ class AbstractPySwarms(AbstractOptimizer):
         model
             Maps input vectors of unit parameter values to physical values and model instances via priors.
         """
-        search_internal_dict = self.paths.load_search_internal()
 
-        search_internal = search_internal_dict["search_internal"]
+        if search_internal is not None:
 
-        search_internal_dict = {
-            "total_iterations": search_internal_dict["total_iterations"],
-            "log_posterior_list": search_internal_dict["log_posterior_list"],
-            "time": search_internal_dict["time"]
-        }
+            search_internal_dict = {
+                "total_iterations": None,
+                "log_posterior_list": [-0.5 * cost for cost in search_internal.cost_history],
+                "time": self.timer.time if self.timer else None,
+            }
+            parameter_lists = search_internal.pos_history
+            parameter_lists_2 = [parameters.tolist()[0] for parameters in search_internal.pos_history]
 
-        parameter_lists = [
-            param.tolist() for parameters in search_internal for param in parameters
-        ]
+        else:
+
+            search_internal_dict = self.paths.load_search_internal()
+            search_internal = search_internal_dict["search_internal"]
+
+            search_internal_dict = {
+                "total_iterations": search_internal_dict["total_iterations"],
+                "log_posterior_list": search_internal_dict["log_posterior_list"],
+                "time": search_internal_dict["time"]
+            }
+            parameter_lists = [
+                param.tolist() for parameters in search_internal for param in parameters
+            ]
+            parameter_lists_2 = [parameters.tolist()[0] for parameters in search_internal]
+
         log_posterior_list = search_internal_dict["log_posterior_list"]
         log_prior_list = model.log_prior_list_from(parameter_lists=parameter_lists)
         log_likelihood_list = [lp - prior for lp, prior in zip(log_posterior_list, log_prior_list)]
@@ -272,7 +290,7 @@ class AbstractPySwarms(AbstractOptimizer):
 
         sample_list = Sample.from_lists(
             model=model,
-            parameter_lists=[parameters.tolist()[0] for parameters in search_internal],
+            parameter_lists=parameter_lists_2,
             log_likelihood_list=log_likelihood_list,
             log_prior_list=log_prior_list,
             weight_list=weight_list

--- a/autofit/non_linear/search/optimize/pyswarms/search/globe.py
+++ b/autofit/non_linear/search/optimize/pyswarms/search/globe.py
@@ -61,7 +61,7 @@ class PySwarmsGlobal(AbstractPySwarms):
 
         self.logger.debug("Creating PySwarms Search")
 
-    def sampler_from(self, model, fitness, bounds, init_pos):
+    def search_internal_from(self, model, fitness, bounds, init_pos):
         """Get the static Dynesty sampler which performs the non-linear search, passing it all associated input Dynesty
         variables."""
 

--- a/autofit/non_linear/search/optimize/pyswarms/search/local.py
+++ b/autofit/non_linear/search/optimize/pyswarms/search/local.py
@@ -60,7 +60,7 @@ class PySwarmsLocal(AbstractPySwarms):
 
         self.logger.debug("Creating PySwarms Search")
 
-    def sampler_from(self, model, fitness, bounds, init_pos):
+    def search_internal_from(self, model, fitness, bounds, init_pos):
         """
         Get the static Dynesty sampler which performs the non-linear search, passing it all associated input Dynesty
         variables.

--- a/docs/cookbooks/database.rst
+++ b/docs/cookbooks/database.rst
@@ -22,8 +22,8 @@ Ann overview of database functionality is given in the following sections:
 
 - **Unique Identifiers**: How unique identifiers are used to ensure every entry of the database is unique.
 - **Info**: Passing an ``info`` dictionary to the search to include information on the model-fit that is not part of the model-fit itself, which can be loaded via the database.
-- **Session**: Set up a database session so results are written directly to the .sqlite database.
 - **Building Database via Directory**: Build a database from results already written to hard-disk in an output folder.
+- **Writing Directly To Database**: Set up a database session so results are written directly to the .sqlite database.
 - **Files**: The files that are stored in the database that can be loaded and inspected.
 - **Generators**: Why the database uses Python generators to load results.
 
@@ -73,16 +73,21 @@ For fits to large datasets this ensures that all relevant information for interp
 
     info = {"date_of_observation": "01-02-18", "exposure_time": 1000.0}
 
-Session
--------
+Results From Hard Disk
+----------------------
 
-We now perform a simple model-fit to 3 datasets, where the results are written directly a sqlite3 database.
+We now perform a simple model-fit to 3 datasets, where the results are written to hard-disk using the standard
+output directory structure and we will then build the database from these results. This behaviour is governed
+by us inputting ``session=None``.
 
-To do this, we start a session, which includes the name of the database ``.sqlite`` file where results are stored.
+If you have existing results you wish to build a database for, you can therefore adapt this example you to do this.
+
+Later in this example we show how results can also also be output directly to an .sqlite database, saving on hard-disk
+space. This will be acheived by setting ``session`` to something that is not ``None``.
 
 .. code-block:: python
 
-    session = af.db.open_database("database.sqlite")
+    session = None
 
 For each dataset we load it from hard-disc, set up a model and analysis and fit it with a non-linear search.
 
@@ -114,7 +119,7 @@ Note how the ``session`` is passed to the ``Dynesty`` search.
             name="database_example",
             path_prefix=path.join("features", "database"),
             unique_tag=dataset_name,  # This makes the unique identifier use the dataset name
-            session=session,  # This instructs the search to write to the .sqlite database.
+            session=session,  # This can instruct the search to write to the .sqlite database.
             nlive=50,
         )
 
@@ -132,16 +137,17 @@ Note how the ``session`` is passed to the ``Dynesty`` search.
 Building Database via Directory
 -------------------------------
 
-The fits above directly wrote the results to the .sqlite file, which we loaded above. However, you may have results
-already written to hard-disk in an output folder, which you wish to build your .sqlite file from.
+The fits above wrote the results to hard-disk in folders, not as an .sqlite database file.
 
-This can be done via the following code, which is commented out below to avoid us deleting the existing .sqlite file.
+We build the database below, where the ``database_name`` corresponds to the name of your output folder and is also the
+name of the ``.sqlite`` database file that is created.
 
-Below, the ``database_name`` corresponds to the name of your output folder and is also the name of the ``.sqlite`` file
-that is created.
+If you are fitting a relatively small number of datasets (e.g. 10-100) having all results written to hard-disk (e.g.
+for quick visual inspection) and using the database for sample wide analysis is beneficial.
 
-If you are fitting a relatively small number of datasets (e.g. 10-100) having all results written
-to hard-disk (e.g. for quick visual inspection) but using the database for sample-wide analysis may be benefitial.
+We can optionally only include completed model-fits but setting ``completed_only=True``.
+
+If you inspect the ``output`` folder, you will see a ``database.sqlite`` file which contains the results.
 
 .. code-block:: python
 
@@ -152,6 +158,33 @@ to hard-disk (e.g. for quick visual inspection) but using the database for sampl
     )
 
     agg.add_directory(directory=path.join("output", database_name)))
+
+Writing Directly To Database
+----------------------------
+
+Results can be written directly to the .sqlite database file, skipping output to hard-disk entirely, by creating
+a session and passing this to the non-linear search.
+
+The code below shows how to do this.
+
+This is ideal for tasks where model-fits to hundreds or thousands of datasets are performed, as it becomes unfeasible
+to inspect the results of all fits on the hard-disk.
+
+Our recommended workflow is to set up database analysis scripts using ~10 model-fits, and then scaling these up
+to large samples by writing directly to the database.
+
+.. code-block:: python
+
+    session = af.db.open_database("database.sqlite")
+
+    search = af.DynestyStatic(
+        name="database_example",
+        path_prefix=path.join("features", "database"),
+        unique_tag=dataset_name,  # This makes the unique identifier use the dataset name
+        session=session,  # This can instruct the search to write to the .sqlite database.
+        nlive=50,
+    )
+
 
 Files
 -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ h5py>=2.10.0
 SQLAlchemy==1.3.20
 scipy<=1.11.3
 astunparse==1.6.3
-threadpoolctl==3.1.0
+threadpoolctl>=3.1.0,<=3.2.0
 timeout-decorator==0.5.0
 xxhash<=3.4.1


### PR DESCRIPTION
PyAutoFit should support runs which output nothing to hard-disk, if no `name` is input into a search.

However, this was not the case, as certain quantities (e.g. the search internal results) were still being output to hard disk. 

This PR prevents the search internal results from being output to hard-disk, which required a bit of a restructure of the code to ensure the results are passed through the code without being loaded.

The source code will be improved in the future in order to homogenize how all these results are stored, but I need to redesign the non-linear search visualization module before doing this.