### PR TITLE
ensure all jax source code imports go via jax_wrapper. Use importskip to prevent tests that rely on jax from running

### DIFF
--- a/autofit/jax_wrapper.py
+++ b/autofit/jax_wrapper.py
@@ -7,25 +7,6 @@ from os import environ
 
 use_jax = environ.get("USE_JAX", "0") == "1"
 
-import numpy  # noqa
-from scipy.special.cython_special import erfinv  # noqa
-
-
-def jit(function, *_, **__):
-    return function
-
-
-def register_pytree_node_class(cls):
-    return cls
-
-
-def register_pytree_node(*_, **__):
-    def decorator(cls):
-        return cls
-
-    return decorator
-
-
 if use_jax:
     try:
         import jax
@@ -34,11 +15,33 @@ if use_jax:
         def jit(function, *args, **kwargs):
             return jax.jit(function, *args, **kwargs)
 
-        from jax._src.tree_util import register_pytree_node_class, register_pytree_node
-        from jax._src.scipy.special import erfinv
-
         print("JAX mode enabled")
     except ImportError:
         raise ImportError(
             "JAX is not installed. Please install it with `pip install jax`."
         )
+else:
+    import numpy  # noqa
+    from scipy.special.cython_special import erfinv  # noqa
+
+    def jit(function, *_, **__):
+        return function
+
+
+try:
+    from jax._src.tree_util import (
+        register_pytree_node_class as register_pytree_node_class,
+        register_pytree_node as register_pytree_node,
+    )
+    from jax._src.scipy.special import erfinv
+
+except ImportError:
+
+    def register_pytree_node_class(cls):
+        return cls
+
+    def register_pytree_node(*_, **__):
+        def decorator(cls):
+            return cls
+
+        return decorator

--- a/autofit/jax_wrapper.py
+++ b/autofit/jax_wrapper.py
@@ -8,10 +8,22 @@ from os import environ
 use_jax = environ.get("USE_JAX", "0") == "1"
 
 import numpy  # noqa
+from scipy.special.cython_special import erfinv  # noqa
 
 
 def jit(function, *_, **__):
     return function
+
+
+def register_pytree_node_class(cls):
+    return cls
+
+
+def register_pytree_node(*_, **__):
+    def decorator(cls):
+        return cls
+
+    return decorator
 
 
 if use_jax:
@@ -21,6 +33,9 @@ if use_jax:
 
         def jit(function, *args, **kwargs):
             return jax.jit(function, *args, **kwargs)
+
+        from jax._src.tree_util import register_pytree_node_class, register_pytree_node
+        from jax._src.scipy.special import erfinv
 
         print("JAX mode enabled")
     except ImportError:

--- a/autofit/mapper/model.py
+++ b/autofit/mapper/model.py
@@ -3,7 +3,7 @@ import logging
 from functools import wraps
 from typing import Optional, Union, Tuple, List, Iterable, Type, Dict
 
-from jax._src.tree_util import register_pytree_node_class
+from autofit.jax_wrapper import register_pytree_node_class
 
 from autofit.mapper.model_object import ModelObject
 from autofit.mapper.prior_model.recursion import DynamicRecursionCache

--- a/autofit/mapper/prior/gaussian.py
+++ b/autofit/mapper/prior/gaussian.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from jax._src.tree_util import register_pytree_node_class
+from autofit.jax_wrapper import register_pytree_node_class
 
 from autofit.messages.normal import NormalMessage
 from .abstract import Prior

--- a/autofit/mapper/prior/uniform.py
+++ b/autofit/mapper/prior/uniform.py
@@ -1,4 +1,4 @@
-from jax._src.tree_util import register_pytree_node_class
+from autofit.jax_wrapper import register_pytree_node_class
 from typing import Optional
 
 from autofit.messages.normal import UniformNormalMessage

--- a/autofit/mapper/prior_model/collection.py
+++ b/autofit/mapper/prior_model/collection.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterable
 
-
-from jax._src.tree_util import register_pytree_node_class
+from autofit.jax_wrapper import register_pytree_node_class
 
 from autofit.mapper.model import ModelInstance, assert_not_frozen
 from autofit.mapper.prior.abstract import Prior

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 from typing import List
 
-from jax._src.tree_util import register_pytree_node_class, register_pytree_node
+from autofit.jax_wrapper import register_pytree_node_class, register_pytree_node
 
 from autoconf.class_path import get_class_path
 from autoconf.exc import ConfigException

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -1,9 +1,8 @@
 import math
-from jax._src.scipy.special import erfinv
 from typing import Tuple, Union
 
 import numpy as np
-from scipy.special.cython_special import erfcinv
+from autofit.jax_wrapper import erfinv
 from scipy.stats import norm
 
 from autoconf import cached_property
@@ -30,7 +29,7 @@ class NormalMessage(AbstractMessage):
     @cached_property
     def log_partition(self):
         eta1, eta2 = self.natural_parameters
-        return -(eta1 ** 2) / 4 / eta2 - np.log(-2 * eta2) / 2
+        return -(eta1**2) / 4 / eta2 - np.log(-2 * eta2) / 2
 
     log_base_measure = -0.5 * np.log(2 * np.pi)
     _support = ((-np.inf, np.inf),)
@@ -70,7 +69,7 @@ class NormalMessage(AbstractMessage):
 
     @staticmethod
     def calc_natural_parameters(mu, sigma):
-        precision = 1 / sigma ** 2
+        precision = 1 / sigma**2
         return np.array([mu * precision, -precision / 2])
 
     @staticmethod
@@ -82,17 +81,17 @@ class NormalMessage(AbstractMessage):
 
     @staticmethod
     def to_canonical_form(x):
-        return np.array([x, x ** 2])
+        return np.array([x, x**2])
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats):
         m1, m2 = suff_stats
-        sigma = np.sqrt(m2 - m1 ** 2)
+        sigma = np.sqrt(m2 - m1**2)
         return cls.calc_natural_parameters(m1, sigma)
 
     @cached_property
     def variance(self):
-        return self.sigma ** 2
+        return self.sigma**2
 
     def sample(self, n_samples=None):
         if n_samples:
@@ -107,7 +106,7 @@ class NormalMessage(AbstractMessage):
     def kl(self, dist):
         return (
             np.log(dist.sigma / self.sigma)
-            + (self.sigma ** 2 + (self.mean - dist.mean) ** 2) / 2 / dist.sigma ** 2
+            + (self.sigma**2 + (self.mean - dist.mean) ** 2) / 2 / dist.sigma**2
             - 1 / 2
         )
 
@@ -129,7 +128,7 @@ class NormalMessage(AbstractMessage):
         if shape:
             x = np.asanyarray(x)
             deltax = x - self.mean
-            hess_logl = -self.sigma ** -2
+            hess_logl = -self.sigma**-2
             grad_logl = deltax * hess_logl
             eta_t = 0.5 * grad_logl * deltax
             logl = self.log_base_measure + eta_t - np.log(self.sigma)
@@ -141,7 +140,7 @@ class NormalMessage(AbstractMessage):
 
         else:
             deltax = x - self.mean
-            hess_logl = -self.sigma ** -2
+            hess_logl = -self.sigma**-2
             grad_logl = deltax * hess_logl
             eta_t = 0.5 * grad_logl * deltax
             logl = self.log_base_measure + eta_t - np.log(self.sigma)
@@ -192,7 +191,7 @@ class NormalMessage(AbstractMessage):
         value
             The physical value of this prior's corresponding parameter in a `NonLinearSearch` sample.
         """
-        return (value - self.mean) ** 2.0 / (2 * self.sigma ** 2.0)
+        return (value - self.mean) ** 2.0 / (2 * self.sigma**2.0)
 
     def __str__(self):
         """
@@ -207,11 +206,11 @@ class NormalMessage(AbstractMessage):
                 self.id, self.mean, self.sigma, self.lower_limit, self.upper_limit
             )
         )
-    
+
     @property
     def natural(self):
         return NaturalNormal.from_natural_parameters(
-            self.natural_parameters * 0., **self._init_kwargs
+            self.natural_parameters * 0.0, **self._init_kwargs
         )
 
     def zeros_like(self) -> "AbstractMessage":
@@ -248,7 +247,7 @@ class NaturalNormal(NormalMessage):
     @cached_property
     def sigma(self):
         precision = -2 * self.parameters[1]
-        return precision ** -0.5
+        return precision**-0.5
 
     @cached_property
     def mean(self):
@@ -265,7 +264,7 @@ class NaturalNormal(NormalMessage):
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats):
         m1, m2 = suff_stats
-        precision = 1 / (m2 - m1 ** 2)
+        precision = 1 / (m2 - m1**2)
         return cls.calc_natural_parameters(m1 * precision, -precision / 2)
 
     @staticmethod
@@ -285,11 +284,11 @@ class NaturalNormal(NormalMessage):
         return cls(mode * precision, -precision / 2, **kwargs)
 
     zeros_like = AbstractMessage.zeros_like
-    
+
     @property
     def natural(self):
         return self
-    
+
 
 UniformNormalMessage = TransformedMessage(NormalMessage(0, 1), phi_transform)
 

--- a/autofit/non_linear/search/nest/dynesty/search/static.py
+++ b/autofit/non_linear/search/nest/dynesty/search/static.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import jax
-from jax import grad
-
 from autoconf import cached_property
 
 from pathlib import Path
@@ -22,6 +19,9 @@ class GradWrapper:
 
     @cached_property
     def grad(self):
+        import jax
+        from jax import grad
+
         print("Compiling gradient")
         return jax.jit(grad(self.function))
 

--- a/test_autofit/graphical/functionality/test_factor_graph.py
+++ b/test_autofit/graphical/functionality/test_factor_graph.py
@@ -12,7 +12,7 @@ def log_sigmoid(x):
 
 
 def log_phi(x):
-    return -(x ** 2) / 2 - 0.5 * np.log(2 * np.pi)
+    return -(x**2) / 2 - 0.5 * np.log(2 * np.pi)
 
 
 def plus_two(x):
@@ -80,15 +80,15 @@ def test_factor_jacobian():
 def test_nested_factor():
     def func(a, b):
         a0 = a[0]
-        c = a[1]['c']
+        c = a[1]["c"]
         return a0 * c * b
 
     a, b, c = graph.variables("a, b, c")
 
-    f = func((1, {'c': 2}), 3)
-    values = {a: 1., b: 3., c: 2.}
+    f = func((1, {"c": 2}), 3)
+    values = {a: 1.0, b: 3.0, c: 2.0}
 
-    factor = graph.Factor(func, [a, {'c': c}], b)
+    factor = graph.Factor(func, [a, {"c": c}], b)
 
     assert factor(values) == pytest.approx(f)
 
@@ -103,15 +103,17 @@ def test_nested_factor():
 def test_nested_factor_jax():
     def func(a, b):
         a0 = a[0]
-        c = a[1]['c']
+        c = a[1]["c"]
         return a0 * c * b
 
     a, b, c = graph.variables("a, b, c")
 
-    f = func((1, {'c': 2}), 3)
-    values = {a: 1., b: 3., c: 2.}
-    
-    factor = graph.Factor(func, (a, {'c': c}), b, vjp=True)
+    f = func((1, {"c": 2}), 3)
+    values = {a: 1.0, b: 3.0, c: 2.0}
+
+    pytest.importorskip("jax")
+
+    factor = graph.Factor(func, (a, {"c": c}), b, vjp=True)
 
     assert factor(values) == pytest.approx(f)
 

--- a/test_autofit/graphical/functionality/test_nested.py
+++ b/test_autofit/graphical/functionality/test_nested.py
@@ -1,14 +1,13 @@
-import collections 
+import collections
 
 import pytest
 
-
-from jax import tree_util
-
 from autofit.graphical import utils
 
+tree_util = pytest.importorskip("jax.tree_util")
 
 NTuple = collections.namedtuple("NTuple", "first, last")
+
 
 def jax_nested_zip(tree, *rest):
     leaves, treedef = tree_util.tree_flatten(tree)
@@ -17,54 +16,54 @@ def jax_nested_zip(tree, *rest):
 
 def jax_key_to_val(key):
     if isinstance(key, tree_util.SequenceKey):
-        return key.idx 
+        return key.idx
     elif isinstance(key, (tree_util.DictKey, tree_util.FlattenedIndexKey)):
-        return key.key 
+        return key.key
     elif isinstance(key, tree_util.GetAttrKey):
-        return key.name 
+        return key.name
     return key
+
 
 def jax_path_to_key(path):
     return tuple(map(jax_key_to_val, path))
 
 
 def test_nested_getitem():
-    obj = {"b": 2, "a": 1, "c": {"b": 2, "a": 1}, 'd': (3, {'e': [4, 5]})}
+    obj = {"b": 2, "a": 1, "c": {"b": 2, "a": 1}, "d": (3, {"e": [4, 5]})}
 
-    assert utils.nested_get(obj, ('b',)) == 2
-    assert utils.nested_get(obj, ('c', 'a')) == 1
-    assert utils.nested_get(obj, ('d', 0)) == 3
-    assert utils.nested_get(obj, ('d', 1, 'e', 1)) == 5
+    assert utils.nested_get(obj, ("b",)) == 2
+    assert utils.nested_get(obj, ("c", "a")) == 1
+    assert utils.nested_get(obj, ("d", 0)) == 3
+    assert utils.nested_get(obj, ("d", 1, "e", 1)) == 5
 
 
 def test_nested_setitem():
-    obj = {"b": 2, "a": 1, "c": {"b": 2, "a": 1}, 'd': (3, {'e': [4, 5]})}
+    obj = {"b": 2, "a": 1, "c": {"b": 2, "a": 1}, "d": (3, {"e": [4, 5]})}
 
-    utils.nested_set(obj, ('b',), 3)
-    assert utils.nested_get(obj, ('b',))
+    utils.nested_set(obj, ("b",), 3)
+    assert utils.nested_get(obj, ("b",))
 
-    utils.nested_set(obj, ('c', 'a'), 2) 
-    assert utils.nested_get(obj, ('c', 'a')) == 2
+    utils.nested_set(obj, ("c", "a"), 2)
+    assert utils.nested_get(obj, ("c", "a")) == 2
 
-    utils.nested_set(obj, ('d', 1, 'e', 1), 6) 
-    assert utils.nested_get(obj, ('d', 1, 'e', 1)) == 6
+    utils.nested_set(obj, ("d", 1, "e", 1), 6)
+    assert utils.nested_get(obj, ("d", 1, "e", 1)) == 6
 
     with pytest.raises(TypeError):
-        utils.nested_set(obj, ('d', 0), 4) 
+        utils.nested_set(obj, ("d", 0), 4)
 
 
 def test_nested_order():
-
-    obj1 = {"b": 2, "a": 1, "c": {"b": 2, "a": 1}, 'd': (3, {'e': [4, 5]})}
-    obj2 = {"a": 1, "b": 2, 'd': (3, {'e': [4, 5]}), "c": {"b": 2, "a": 1}}
+    obj1 = {"b": 2, "a": 1, "c": {"b": 2, "a": 1}, "d": (3, {"e": [4, 5]})}
+    obj2 = {"a": 1, "b": 2, "d": (3, {"e": [4, 5]}), "c": {"b": 2, "a": 1}}
 
     assert all(v1 == v2 for (v1, v2) in utils.nested_zip(obj1, obj2))
     assert all(utils.nested_filter(lambda x, y: x == y, obj1, obj2))
     assert list(utils.nested_zip(obj1)) == list(utils.nested_zip(obj2))
     assert list(utils.nested_zip(obj1, obj2)) == list(jax_nested_zip(obj1, obj2))
 
-    obj1 = {"b": 2, "a": 1, "c": {"b": 2, "a": 1}, 'd': (3, {'e': NTuple(4, 5)})}
-    obj2 = {"a": 1, "b": 2, 'd': (3, {'e': NTuple(4, 5)}), "c": {"b": 2, "a": 1}}
+    obj1 = {"b": 2, "a": 1, "c": {"b": 2, "a": 1}, "d": (3, {"e": NTuple(4, 5)})}
+    obj2 = {"a": 1, "b": 2, "d": (3, {"e": NTuple(4, 5)}), "c": {"b": 2, "a": 1}}
 
     assert all(v1 == v2 for (v1, v2) in utils.nested_zip(obj1, obj2))
     assert all(utils.nested_filter(lambda x, y: x == y, obj1, obj2))
@@ -73,90 +72,165 @@ def test_nested_order():
 
 
 def test_nested_items():
-    
-    obj1 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, 'c': (3, {'e': [4, 5]})}
+    obj1 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, "c": (3, {"e": [4, 5]})}
 
     for (k1, v1), (p2, v2) in zip(
-            utils.nested_items(obj1), 
-            tree_util.tree_flatten_with_path(obj1)[0]
+        utils.nested_items(obj1), tree_util.tree_flatten_with_path(obj1)[0]
     ):
         assert k1 == jax_path_to_key(p2)
         assert v1 == v2
 
 
 def test_nested_filter():
-    obj1 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, 'c': (3, {'e': [4, 5]})}
+    obj1 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, "c": (3, {"e": [4, 5]})}
     assert list(utils.nested_filter(lambda x: x % 2 == 0, obj1)) == [(2,), (4,), (2,)]
 
-    obj1 = {"b": 2, "a": 1,  'c': (3, {'e': [4, 5]}), "d": {"b": 2, "a": 1}}
+    obj1 = {"b": 2, "a": 1, "c": (3, {"e": [4, 5]}), "d": {"b": 2, "a": 1}}
     assert list(utils.nested_filter(lambda x: x % 2 == 0, obj1)) == [(2,), (4,), (2,)]
 
 
 def test_nested_map():
-    obj1 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, 'c': (3, {'e': [4, 5]})}
-    obj2 = {'a': 2, 'b': 4, 'c': (6, {'e': [8, 10]}), 'd': {'a': 2, 'b': 4}}
-    obj12 = utils.nested_map(lambda x: x*2, obj1)
+    obj1 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, "c": (3, {"e": [4, 5]})}
+    obj2 = {"a": 2, "b": 4, "c": (6, {"e": [8, 10]}), "d": {"a": 2, "b": 4}}
+    obj12 = utils.nested_map(lambda x: x * 2, obj1)
     assert obj12 == obj2
 
-    obj3 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, 'c': (3, {'e': (4, 5)})}
-    obj4 = {'a': 2, 'b': 4, 'c': (6, {'e': (8, 10)}), 'd': {'a': 2, 'b': 4}}
-    obj32 = utils.nested_map(lambda x: x*2, obj3)
+    obj3 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, "c": (3, {"e": (4, 5)})}
+    obj4 = {"a": 2, "b": 4, "c": (6, {"e": (8, 10)}), "d": {"a": 2, "b": 4}}
+    obj32 = utils.nested_map(lambda x: x * 2, obj3)
     assert obj32 == obj4
 
-
-    obj5 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, 'c': (3, {'e': NTuple(4, 5)})}
-    obj6 = {'a': 2, 'b': 4, 'c': (6, {'e': NTuple(8, 10)}), 'd': {'a': 2, 'b': 4}}
-    obj52 = utils.nested_map(lambda x: x*2, obj5)
+    obj5 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, "c": (3, {"e": NTuple(4, 5)})}
+    obj6 = {"a": 2, "b": 4, "c": (6, {"e": NTuple(8, 10)}), "d": {"a": 2, "b": 4}}
+    obj52 = utils.nested_map(lambda x: x * 2, obj5)
     assert obj52 == obj6 == obj4
 
     assert obj32 != obj2
     assert obj52 != obj2
 
-
-    assert all(utils.nested_iter(utils.nested_map(
-        lambda a, b, c: a == b == c, obj1, obj3, obj5
-    )))
-    assert all(utils.nested_iter(utils.nested_map(
-        lambda a, b, c: a == b == c, obj2, obj4, obj6
-    )))
-    assert all(map(lambda x: x[0] == x[1] == x[2],  utils.nested_zip(obj1, obj3, obj5)))
-    assert all(map(lambda x: x[0] == x[1] == x[2],  utils.nested_zip(obj2, obj32, obj52)))
+    assert all(
+        utils.nested_iter(
+            utils.nested_map(lambda a, b, c: a == b == c, obj1, obj3, obj5)
+        )
+    )
+    assert all(
+        utils.nested_iter(
+            utils.nested_map(lambda a, b, c: a == b == c, obj2, obj4, obj6)
+        )
+    )
+    assert all(map(lambda x: x[0] == x[1] == x[2], utils.nested_zip(obj1, obj3, obj5)))
+    assert all(
+        map(lambda x: x[0] == x[1] == x[2], utils.nested_zip(obj2, obj32, obj52))
+    )
 
 
 def test_nested_update():
-    assert utils.nested_update([1, (2, 3), [3, 2, {1, 2}]], {2: 'a'}) == [1, ('a', 3), [3, 'a', {1, 'a'}]]
-    assert utils.nested_update([1, NTuple(2, 3), [3, 2, {1, 2}]], {2: 'a'}) == [1, ('a', 3), [3, 'a', {1, 'a'}]]
-    assert isinstance(utils.nested_update([1, NTuple(2, 3), [3, 2, {1, 2}]], {2: 'a'})[1], NTuple)
-    assert utils.nested_update([{2: 2}], {2: 'a'}) == [{2: 'a'}]
-    
+    assert utils.nested_update([1, (2, 3), [3, 2, {1, 2}]], {2: "a"}) == [
+        1,
+        ("a", 3),
+        [3, "a", {1, "a"}],
+    ]
+    assert utils.nested_update([1, NTuple(2, 3), [3, 2, {1, 2}]], {2: "a"}) == [
+        1,
+        ("a", 3),
+        [3, "a", {1, "a"}],
+    ]
+    assert isinstance(
+        utils.nested_update([1, NTuple(2, 3), [3, 2, {1, 2}]], {2: "a"})[1], NTuple
+    )
+    assert utils.nested_update([{2: 2}], {2: "a"}) == [{2: "a"}]
+
 
 def test_nested_items():
-    obj1 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, 'c': (3, {'e': [4, 5]})}
-    obj2 = {'a': 2, 'b': 4, 'c': (6, {'e': [8, 10]}), 'd': {'a': 2, 'b': 4}}
+    obj1 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, "c": (3, {"e": [4, 5]})}
+    obj2 = {"a": 2, "b": 4, "c": (6, {"e": [8, 10]}), "d": {"a": 2, "b": 4}}
 
-    obj3 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, 'c': (3, {'e': (4, 5)})}
-    obj4 = {'a': 2, 'b': 4, 'c': (6, {'e': (8, 10)}), 'd': {'a': 2, 'b': 4}}
+    obj3 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, "c": (3, {"e": (4, 5)})}
+    obj4 = {"a": 2, "b": 4, "c": (6, {"e": (8, 10)}), "d": {"a": 2, "b": 4}}
 
-    obj5 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, 'c': (3, {'e': NTuple(4, 5)})}
-    obj6 = {'a': 2, 'b': 4, 'c': (6, {'e': NTuple(8, 10)}), 'd': {'a': 2, 'b': 4}}
+    obj5 = {"b": 2, "a": 1, "d": {"b": 2, "a": 1}, "c": (3, {"e": NTuple(4, 5)})}
+    obj6 = {"a": 2, "b": 4, "c": (6, {"e": NTuple(8, 10)}), "d": {"a": 2, "b": 4}}
 
     for path, val in utils.nested_items(obj1):
-        assert utils.nested_getitem(obj2, path) == utils.nested_getitem(obj4, path) == val * 2
+        assert (
+            utils.nested_getitem(obj2, path)
+            == utils.nested_getitem(obj4, path)
+            == val * 2
+        )
 
     for path, val in utils.nested_items(obj3):
-        assert utils.nested_getitem(obj4, path) == utils.nested_getitem(obj6, path) == val * 2
+        assert (
+            utils.nested_getitem(obj4, path)
+            == utils.nested_getitem(obj6, path)
+            == val * 2
+        )
 
     for path, val in utils.nested_items(obj5):
-        assert utils.nested_getitem(obj6, path) == utils.nested_getitem(obj2, path) == val * 2
+        assert (
+            utils.nested_getitem(obj6, path)
+            == utils.nested_getitem(obj2, path)
+            == val * 2
+        )
 
-    assert list(utils.nested_items([NTuple(1, 2), {2: 5, 1: 3}])) == [((0, 0), 1), ((0, 1), 2), ((1, 1), 3), ((1, 2), 5)]
+    assert list(utils.nested_items([NTuple(1, 2), {2: 5, 1: 3}])) == [
+        ((0, 0), 1),
+        ((0, 1), 2),
+        ((1, 1), 3),
+        ((1, 2), 5),
+    ]
 
-    assert list(utils.nested_items([1, (2, 3), [3, {'a': 1, 'b': 2}]])) == list(utils.nested_items([1, (2, 3), [3, {'b': 2, 'a': 1}]]))
-    assert list(utils.nested_items([1, (2, 3), [3, {'b': 2, 'a': 1, }]])) == list(utils.nested_items([1, (2, 3), [3, {'b': 2, 'a': 1}]]))
+    assert list(utils.nested_items([1, (2, 3), [3, {"a": 1, "b": 2}]])) == list(
+        utils.nested_items([1, (2, 3), [3, {"b": 2, "a": 1}]])
+    )
+    assert list(
+        utils.nested_items(
+            [
+                1,
+                (2, 3),
+                [
+                    3,
+                    {
+                        "b": 2,
+                        "a": 1,
+                    },
+                ],
+            ]
+        )
+    ) == list(utils.nested_items([1, (2, 3), [3, {"b": 2, "a": 1}]]))
 
-    obj1 = [1, (2, 3), [3, {'b': 2, 'a': 1, }]]
-    obj2 = [1, (2, 3), [3, {'a': 1, 'b': 2, }]]
-    obj3 = [1, NTuple(2, 3), [3, {'a': 1, 'b': 2, }]]
+    obj1 = [
+        1,
+        (2, 3),
+        [
+            3,
+            {
+                "b": 2,
+                "a": 1,
+            },
+        ],
+    ]
+    obj2 = [
+        1,
+        (2, 3),
+        [
+            3,
+            {
+                "a": 1,
+                "b": 2,
+            },
+        ],
+    ]
+    obj3 = [
+        1,
+        NTuple(2, 3),
+        [
+            3,
+            {
+                "a": 1,
+                "b": 2,
+            },
+        ],
+    ]
 
     # Need jax version > 0.4
     if hasattr(tree_util, "tree_flatten_with_path"):
@@ -164,11 +238,11 @@ def test_nested_items():
         af_flat = utils.nested_items(obj2)
 
         for (jpath, jval), (akey, aval) in zip(jax_flat, af_flat):
-            jkey = jax_path_to_key(jpath) 
-            assert jkey == akey 
-            assert jval == aval 
+            jkey = jax_path_to_key(jpath)
+            assert jkey == akey
+            assert jval == aval
             assert (
-                utils.nested_get(obj2, jkey) 
+                utils.nested_get(obj2, jkey)
                 == utils.nested_get(obj1, jkey)
                 == utils.nested_get(obj2, akey)
                 == utils.nested_get(obj1, akey)
@@ -177,11 +251,11 @@ def test_nested_items():
         jax_flat = tree_util.tree_flatten_with_path(obj2)[0]
         af_flat = utils.nested_items(obj3)
         for (jpath, jval), (akey, aval) in zip(jax_flat, af_flat):
-            jkey = jax_path_to_key(jpath) 
-            assert jkey == akey 
-            assert jval == aval 
+            jkey = jax_path_to_key(jpath)
+            assert jkey == akey
+            assert jval == aval
             assert (
-                utils.nested_get(obj2, jkey) 
+                utils.nested_get(obj2, jkey)
                 == utils.nested_get(obj1, jkey)
                 == utils.nested_get(obj2, akey)
                 == utils.nested_get(obj1, akey)

--- a/test_autofit/jax/test_jit.py
+++ b/test_autofit/jax/test_jit.py
@@ -1,6 +1,6 @@
 import pickle
 
-from autofit.jax_wrapper import numpy as np
+from autofit.jax_wrapper import numpy as np, jit
 
 import autofit as af
 from autofit import jax_wrapper
@@ -37,7 +37,7 @@ def make_instance():
 def test_jit_likelihood(analysis, instance):
     instance = Gaussian()
 
-    jitted = jax.jit(analysis.log_likelihood_function)
+    jitted = jit(analysis.log_likelihood_function)
 
     assert jitted(instance) == analysis.log_likelihood_function(instance)
 

--- a/test_autofit/jax/test_jit.py
+++ b/test_autofit/jax/test_jit.py
@@ -1,15 +1,15 @@
 import pickle
 
-import jax
-from jax import numpy as np
+from autofit.jax_wrapper import numpy as np
 
 import autofit as af
-from autoconf.conf import with_config
 from autofit import jax_wrapper
 from test_autofit.graphical.gaussian.model import Analysis, Gaussian, make_data
 from test_autofit.graphical.gaussian import model as model_module
 
 import pytest
+
+jax = pytest.importorskip("jax")
 
 
 @pytest.fixture(autouse=True)

--- a/test_autofit/jax/test_pytrees.py
+++ b/test_autofit/jax/test_pytrees.py
@@ -5,13 +5,11 @@ from autofit.jax_wrapper import numpy as jnp
 import autofit as af
 
 
-grad = pytest.importorskip("jax.grad")
-vmap = pytest.importorskip("jax.vmap")
-_registry = pytest.importorskip("jax._src.tree_util._registry")
+jax = pytest.importorskip("jax")
 
 
 def recreate(o):
-    flatten_func, unflatten_func = _registry[type(o)]
+    flatten_func, unflatten_func = jax._src.tree_util._registry[type(o)]
     children, aux_data = flatten_func(o)
     return unflatten_func(aux_data, children)
 
@@ -27,7 +25,7 @@ def patch_np(monkeypatch):
 
 
 def test_gradient(gaussian):
-    gradient = grad(gaussian.f)
+    gradient = jax.grad(gaussian.f)
 
     assert float(gradient(1.0)) == 0.0
 
@@ -40,7 +38,7 @@ def classic(gaussian, size=1000):
 
 
 def vmapped(gaussian, size=1000):
-    f = vmap(gaussian.f)
+    f = jax.vmap(gaussian.f)
     return list(f(np.arange(size)))
 
 

--- a/test_autofit/jax/test_pytrees.py
+++ b/test_autofit/jax/test_pytrees.py
@@ -1,10 +1,13 @@
 import numpy as np
 import pytest
-from jax import grad, vmap
-from jax._src.tree_util import _registry
-from jax import numpy as jnp
+from autofit.jax_wrapper import numpy as jnp
 
 import autofit as af
+
+
+grad = pytest.importorskip("jax.grad")
+vmap = pytest.importorskip("jax.vmap")
+_registry = pytest.importorskip("jax._src.tree_util._registry")
 
 
 def recreate(o):

--- a/test_autofit/jax/test_pytrees.py
+++ b/test_autofit/jax/test_pytrees.py
@@ -24,15 +24,6 @@ def patch_np(monkeypatch):
     monkeypatch.setattr(af.example.model, "np", jnp)
 
 
-def test_gradient(gaussian):
-    gradient = jax.grad(gaussian.f)
-
-    assert float(gradient(1.0)) == 0.0
-
-    gaussian.centre = 2.0
-    assert float(gradient(1.0)) != 0.0
-
-
 def classic(gaussian, size=1000):
     return list(map(gaussian.f, np.arange(size)))
 
@@ -40,11 +31,6 @@ def classic(gaussian, size=1000):
 def vmapped(gaussian, size=1000):
     f = jax.vmap(gaussian.f)
     return list(f(np.arange(size)))
-
-
-def test_vmap(gaussian):
-    for _ in range(1):
-        assert classic(gaussian) == vmapped(gaussian)
 
 
 def test_gaussian_prior():


### PR DESCRIPTION
Resolve #895
