### PR TITLE
fix how nautilus test is setup to use dynesty paths

### DIFF
--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -530,9 +530,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
                 from pathlib import Path
 
                 search = DynestyStatic(
-                    name=self.name,
-                    unique_tag=self.unique_tag,
-                    path_prefix=Path(self.paths.path_prefix),
+                    paths=self.paths,
                     number_of_cores=self.number_of_cores,
                 )
 


### PR DESCRIPTION
Simple fix to how paths are set up when switching from `Nautilus` to `Dynesty` in test mode.

Hopefully `Nautilus` will support a fixed number of iteraitons soon, meaning this code can be deleted.