### PR TITLE
remove code which bypass assert limits in test mode

### DIFF
--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -96,11 +96,6 @@ class Prior(Variable, ABC, ArithmeticMixin):
         return self.message.factor
 
     def assert_within_limits(self, value):
-        if (
-            conf.instance["general"]["model"]["ignore_prior_limits"]
-            or os.environ.get("PYAUTOFIT_TEST_MODE") == "1"
-        ):
-            return
         if not (self.lower_limit <= value <= self.upper_limit):
             raise exc.PriorLimitException(
                 "The physical value {} for a prior "


### PR DESCRIPTION
For whatever reason, prior limits were ignored in test mode:

```
    def assert_within_limits(self, value):
        if (
            conf.instance["general"]["model"]["ignore_prior_limits"]
            or os.environ.get("PYAUTOFIT_TEST_MODE") == "1"
        ):
            return
        if not (self.lower_limit <= value <= self.upper_limit):
            raise exc.PriorLimitException(
                "The physical value {} for a prior "
                "was not within its limits {}, {}".format(
                    value, self.lower_limit, self.upper_limit
                )
            )
```

I don't know why this is, and I'm sure I'll find out soon, but I have deleted this because it is causing its own issues when testing code.