### PR TITLE
feature/grid search attribute

### DIFF
--- a/autofit/non_linear/grid/grid_search/result.py
+++ b/autofit/non_linear/grid/grid_search/result.py
@@ -184,12 +184,26 @@ class GridSearchResult:
         """
         return self._list_to_native(lst=[sample for sample in self.samples])
 
-    def attribute_grid(self, attribute_name: str):
+    def attribute_grid(self, attribute_name: str) -> np.ndarray:
+        """
+        Get a list of the attribute of the best instance from every search in a numpy array with the native dimensions
+        of the grid search.
+
+        Parameters
+        ----------
+        attribute_name
+            The name of the attribute to get from the instance
+
+        Returns
+        -------
+        A numpy array of the attribute of the best instance from every search in the grid search.
+        """
+
         def _get_attribute(
             obj: Union[np.ndarray, SamplesInterface],
         ):
             if isinstance(obj, np.ndarray):
-                return [_get_attribute(item) for item in obj]
+                return np.array([_get_attribute(item) for item in obj])
             return getattr(obj.instance, attribute_name)
 
         return _get_attribute(self.samples_native)

--- a/autofit/non_linear/grid/grid_search/result.py
+++ b/autofit/non_linear/grid/grid_search/result.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 import numpy as np
 
@@ -183,6 +183,16 @@ class GridSearchResult:
         [0, 0]) of the NumPy array.
         """
         return self._list_to_native(lst=[sample for sample in self.samples])
+
+    def attribute_grid(self, attribute_name: str):
+        def _get_attribute(
+            obj: Union[np.ndarray, SamplesInterface],
+        ):
+            if isinstance(obj, np.ndarray):
+                return [_get_attribute(item) for item in obj]
+            return getattr(obj.instance, attribute_name)
+
+        return _get_attribute(self.samples_native)
 
     @property
     def log_likelihoods_native(self):

--- a/autofit/non_linear/grid/grid_search/result.py
+++ b/autofit/non_linear/grid/grid_search/result.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Union, Iterable
 
 import numpy as np
 
@@ -184,27 +184,33 @@ class GridSearchResult:
         """
         return self._list_to_native(lst=[sample for sample in self.samples])
 
-    def attribute_grid(self, attribute_name: str) -> np.ndarray:
+    def attribute_grid(self, attribute_path: Union[str, Iterable[str]]) -> np.ndarray:
         """
         Get a list of the attribute of the best instance from every search in a numpy array with the native dimensions
         of the grid search.
 
         Parameters
         ----------
-        attribute_name
-            The name of the attribute to get from the instance
+        attribute_path
+            The path to the attribute to get from the instance
 
         Returns
         -------
         A numpy array of the attribute of the best instance from every search in the grid search.
         """
+        if isinstance(attribute_path, str):
+            attribute_path = attribute_path.split(".")
 
         def _get_attribute(
             obj: Union[np.ndarray, SamplesInterface],
         ):
             if isinstance(obj, np.ndarray):
                 return np.array([_get_attribute(item) for item in obj])
-            return getattr(obj.instance, attribute_name)
+
+            item = obj.instance
+            for attribute_name in attribute_path:
+                item = getattr(item, attribute_name)
+            return item
 
         return _get_attribute(self.samples_native)
 

--- a/autofit/non_linear/grid/grid_search/result.py
+++ b/autofit/non_linear/grid/grid_search/result.py
@@ -201,18 +201,14 @@ class GridSearchResult:
         if isinstance(attribute_path, str):
             attribute_path = attribute_path.split(".")
 
-        def _get_attribute(
-            obj: Union[np.ndarray, SamplesInterface],
-        ):
-            if isinstance(obj, np.ndarray):
-                return np.array([_get_attribute(item) for item in obj])
-
-            item = obj.instance
+        attribute_list = []
+        for sample in self.samples:
+            attribute = sample.instance
             for attribute_name in attribute_path:
-                item = getattr(item, attribute_name)
-            return item
+                attribute = getattr(attribute, attribute_name)
+            attribute_list.append(attribute)
 
-        return _get_attribute(self.samples_native)
+        return self._list_to_native(attribute_list)
 
     @property
     def log_likelihoods_native(self):

--- a/test_autofit/non_linear/grid/test_result.py
+++ b/test_autofit/non_linear/grid/test_result.py
@@ -67,6 +67,34 @@ def test_higher_dimension_instance_attributes(model, samples_1, samples_2):
     assert (result.attribute_grid("centre") == [[1.0, 2.0], [1.0, 2.0]]).all()
 
 
+def test_paths(result):
+    model = af.Collection(
+        gaussian=af.Model(
+            af.Gaussian,
+            centre=af.UniformPrior(lower_limit=0.0, upper_limit=1.0),
+        )
+    )
+    samples = SamplesSummary(
+        af.Sample(
+            1.0,
+            1.0,
+            1.0,
+            {
+                "gaussian.centre": 1.0,
+                "gaussian.normalization": 2.0,
+                "gaussian.sigma": 3.0,
+            },
+        ),
+        model,
+    )
+    result = af.GridSearchResult(
+        samples=[samples, samples],
+        lower_limits_lists=[[0.0], [0.5]],
+        grid_priors=[model.gaussian.centre],
+    )
+    assert (result.attribute_grid("gaussian.centre") == [1.0, 1.0]).all()
+
+
 @pytest.mark.parametrize(
     "upper_limit, physical_value",
     [

--- a/test_autofit/non_linear/grid/test_result.py
+++ b/test_autofit/non_linear/grid/test_result.py
@@ -67,7 +67,8 @@ def test_higher_dimension_instance_attributes(model, samples_1, samples_2):
     assert (result.attribute_grid("centre") == [[1.0, 2.0], [1.0, 2.0]]).all()
 
 
-def test_paths(result):
+@pytest.fixture(name="deep_result")
+def make_deep_result(model, samples_1, samples_2):
     model = af.Collection(
         gaussian=af.Model(
             af.Gaussian,
@@ -87,12 +88,22 @@ def test_paths(result):
         ),
         model,
     )
-    result = af.GridSearchResult(
+    return af.GridSearchResult(
         samples=[samples, samples],
         lower_limits_lists=[[0.0], [0.5]],
         grid_priors=[model.gaussian.centre],
     )
-    assert (result.attribute_grid("gaussian.centre") == [1.0, 1.0]).all()
+
+
+def test_paths(deep_result):
+    assert (deep_result.attribute_grid("gaussian.centre") == [1.0, 1.0]).all()
+
+
+def test_instances(deep_result):
+    assert (
+        deep_result.attribute_grid("gaussian")
+        == [af.Gaussian(1.0, 2.0, 3.0), af.Gaussian(1.0, 2.0, 3.0)]
+    ).all()
 
 
 @pytest.mark.parametrize(

--- a/test_autofit/non_linear/grid/test_result.py
+++ b/test_autofit/non_linear/grid/test_result.py
@@ -1,6 +1,7 @@
 import pytest
 
 import autofit as af
+from autofit.non_linear.samples.summary import SamplesSummary
 
 
 @pytest.fixture(name="model")
@@ -13,8 +14,41 @@ def make_model():
 @pytest.fixture(name="result")
 def make_result(model):
     return af.GridSearchResult(
-        samples=[], lower_limits_lists=[[0.0], [0.5]], grid_priors=[model.centre]
+        samples=[
+            SamplesSummary(
+                af.Sample(
+                    1.0,
+                    1.0,
+                    1.0,
+                    {
+                        "centre": 1.0,
+                        "normalization": 2.0,
+                        "sigma": 3.0,
+                    },
+                ),
+                model,
+            ),
+            SamplesSummary(
+                af.Sample(
+                    1.0,
+                    1.0,
+                    1.0,
+                    {
+                        "centre": 2.0,
+                        "normalization": 4.0,
+                        "sigma": 6.0,
+                    },
+                ),
+                model,
+            ),
+        ],
+        lower_limits_lists=[[0.0], [0.5]],
+        grid_priors=[model.centre],
     )
+
+
+def test_instance_attribute_from_path(result):
+    assert result.attribute_grid("centre") == [1.0, 2.0]
 
 
 @pytest.mark.parametrize(

--- a/test_autofit/non_linear/grid/test_result.py
+++ b/test_autofit/non_linear/grid/test_result.py
@@ -11,44 +11,60 @@ def make_model():
     )
 
 
+@pytest.fixture(name="samples_1")
+def make_samples_1(model):
+    return SamplesSummary(
+        af.Sample(
+            1.0,
+            1.0,
+            1.0,
+            {
+                "centre": 1.0,
+                "normalization": 2.0,
+                "sigma": 3.0,
+            },
+        ),
+        model,
+    )
+
+
+@pytest.fixture(name="samples_2")
+def make_samples_2(model):
+    return SamplesSummary(
+        af.Sample(
+            1.0,
+            1.0,
+            1.0,
+            {
+                "centre": 2.0,
+                "normalization": 4.0,
+                "sigma": 6.0,
+            },
+        ),
+        model,
+    )
+
+
 @pytest.fixture(name="result")
-def make_result(model):
+def make_result(model, samples_1, samples_2):
     return af.GridSearchResult(
-        samples=[
-            SamplesSummary(
-                af.Sample(
-                    1.0,
-                    1.0,
-                    1.0,
-                    {
-                        "centre": 1.0,
-                        "normalization": 2.0,
-                        "sigma": 3.0,
-                    },
-                ),
-                model,
-            ),
-            SamplesSummary(
-                af.Sample(
-                    1.0,
-                    1.0,
-                    1.0,
-                    {
-                        "centre": 2.0,
-                        "normalization": 4.0,
-                        "sigma": 6.0,
-                    },
-                ),
-                model,
-            ),
-        ],
+        samples=[samples_1, samples_2],
         lower_limits_lists=[[0.0], [0.5]],
         grid_priors=[model.centre],
     )
 
 
 def test_instance_attribute_from_path(result):
-    assert result.attribute_grid("centre") == [1.0, 2.0]
+    assert (result.attribute_grid("centre") == [1.0, 2.0]).all()
+
+
+def test_higher_dimension_instance_attributes(model, samples_1, samples_2):
+    result = af.GridSearchResult(
+        samples=[samples_1, samples_2, samples_1, samples_2],
+        lower_limits_lists=[[0.0, 0.0], [0.0, 0.5], [0.5, 0.0], [0.5, 0.5]],
+        grid_priors=[model.centre, model.normalization],
+    )
+    assert (result.attribute_grid("centre") == [[1.0, 2.0], [1.0, 2.0]]).all()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #861

GridSearchResult now has a method called 'attribute_grid' which can be used to obtain a numpy array in the same dimensions as the grid search
```python
result.attribute_grid("centre")
```

This supports querying attributes deeper in the model using . delimited strings (or iterables)

```python
result.attribute_grid("gaussian.centre")
```

Values are taken from the highest log-likelihood instance. Currently SamplesSummary does not retain the median instance.
