### PR TITLE
feature/derived quantities

### DIFF
--- a/autofit/example/model.py
+++ b/autofit/example/model.py
@@ -2,6 +2,7 @@ import math
 from typing import Tuple
 
 from autofit.jax_wrapper import numpy as np
+from autofit.mapper.derived_quantity import derived_quantity
 
 """
 The `Gaussian` class in this module is the model components that is fitted to data using a non-linear search. The
@@ -36,6 +37,14 @@ class Gaussian:
         self.centre = centre
         self.normalization = normalization
         self.sigma = sigma
+
+    @derived_quantity
+    def lower_bound(self):
+        return self.centre - 5 * self.sigma
+
+    @derived_quantity
+    def upper_bound(self):
+        return self.centre + 5 * self.sigma
 
     def _tree_flatten(self):
         return (self.centre, self.normalization, self.sigma), None

--- a/autofit/interpolator/covariance.py
+++ b/autofit/interpolator/covariance.py
@@ -122,7 +122,7 @@ class CovarianceInterpolator(AbstractInterpolator):
 
         This comprises covariance matrices for each sample, subsumed along the diagonal
         """
-        matrices = [samples.covariance_matrix() for samples in self.samples_list]
+        matrices = [samples.covariance_matrix for samples in self.samples_list]
         prior_count = self.samples_list[0].model.prior_count
         size = prior_count * len(self.samples_list)
         array = np.zeros((size, size))

--- a/autofit/mapper/derived_quantity.py
+++ b/autofit/mapper/derived_quantity.py
@@ -1,0 +1,9 @@
+from autoconf.tools.decorators import CachedProperty
+
+
+class DerivedQuantity(CachedProperty):
+    def __set__(self, obj, value):
+        obj.__dict__[self.func.__name__] = value
+
+
+derived_quantity = DerivedQuantity

--- a/autofit/mapper/derived_quantity.py
+++ b/autofit/mapper/derived_quantity.py
@@ -2,6 +2,15 @@ from autoconf.tools.decorators import CachedProperty
 
 
 class DerivedQuantityDecorator(CachedProperty):
+    """
+    A derived quantity is an important quantity that is computed from a model instance.
+
+    This decorator makes a method into a property and indicates that autofit should
+    track the quantity.
+
+    Once a quantity is computed, it is cached and not recomputed.
+    """
+
     def __set__(self, obj, value):
         obj.__dict__[self.func.__name__] = value
 

--- a/autofit/mapper/derived_quantity.py
+++ b/autofit/mapper/derived_quantity.py
@@ -1,9 +1,9 @@
 from autoconf.tools.decorators import CachedProperty
 
 
-class DerivedQuantity(CachedProperty):
+class DerivedQuantityDecorator(CachedProperty):
     def __set__(self, obj, value):
         obj.__dict__[self.func.__name__] = value
 
 
-derived_quantity = DerivedQuantity
+derived_quantity = DerivedQuantityDecorator

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -208,9 +208,9 @@ class AbstractPriorModel(AbstractModel):
     @property
     def derived_quantities(self):
         return [
-            derived_quantity
-            for prior_model in self.direct_prior_model_tuples
-            for derived_quantity in prior_model[1].derived_quantities
+            (name,) + derived_quantity
+            for name, prior_model in self.direct_prior_model_tuples
+            for derived_quantity in prior_model.derived_quantities
         ]
 
     def cast(

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -205,6 +205,14 @@ class AbstractPriorModel(AbstractModel):
                 f"{number_of_failed_assertions} assertions failed!\n{name_string}"
             )
 
+    @property
+    def derived_quantities(self):
+        return [
+            derived_quantity
+            for prior_model in self.direct_prior_model_tuples
+            for derived_quantity in prior_model[1].derived_quantities
+        ]
+
     def cast(
         self,
         value_dict: Dict["AbstractModel", dict],

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -206,7 +206,11 @@ class AbstractPriorModel(AbstractModel):
             )
 
     @property
-    def derived_quantities(self):
+    def derived_quantities(self) -> List[Tuple[str, ...]]:
+        """
+        The paths to attributes of the model which are derived (i.e.
+        methods marked with the derived_quantity decorator)
+        """
         return [
             (name,) + derived_quantity
             for name, prior_model in self.direct_prior_model_tuples

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -226,7 +226,7 @@ class Model(AbstractPriorModel):
     @property
     def derived_quantities(self) -> List[str]:
         return super().derived_quantities + [
-            key
+            (key,)
             for key, value in self.cls.__dict__.items()
             if isinstance(value, derived_quantity)
         ]

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -225,7 +225,7 @@ class Model(AbstractPriorModel):
 
     @property
     def derived_quantities(self) -> List[str]:
-        return [
+        return super().derived_quantities + [
             key
             for key, value in self.cls.__dict__.items()
             if isinstance(value, derived_quantity)

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -224,7 +224,11 @@ class Model(AbstractPriorModel):
         ]
 
     @property
-    def derived_quantities(self) -> List[str]:
+    def derived_quantities(self) -> List[typing.Tuple[str, ...]]:
+        """
+        The paths to attributes of the model which are derived (i.e.
+        methods marked with the derived_quantity decorator)
+        """
         return super().derived_quantities + [
             (key,)
             for key, value in self.cls.__dict__.items()

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -10,6 +10,7 @@ from autofit.jax_wrapper import register_pytree_node_class, register_pytree_node
 
 from autoconf.class_path import get_class_path
 from autoconf.exc import ConfigException
+from autofit.mapper.derived_quantity import derived_quantity
 from autofit.mapper.model import assert_not_frozen
 from autofit.mapper.model_object import ModelObject
 from autofit.mapper.prior.abstract import Prior
@@ -220,6 +221,14 @@ class Model(AbstractPriorModel):
             + self.direct_instance_tuples
             + self.direct_deferred_tuples
             + self.direct_prior_tuples
+        ]
+
+    @property
+    def derived_quantities(self) -> List[str]:
+        return [
+            key
+            for key, value in self.cls.__dict__.items()
+            if isinstance(value, derived_quantity)
         ]
 
     def instance_flatten(self, instance):

--- a/autofit/non_linear/mock/mock_samples.py
+++ b/autofit/non_linear/mock/mock_samples.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 from autofit.non_linear.samples import SamplesPDF, Sample, SamplesNest
 
 
@@ -68,7 +66,6 @@ class MockSamples(SamplesPDF):
         return self._max_log_likelihood_instance
 
     def gaussian_priors_at_sigma(self, sigma=None):
-
         if self._gaussian_tuples is None:
             return super().gaussian_priors_at_sigma(sigma=sigma)
 
@@ -94,5 +91,6 @@ class MockSamplesNest(SamplesNest):
                 for log_likelihood in self.log_likelihood_list
             ]
 
-        super().__init__(model=model, sample_list=sample_list, samples_info=samples_info)
-
+        super().__init__(
+            model=model, sample_list=sample_list, samples_info=samples_info
+        )

--- a/autofit/non_linear/mock/mock_search.py
+++ b/autofit/non_linear/mock/mock_search.py
@@ -83,7 +83,7 @@ class MockSearch(NonLinearSearch):
                 # Return Chi squared
                 return -2 * log_likelihood
 
-        self.paths.samples_to_csv(self.samples)
+        self.paths.save_samples(self.samples)
 
         if self.save_for_aggregator:
             analysis.save_attributes(paths=self.paths)
@@ -127,7 +127,7 @@ class MockSearch(NonLinearSearch):
             ],
         )
 
-        self.paths.samples_to_csv(self.samples)
+        self.paths.save_samples(self.samples)
 
         return analysis.make_result(
             samples=samples,
@@ -135,7 +135,7 @@ class MockSearch(NonLinearSearch):
 
     def perform_update(self, model, analysis, during_analysis, search_internal=None):
         if self.samples is not None and not self.return_sensitivity_results:
-            self.paths.samples_to_csv(self.samples)
+            self.paths.save_samples(self.samples)
             return self.samples
 
         return MockSamples(

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -433,12 +433,13 @@ class AbstractPaths(ABC):
         with open_(filename, "w") as f:
             f.write(result_info)
 
-        derived_info = derived_info_from(samples=samples)
+        if self.model.derived_quantities:
+            derived_info = derived_info_from(samples=samples)
 
-        filename = self.output_path / "derived.results"
+            filename = self.output_path / "derived.results"
 
-        with open_(filename, "w") as f:
-            f.write(derived_info)
+            with open_(filename, "w") as f:
+                f.write(derived_info)
 
         text_util.search_summary_to_file(
             samples=samples,

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -415,6 +415,10 @@ class AbstractPaths(ABC):
         """
 
     @abstractmethod
+    def save_derived_quantities(self, samples):
+        pass
+
+    @abstractmethod
     def load_samples_info(self):
         pass
 
@@ -437,6 +441,10 @@ class AbstractPaths(ABC):
     @property
     def _samples_file(self) -> Path:
         return self._files_path / "samples.csv"
+
+    @property
+    def _derived_quantities_file(self) -> Path:
+        return self._files_path / "derived_quantities.csv"
 
     @property
     def _covariance_file(self) -> Path:

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -1,5 +1,3 @@
-import dill
-import json
 import logging
 import os
 import re
@@ -9,7 +7,7 @@ from abc import ABC, abstractmethod
 from configparser import NoSectionError
 from os import path
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import numpy as np
 
@@ -414,11 +412,6 @@ class AbstractPaths(ABC):
     def save_samples(self, samples):
         """
         Save samples to the database
-        """
-
-    def samples_to_csv(self, samples):
-        """
-        Save the final-result samples associated with the phase as a pickle
         """
 
     @abstractmethod

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -14,6 +14,7 @@ import numpy as np
 from autoconf import conf
 from autofit.mapper.identifier import Identifier, IdentifierField
 from autofit.text import text_util
+from autofit.text.text_util import derived_info_from
 from autofit.tools.util import open_, zip_directory
 
 logger = logging.getLogger(__name__)
@@ -431,6 +432,13 @@ class AbstractPaths(ABC):
 
         with open_(filename, "w") as f:
             f.write(result_info)
+
+        derived_info = derived_info_from(samples=samples)
+
+        filename = self.output_path / "derived.results"
+
+        with open_(filename, "w") as f:
+            f.write(derived_info)
 
         text_util.search_summary_to_file(
             samples=samples,

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -417,7 +417,16 @@ class AbstractPaths(ABC):
 
     @abstractmethod
     def save_derived_quantities(self, samples):
-        pass
+        """
+        Write out the derived quantities of the model.
+
+        This is like samples, but for the derived quantities of the model.
+
+        Parameters
+        ----------
+        samples
+            An object comprising each sample and a model which is used to compute the derived quantities.
+        """
 
     @abstractmethod
     def load_samples_info(self):

--- a/autofit/non_linear/paths/database.py
+++ b/autofit/non_linear/paths/database.py
@@ -263,12 +263,6 @@ class DatabasePaths(AbstractPaths):
         self.fit.samples = samples
         self.fit.set_json("samples_info", samples.samples_info)
 
-    def samples_to_csv(self, samples):
-        """
-        Save the final-result samples associated with the phase as a pickle
-        """
-        pass
-
     def _load_samples(self):
         samples = self.fit.samples
         samples.model = self.model

--- a/autofit/non_linear/paths/database.py
+++ b/autofit/non_linear/paths/database.py
@@ -263,6 +263,15 @@ class DatabasePaths(AbstractPaths):
         self.fit.samples = samples
         self.fit.set_json("samples_info", samples.samples_info)
 
+    def save_derived_quantities(self, samples):
+        if not self.save_all_samples:
+            samples = samples.minimise()
+
+        self.fit.set_array(
+            "derived_quantities",
+            np.array(samples.derived_quantities),
+        )
+
     def _load_samples(self):
         samples = self.fit.samples
         samples.model = self.model

--- a/autofit/non_linear/paths/database.py
+++ b/autofit/non_linear/paths/database.py
@@ -266,10 +266,11 @@ class DatabasePaths(AbstractPaths):
     def save_derived_quantities(self, samples):
         if not self.save_all_samples:
             samples = samples.minimise()
+            samples.model = self.model
 
         self.fit.set_array(
             "derived_quantities",
-            np.array(samples.derived_quantities),
+            np.array(samples.derived_quantities_list),
         )
 
     def _load_samples(self):

--- a/autofit/non_linear/paths/database.py
+++ b/autofit/non_linear/paths/database.py
@@ -264,6 +264,16 @@ class DatabasePaths(AbstractPaths):
         self.fit.set_json("samples_info", samples.samples_info)
 
     def save_derived_quantities(self, samples):
+        """
+        Write out the derived quantities of the model.
+
+        This is like samples, but for the derived quantities of the model.
+
+        Parameters
+        ----------
+        samples
+            An object comprising each sample and a model which is used to compute the derived quantities.
+        """
         if not self.save_all_samples:
             samples = samples.minimise()
             samples.model = self.model

--- a/autofit/non_linear/paths/directory.py
+++ b/autofit/non_linear/paths/directory.py
@@ -212,9 +212,6 @@ class DirectoryPaths(AbstractPaths):
         return load_from_table(filename=self._samples_file)
 
     def save_samples(self, samples):
-        pass
-
-    def samples_to_csv(self, samples):
         """
         Save the final-result samples associated with the phase as a pickle
         """

--- a/autofit/non_linear/paths/directory.py
+++ b/autofit/non_linear/paths/directory.py
@@ -230,6 +230,16 @@ class DirectoryPaths(AbstractPaths):
                     )
 
     def save_derived_quantities(self, samples: Samples):
+        """
+        Write out the derived quantities of the model to a file.
+
+        This is like the samples.csv file, but for the derived quantities of the model.
+
+        Parameters
+        ----------
+        samples
+            An object comprising each sample and a model which is used to compute the derived quantities.
+        """
         write_table(
             filename=str(self._derived_quantities_file),
             headers=[

--- a/autofit/non_linear/paths/directory.py
+++ b/autofit/non_linear/paths/directory.py
@@ -17,8 +17,8 @@ from ..samples import load_from_table
 from autofit.non_linear.samples.pdf import SamplesPDF
 import numpy as np
 
-from ... import Samples
-from ...text.formatter import write_table
+from autofit.non_linear.samples.samples import Samples
+from autofit.text.formatter import write_table
 
 logger = logging.getLogger(__name__)
 

--- a/autofit/non_linear/paths/directory.py
+++ b/autofit/non_linear/paths/directory.py
@@ -17,6 +17,9 @@ from ..samples import load_from_table
 from autofit.non_linear.samples.pdf import SamplesPDF
 import numpy as np
 
+from ... import Samples
+from ...text.formatter import write_table
+
 logger = logging.getLogger(__name__)
 
 
@@ -225,6 +228,16 @@ class DirectoryPaths(AbstractPaths):
                     logger.warning(
                         f"Could not save covariance matrix because of the following error:\n{e}"
                     )
+
+    def save_derived_quantities(self, samples: Samples):
+        write_table(
+            filename=str(self._derived_quantities_file),
+            headers=[
+                ".".join(derived_quantity)
+                for derived_quantity in self.model.derived_quantities
+            ],
+            rows=samples.derived_quantities_list,
+        )
 
     def load_samples_info(self):
         with open_(self._info_file) as infile:

--- a/autofit/non_linear/paths/null.py
+++ b/autofit/non_linear/paths/null.py
@@ -9,6 +9,9 @@ class NullPaths(AbstractPaths):
     Null version of paths object for avoiding writing of files to disk
     """
 
+    def saved_derived_quantities(self, samples):
+        pass
+
     def save_json(self, name, object_dict: dict, prefix: str = ""):
         pass
 

--- a/autofit/non_linear/paths/null.py
+++ b/autofit/non_linear/paths/null.py
@@ -9,7 +9,7 @@ class NullPaths(AbstractPaths):
     Null version of paths object for avoiding writing of files to disk
     """
 
-    def saved_derived_quantities(self, samples):
+    def save_derived_quantities(self, samples):
         pass
 
     def save_json(self, name, object_dict: dict, prefix: str = ""):

--- a/autofit/non_linear/samples/interface.py
+++ b/autofit/non_linear/samples/interface.py
@@ -11,9 +11,9 @@ from autofit.mapper.prior_model.abstract import Path
 def to_instance(func):
     @wraps(func)
     def wrapper(
-        obj, as_instance: bool = True, *args, **kwargs
+        obj, *args, as_instance: bool = True, **kwargs
     ) -> Union[List, ModelInstance]:
-        vector = func(obj, as_instance, *args, **kwargs)
+        vector = func(obj, *args, **kwargs)
 
         if as_instance:
             return obj.model.instance_from_vector(

--- a/autofit/non_linear/samples/mcmc.py
+++ b/autofit/non_linear/samples/mcmc.py
@@ -9,20 +9,20 @@ from autofit.non_linear.search.mcmc.auto_correlations import AutoCorrelationsSet
 from autofit.non_linear.samples.pdf import SamplesPDF
 from autofit.non_linear.samples.samples import Sample
 
-from autofit.non_linear.samples.samples import to_instance, to_instance_sigma
+from autofit.non_linear.samples.samples import to_instance
 
 from autofit import exc
 
-class SamplesMCMC(SamplesPDF):
 
+class SamplesMCMC(SamplesPDF):
     def __init__(
-            self,
-            model: AbstractPriorModel,
-            sample_list: List[Sample],
-            samples_info : Optional[Dict] = None,
-            search_internal: Optional = None,
-            auto_correlation_settings: Optional[AutoCorrelationsSettings] = None,
-            auto_correlations : Optional[AutoCorrelations] = None
+        self,
+        model: AbstractPriorModel,
+        sample_list: List[Sample],
+        samples_info: Optional[Dict] = None,
+        search_internal: Optional = None,
+        auto_correlation_settings: Optional[AutoCorrelationsSettings] = None,
+        auto_correlations: Optional[AutoCorrelations] = None,
     ):
         """
         The `Samples` classes in **PyAutoFit** provide an interface between the search_internal of
@@ -57,13 +57,10 @@ class SamplesMCMC(SamplesPDF):
             model=model,
             sample_list=sample_list,
             samples_info=samples_info,
-            search_internal=search_internal
+            search_internal=search_internal,
         )
 
-    def __add__(
-            self,
-            other: "SamplesMCMC"
-    ) -> "SamplesMCMC":
+    def __add__(self, other: "SamplesMCMC") -> "SamplesMCMC":
         """
         Samples can be added together, which combines their `sample_list` meaning that inferred parameters are
         computed via their joint PDF.
@@ -86,7 +83,7 @@ class SamplesMCMC(SamplesPDF):
         warnings.warn(
             f"Addition of {self.__class__.__name__} cannot retain results in native format. "
             "Visualization of summed samples diabled.",
-            exc.SamplesWarning
+            exc.SamplesWarning,
         )
 
         return self.__class__(
@@ -94,7 +91,7 @@ class SamplesMCMC(SamplesPDF):
             sample_list=self.sample_list + other.sample_list,
             samples_info=self.samples_info,
             auto_correlation_settings=self.auto_correlation_settings,
-            search_internal=None
+            search_internal=None,
         )
 
     @property
@@ -141,8 +138,8 @@ class SamplesMCMC(SamplesPDF):
 
         return self.max_log_likelihood(as_instance=False)
 
-    @to_instance_sigma
-    def values_at_sigma(self, sigma: float, as_instance: bool = True) -> [float]:
+    @to_instance
+    def values_at_sigma(self, sigma: float) -> [float]:
         """
         The value of every parameter marginalized in 1D at an input sigma value of its probability density function
         (PDF), returned as two lists of values corresponding to the lower and upper values parameter values.
@@ -175,10 +172,10 @@ class SamplesMCMC(SamplesPDF):
             ]
 
         parameters_min = list(
-            np.min(self.parameter_lists[-self.unconverged_sample_size:], axis=0)
+            np.min(self.parameter_lists[-self.unconverged_sample_size :], axis=0)
         )
         parameters_max = list(
-            np.max(self.parameter_lists[-self.unconverged_sample_size:], axis=0)
+            np.max(self.parameter_lists[-self.unconverged_sample_size :], axis=0)
         )
 
         return [

--- a/autofit/non_linear/samples/nest.py
+++ b/autofit/non_linear/samples/nest.py
@@ -9,14 +9,14 @@ from autofit.non_linear.samples.stored import SamplesStored
 
 from autofit import exc
 
-class SamplesNest(SamplesPDF):
 
+class SamplesNest(SamplesPDF):
     def __init__(
-            self,
-            model: AbstractPriorModel,
-            sample_list: List[Sample],
-            samples_info : Optional[Dict] = None,
-            search_internal: Optional = None,
+        self,
+        model: AbstractPriorModel,
+        sample_list: List[Sample],
+        samples_info: Optional[Dict] = None,
+        search_internal: Optional = None,
     ):
         """
         The `Samples` classes in **PyAutoFit** provide an interface between the search_internal of
@@ -48,13 +48,10 @@ class SamplesNest(SamplesPDF):
             model=model,
             sample_list=sample_list,
             samples_info=samples_info,
-            search_internal=search_internal
+            search_internal=search_internal,
         )
 
-    def __add__(
-            self,
-            other: "SamplesNest"
-    ) -> "SamplesNest":
+    def __add__(self, other: "SamplesNest") -> "SamplesNest":
         """
         Samples can be added together, which combines their `sample_list` meaning that inferred parameters are
         computed via their joint PDF.
@@ -77,14 +74,14 @@ class SamplesNest(SamplesPDF):
         warnings.warn(
             f"Addition of {self.__class__.__name__} cannot retain results in native format. "
             "Visualization of summed samples diabled.",
-            exc.SamplesWarning
+            exc.SamplesWarning,
         )
 
         return self.__class__(
             model=self.model,
             sample_list=self.sample_list + other.sample_list,
             samples_info=self.samples_info,
-            search_internal=None
+            search_internal=None,
         )
 
     @property
@@ -114,9 +111,7 @@ class SamplesNest(SamplesPDF):
         return self.total_accepted_samples / self.total_samples
 
     def samples_within_parameter_range(
-            self,
-            parameter_index: int,
-            parameter_range: [float, float]
+        self, parameter_index: int, parameter_range: [float, float]
     ) -> "SamplesStored":
         """
         Returns a new set of Samples where all points without parameter values inside a specified range removed.
@@ -147,12 +142,11 @@ class SamplesNest(SamplesPDF):
         weight_list = []
 
         for sample in self.sample_list:
-
             parameters = sample.parameter_lists_for_model(model=self.model)
 
             if (parameters[parameter_index] > parameter_range[0]) and (
-                    parameters[parameter_index] < parameter_range[1]):
-
+                parameters[parameter_index] < parameter_range[1]
+            ):
                 parameter_list.append(parameters)
                 log_likelihood_list.append(sample.log_likelihood)
                 log_prior_list.append(sample.log_prior)
@@ -163,7 +157,7 @@ class SamplesNest(SamplesPDF):
             parameter_lists=parameter_list,
             log_likelihood_list=log_likelihood_list,
             log_prior_list=log_prior_list,
-            weight_list=weight_list
+            weight_list=weight_list,
         )
 
         return SamplesStored(

--- a/autofit/non_linear/samples/pdf.py
+++ b/autofit/non_linear/samples/pdf.py
@@ -60,7 +60,7 @@ class SamplesPDF(Samples):
 
     def summary(self):
         try:
-            covariance_matrix = self.covariance_matrix()
+            covariance_matrix = self.covariance_matrix
         except Exception as e:
             logging.warning(f"Could not create covariance matrix: {e}")
             covariance_matrix = None
@@ -389,6 +389,7 @@ class SamplesPDF(Samples):
             )
         )
 
+    @property
     def covariance_matrix(self) -> np.ndarray:
         """
         Compute the covariance matrix of the non-linear search samples, using the method `np.cov()` which is described
@@ -418,7 +419,7 @@ class SamplesPDF(Samples):
             The filename the covariance matrix is saved to.
         """
         # noinspection PyTypeChecker
-        np.savetxt(filename, self.covariance_matrix(), delimiter=",")
+        np.savetxt(filename, self.covariance_matrix, delimiter=",")
 
     @property
     def log_evidence(self):

--- a/autofit/non_linear/samples/pdf.py
+++ b/autofit/non_linear/samples/pdf.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import pathlib
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -409,7 +410,7 @@ class SamplesPDF(Samples):
             return np.eye(1)
         return np.cov(m=self.parameter_lists, rowvar=False, aweights=self.weight_list)
 
-    def save_covariance_matrix(self, filename: Union[Path, str]):
+    def save_covariance_matrix(self, filename: Union[pathlib.Path, str]):
         """
         Save the covariance matrix as a CSV file.
 

--- a/autofit/non_linear/samples/pdf.py
+++ b/autofit/non_linear/samples/pdf.py
@@ -7,13 +7,9 @@ import numpy as np
 
 from autoconf import conf
 from autofit.mapper.model import ModelInstance
-from autofit.mapper.prior_model.abstract import AbstractPriorModel, Path
+from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.samples.sample import Sample, load_from_table
-from autofit.non_linear.samples.samples import (
-    to_instance,
-    to_instance_sigma,
-    to_instance_input,
-)
+from autofit.non_linear.samples.samples import to_instance
 from .samples import Samples
 from .summary import SamplesSummary
 
@@ -125,7 +121,7 @@ class SamplesPDF(Samples):
         return True
 
     @to_instance
-    def median_pdf(self, as_instance: bool = True) -> List[float]:
+    def median_pdf(self) -> List[float]:
         """
         The median of the probability density function (PDF) of every parameter marginalized in 1D, returned
         as a model instance or list of values.
@@ -137,10 +133,8 @@ class SamplesPDF(Samples):
             ]
         return self.max_log_likelihood(as_instance=False)
 
-    @to_instance_sigma
-    def values_at_sigma(
-        self, sigma: float, as_instance: bool = True
-    ) -> [Tuple, ModelInstance]:
+    @to_instance
+    def values_at_sigma(self, sigma: float) -> [Tuple, ModelInstance]:
         """
         The value of every parameter marginalized in 1D at an input sigma value of its probability density function
         (PDF), returned as two lists of values corresponding to the lower and upper values parameter values.
@@ -188,10 +182,8 @@ class SamplesPDF(Samples):
             for index in range(len(parameters_min))
         ]
 
-    @to_instance_sigma
-    def values_at_upper_sigma(
-        self, sigma: float, as_instance: bool = True
-    ) -> Union[List, ModelInstance]:
+    @to_instance
+    def values_at_upper_sigma(self, sigma: float) -> Union[List, ModelInstance]:
         """
         The upper value of every parameter marginalized in 1D at an input sigma value of its probability density
         function (PDF), returned as a list.
@@ -207,10 +199,8 @@ class SamplesPDF(Samples):
             map(lambda param: param[1], self.values_at_sigma(sigma, as_instance=False))
         )
 
-    @to_instance_sigma
-    def values_at_lower_sigma(
-        self, sigma: float, as_instance: bool = True
-    ) -> Union[List, ModelInstance]:
+    @to_instance
+    def values_at_lower_sigma(self, sigma: float) -> Union[List, ModelInstance]:
         """
         The lower value of every parameter marginalized in 1D at an input sigma value of its probability density
         function (PDF), returned as a list.
@@ -226,7 +216,7 @@ class SamplesPDF(Samples):
             map(lambda param: param[0], self.values_at_sigma(sigma, as_instance=False))
         )
 
-    @to_instance_sigma
+    @to_instance
     def errors_at_sigma(
         self, sigma: float, as_instance: bool = True
     ) -> [Tuple, ModelInstance]:
@@ -248,7 +238,7 @@ class SamplesPDF(Samples):
             for lower, upper in zip(error_vector_lower, error_vector_upper)
         ]
 
-    @to_instance_sigma
+    @to_instance
     def errors_at_upper_sigma(
         self, sigma: float, as_instance: bool = True
     ) -> Union[List, ModelInstance]:
@@ -272,10 +262,8 @@ class SamplesPDF(Samples):
             )
         )
 
-    @to_instance_sigma
-    def errors_at_lower_sigma(
-        self, sigma: float, as_instance: bool = True
-    ) -> Union[List, ModelInstance]:
+    @to_instance
+    def errors_at_lower_sigma(self, sigma: float) -> Union[List, ModelInstance]:
         """
         The lower error of every parameter marginalized in 1D at an input sigma value of its probability density
         function (PDF), returned as a list.
@@ -296,10 +284,8 @@ class SamplesPDF(Samples):
             )
         )
 
-    @to_instance_sigma
-    def error_magnitudes_at_sigma(
-        self, sigma: float, as_instance: bool = True
-    ) -> Union[List, ModelInstance]:
+    @to_instance
+    def error_magnitudes_at_sigma(self, sigma: float) -> Union[List, ModelInstance]:
         """
         The magnitude of every error after marginalization in 1D at an input sigma value of the probability density
         function (PDF), returned as two lists of values corresponding to the lower and upper errors.
@@ -348,9 +334,7 @@ class SamplesPDF(Samples):
         return list(map(lambda mean, sigma: (mean, sigma), means, sigmas))
 
     @to_instance
-    def draw_randomly_via_pdf(
-        self, as_instance: bool = True
-    ) -> Union[List, ModelInstance]:
+    def draw_randomly_via_pdf(self) -> Union[List, ModelInstance]:
         """
         The parameter vector of an individual sample of the non-linear search drawn randomly from the PDF, returned as
         a 1D list.
@@ -365,9 +349,9 @@ class SamplesPDF(Samples):
 
         return self.parameter_lists[sample_index][:]
 
-    @to_instance_input
+    @to_instance
     def offset_values_via_input_values(
-        self, input_vector: List, as_instance: bool = True
+        self, input_vector: List
     ) -> Union[List, ModelInstance]:
         """
         The values of an input_vector offset by the median_pdf(as_instance=False) (the PDF medians).

--- a/autofit/non_linear/samples/sample.py
+++ b/autofit/non_linear/samples/sample.py
@@ -11,7 +11,11 @@ from autofit.tools.util import split_paths
 
 class Sample:
     def __init__(
-        self, log_likelihood: float, log_prior: float, weight: float, kwargs=None
+        self,
+        log_likelihood: float,
+        log_prior: float,
+        weight: float,
+        kwargs=None,
     ):
         """
         One sample taken during a search

--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -1,6 +1,5 @@
 from abc import ABC
-import csv
-from functools import wraps
+
 import json
 import warnings
 from copy import copy
@@ -17,165 +16,6 @@ from autofit.non_linear.samples.sample import Sample
 from .summary import SamplesSummary
 from .interface import SamplesInterface, to_instance
 from ...text.formatter import write_table
-
-
-### TODO: Rich how do I reduce this to one wrapper sensible?
-
-
-def to_instance_sigma(func):
-    """
-
-    Parameters
-    ----------
-    func
-
-    Returns
-    -------
-        A function that returns a 2D image.
-    """
-
-    @wraps(func)
-    def wrapper(
-        obj, sigma, as_instance: bool = True, *args, **kwargs
-    ) -> Union[List, ModelInstance]:
-        """
-        This decorator checks if a light profile is a `LightProfileOperated` class and therefore already has had operations like a
-        PSF convolution performed.
-
-        This is compared to the `only_operated` input to determine if the image of that light profile is returned, or
-        an array of zeros.
-
-        Parameters
-        ----------
-        obj
-            A light profile with an `image_2d_from` function whose class is inspected to determine if the image is
-            operated on.
-        grid
-            A grid_like object of (y,x) coordinates on which the function values are evaluated.
-        operated_only
-            By default this is None and the image is returned irrespecive of light profile class (E.g. it does not matter
-            if it is already operated or not). If this input is included as a bool, the light profile image is only
-            returned if they are or are not already operated.
-
-        Returns
-        -------
-            The 2D image, which is customized depending on whether it has been operated on.
-        """
-
-        vector = func(obj, sigma, as_instance, *args, **kwargs)
-
-        if as_instance:
-            return obj.model.instance_from_vector(
-                vector=vector, ignore_prior_limits=True
-            )
-
-        return vector
-
-    return wrapper
-
-
-def to_instance_samples(func):
-    """
-
-    Parameters
-    ----------
-    func
-
-    Returns
-    -------
-        A function that returns a 2D image.
-    """
-
-    @wraps(func)
-    def wrapper(
-        obj, sample_index, as_instance: bool = True, *args, **kwargs
-    ) -> Union[List, ModelInstance]:
-        """
-        This decorator checks if a light profile is a `LightProfileOperated` class and therefore already has had operations like a
-        PSF convolution performed.
-
-        This is compared to the `only_operated` input to determine if the image of that light profile is returned, or
-        an array of zeros.
-
-        Parameters
-        ----------
-        obj
-            A light profile with an `image_2d_from` function whose class is inspected to determine if the image is
-            operated on.
-        grid
-            A grid_like object of (y,x) coordinates on which the function values are evaluated.
-        operated_only
-            By default this is None and the image is returned irrespecive of light profile class (E.g. it does not matter
-            if it is already operated or not). If this input is included as a bool, the light profile image is only
-            returned if they are or are not already operated.
-
-        Returns
-        -------
-            The 2D image, which is customized depending on whether it has been operated on.
-        """
-
-        vector = func(obj, sample_index, as_instance, *args, **kwargs)
-
-        if as_instance:
-            return obj.model.instance_from_vector(
-                vector=vector, ignore_prior_limits=True
-            )
-
-        return vector
-
-    return wrapper
-
-
-def to_instance_input(func):
-    """
-
-    Parameters
-    ----------
-    func
-
-    Returns
-    -------
-        A function that returns a 2D image.
-    """
-
-    @wraps(func)
-    def wrapper(
-        obj, input_vector, as_instance: bool = True, *args, **kwargs
-    ) -> Union[List, ModelInstance]:
-        """
-        This decorator checks if a light profile is a `LightProfileOperated` class and therefore already has had operations like a
-        PSF convolution performed.
-
-        This is compared to the `only_operated` input to determine if the image of that light profile is returned, or
-        an array of zeros.
-
-        Parameters
-        ----------
-        obj
-            A light profile with an `image_2d_from` function whose class is inspected to determine if the image is
-            operated on.
-        grid
-            A grid_like object of (y,x) coordinates on which the function values are evaluated.
-        operated_only
-            By default this is None and the image is returned irrespecive of light profile class (E.g. it does not matter
-            if it is already operated or not). If this input is included as a bool, the light profile image is only
-            returned if they are or are not already operated.
-
-        Returns
-        -------
-            The 2D image, which is customized depending on whether it has been operated on.
-        """
-
-        vector = func(obj, input_vector, as_instance, *args, **kwargs)
-
-        if as_instance:
-            return obj.model.instance_from_vector(
-                vector=vector, ignore_prior_limits=True
-            )
-
-        return vector
-
-    return wrapper
 
 
 class Samples(SamplesInterface, ABC):
@@ -217,6 +57,10 @@ class Samples(SamplesInterface, ABC):
         self.sample_list = sample_list
         self.samples_info = samples_info
         self.search_internal = search_internal
+
+    @property
+    def derived_quantities_list(self):
+        return [sample for sample in self.sample_list]
 
     @property
     def log_evidence(self):
@@ -514,7 +358,7 @@ class Samples(SamplesInterface, ABC):
         return most_likely_sample
 
     @to_instance
-    def max_log_likelihood(self, as_instance: bool = True) -> List[float]:
+    def max_log_likelihood(self) -> List[float]:
         """
         The parameters of the maximum log likelihood sample of the `NonLinearSearch` returned as a model instance or
         list of values.
@@ -538,16 +382,14 @@ class Samples(SamplesInterface, ABC):
         return int(np.argmax(self.log_posterior_list))
 
     @to_instance
-    def max_log_posterior(self, as_instance: bool = True) -> ModelInstance:
+    def max_log_posterior(self) -> ModelInstance:
         """
         The parameters of the maximum log posterior sample of the `NonLinearSearch` returned as a model instance.
         """
         return self.parameter_lists[self.max_log_posterior_index]
 
-    @to_instance_samples
-    def from_sample_index(
-        self, sample_index: int, as_instance: bool = True
-    ) -> ModelInstance:
+    @to_instance
+    def from_sample_index(self, sample_index: int) -> ModelInstance:
         """
         The parameters of an individual sample of the non-linear search, returned as a model instance.
 

--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -59,8 +59,28 @@ class Samples(SamplesInterface, ABC):
         self.search_internal = search_internal
 
     @property
+    def instances(self):
+        return [
+            self.model.instance_from_vector(
+                sample.parameter_lists_for_paths(
+                    self.paths if sample.is_path_kwargs else self.names
+                )
+            )
+            for sample in self.sample_list
+        ]
+
+    @property
     def derived_quantities_list(self):
-        return [sample for sample in self.sample_list]
+        derived_quantities_list = []
+        for instance in self.instances:
+            instance_derived_quantities = []
+            for derived_quantity in self.model.derived_quantities:
+                obj = instance
+                for name in derived_quantity:
+                    obj = getattr(obj, name)
+                instance_derived_quantities.append(obj)
+            derived_quantities_list.append(instance_derived_quantities)
+        return derived_quantities_list
 
     @property
     def log_evidence(self):

--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -70,16 +70,16 @@ class Samples(SamplesInterface, ABC):
         ]
 
     def derived_quantities_for_instances(self, instances):
-        derived_quantities_list = []
-        for instance in instances:
-            instance_derived_quantities = []
-            for derived_quantity in self.model.derived_quantities:
-                obj = instance
-                for name in derived_quantity:
-                    obj = getattr(obj, name)
-                instance_derived_quantities.append(obj)
-            derived_quantities_list.append(instance_derived_quantities)
-        return derived_quantities_list
+        return list(map(self.derived_quantities_for_instance, instances))
+
+    def derived_quantities_for_instance(self, instance):
+        instance_derived_quantities = []
+        for derived_quantity in self.model.derived_quantities:
+            obj = instance
+            for name in derived_quantity:
+                obj = getattr(obj, name)
+            instance_derived_quantities.append(obj)
+        return instance_derived_quantities
 
     @property
     def derived_quantities_list(self):

--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -60,6 +60,9 @@ class Samples(SamplesInterface, ABC):
 
     @property
     def instances(self):
+        """
+        One model instance for each sample
+        """
         return [
             self.model.instance_from_vector(
                 sample.parameter_lists_for_paths(
@@ -69,10 +72,34 @@ class Samples(SamplesInterface, ABC):
             for sample in self.sample_list
         ]
 
-    def derived_quantities_for_instances(self, instances):
+    def derived_quantities_for_instances(self, instances) -> List[List[float]]:
+        """
+        The derived quantities of the model for each sample
+
+        Parameters
+        ----------
+        instances
+            The model instances for each sample
+
+        Returns
+        -------
+        The derived quantities of the model for each sample
+        """
         return list(map(self.derived_quantities_for_instance, instances))
 
-    def derived_quantities_for_instance(self, instance):
+    def derived_quantities_for_instance(self, instance) -> List[float]:
+        """
+        The derived quantities of the model for a single sample
+
+        Parameters
+        ----------
+        instance
+            The model instance for a single sample
+
+        Returns
+        -------
+        The derived quantities of the model for a single sample
+        """
         instance_derived_quantities = []
         for derived_quantity in self.model.derived_quantities:
             obj = instance
@@ -82,8 +109,26 @@ class Samples(SamplesInterface, ABC):
         return instance_derived_quantities
 
     @property
-    def derived_quantities_list(self):
+    def derived_quantities_list(self) -> List[List[float]]:
+        """
+        The derived quantities of the model for each sample
+        """
         return self.derived_quantities_for_instances(self.instances)
+
+    @property
+    def derived_quantities_summary_dict(self) -> dict:
+        """
+        A summary of the derived quantities of the model.
+        """
+        return {
+            "max_log_likelihood_sample": {
+                ".".join(derived_quantity): value
+                for derived_quantity, value in zip(
+                    self.model.derived_quantities,
+                    self.derived_quantities_for_instance(self.max_log_likelihood()),
+                )
+            }
+        }
 
     @property
     def log_evidence(self):

--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -69,10 +69,9 @@ class Samples(SamplesInterface, ABC):
             for sample in self.sample_list
         ]
 
-    @property
-    def derived_quantities_list(self):
+    def derived_quantities_for_instances(self, instances):
         derived_quantities_list = []
-        for instance in self.instances:
+        for instance in instances:
             instance_derived_quantities = []
             for derived_quantity in self.model.derived_quantities:
                 obj = instance
@@ -81,6 +80,10 @@ class Samples(SamplesInterface, ABC):
                 instance_derived_quantities.append(obj)
             derived_quantities_list.append(instance_derived_quantities)
         return derived_quantities_list
+
+    @property
+    def derived_quantities_list(self):
+        return self.derived_quantities_for_instances(self.instances)
 
     @property
     def log_evidence(self):

--- a/autofit/non_linear/samples/summary.py
+++ b/autofit/non_linear/samples/summary.py
@@ -28,11 +28,8 @@ class SamplesSummary(SamplesInterface):
         """
         super().__init__(model=model)
         self._max_log_likelihood_sample = max_log_likelihood_sample
-        self._covariance_matrix = covariance_matrix
+        self.covariance_matrix = covariance_matrix
         self._log_evidence = log_evidence
-
-    def covariance_matrix(self) -> np.ndarray:
-        return self._covariance_matrix
 
     @property
     def max_log_likelihood_sample(self):

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -916,7 +916,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             return samples
 
         if self.is_master:
-            self.paths.samples_to_csv(samples=samples)
+            self.paths.save_samples(samples=samples)
 
             if not self.skip_save_samples:
                 self.paths.save_json("samples_summary", to_dict(samples.summary()))

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -759,6 +759,9 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
                 if not self.skip_save_samples:
                     self.paths.save_json("samples_summary", to_dict(samples.summary()))
+                    self.paths.save_json(
+                        "derived_summary", samples.derived_quantities_summary_dict
+                    )
 
                 analysis.save_results(paths=self.paths, result=result)
 
@@ -923,6 +926,9 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
             if not self.skip_save_samples:
                 self.paths.save_json("samples_summary", to_dict(samples.summary()))
+                self.paths.save_json(
+                    "derived_summary", samples.derived_quantities_summary_dict
+                )
 
             self.perform_visualization(
                 model=model,

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -918,6 +918,9 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         if self.is_master:
             self.paths.save_samples(samples=samples)
 
+            if not during_analysis:
+                self.paths.save_derived_quantities(samples=samples)
+
             if not self.skip_save_samples:
                 self.paths.save_json("samples_summary", to_dict(samples.summary()))
 

--- a/autofit/text/samples_text.py
+++ b/autofit/text/samples_text.py
@@ -47,7 +47,13 @@ def summary(
     return f"\n\nSummary ({sigma} sigma limits):\n\n{sigma_formatter.text}"
 
 
-def derived_quantity_summary(samples, sigma=3.0, median_pdf_model=True) -> str:
+def derived_quantity_summary(
+    samples,
+    sigma=3.0,
+    indent=1,
+    median_pdf_model=True,
+    line_length=None,
+) -> str:
     """
     Create a string summarizing the results of the `NonLinearSearch` at an input sigma value.
 
@@ -72,8 +78,12 @@ def derived_quantity_summary(samples, sigma=3.0, median_pdf_model=True) -> str:
 
     parameter_names = list(zip(*samples.model.derived_quantities))[-1]
 
+    if line_length is None:
+        line_length = len(max(parameter_names, key=len)) + 8
+
     sigma_formatter = frm.TextFormatter(
-        indent=1, line_length=len(max(parameter_names, key=len)) + 8
+        indent=indent,
+        line_length=line_length,
     )
 
     for i, prior_path in enumerate(samples.model.derived_quantities):

--- a/autofit/text/samples_text.py
+++ b/autofit/text/samples_text.py
@@ -4,8 +4,8 @@ from autofit.text import formatter as frm
 
 logger = logging.getLogger(__name__)
 
-def values_from_samples(samples, median_pdf_model):
 
+def values_from_samples(samples, median_pdf_model):
     if median_pdf_model:
         return samples.median_pdf(as_instance=False)
     return samples.max_log_likelihood(as_instance=False)
@@ -22,7 +22,8 @@ def summary(
     Parameters
     ----------
     sigma
-        The sigma within which the PDF is used to estimate errors (e.g. sigma = 1.0 uses 0.6826 of the PDF)."""
+        The sigma within which the PDF is used to estimate errors (e.g. sigma = 1.0 uses 0.6826 of the PDF).
+    """
 
     values = values_from_samples(samples=samples, median_pdf_model=median_pdf_model)
     values_at_sigma = samples.values_at_sigma(sigma=sigma, as_instance=False)
@@ -35,7 +36,47 @@ def summary(
     sigma_formatter = frm.TextFormatter(indent=indent, line_length=line_length)
 
     for i, prior_path in enumerate(samples.model.unique_prior_paths):
+        value_result = frm.value_result_string_from(
+            parameter_name=parameter_names[i],
+            value=values[i],
+            values_at_sigma=values_at_sigma[i],
+        )
 
+        sigma_formatter.add(prior_path, value_result)
+
+    return f"\n\nSummary ({sigma} sigma limits):\n\n{sigma_formatter.text}"
+
+
+def derived_quantity_summary(samples, sigma=3.0, median_pdf_model=True) -> str:
+    """
+    Create a string summarizing the results of the `NonLinearSearch` at an input sigma value.
+
+    This function is used for creating the model.results files of a non-linear search.
+
+    Parameters
+    ----------
+    sigma
+        The sigma within which the PDF is used to estimate errors (e.g. sigma = 1.0 uses 0.6826 of the PDF).
+    """
+
+    instance = (
+        samples.median_pdf() if median_pdf_model else samples.max_log_likelihood()
+    )
+    values = samples.derived_quantities_for_instance(instance)
+
+    sigma_values = samples.values_at_sigma(sigma=sigma, as_instance=False)
+    lower, upper = map(samples.model.instance_from_vector, zip(*sigma_values))
+    values_at_sigma = list(
+        zip(*map(samples.derived_quantities_for_instance, [lower, upper]))
+    )
+
+    parameter_names = list(zip(*samples.model.derived_quantities))[-1]
+
+    sigma_formatter = frm.TextFormatter(
+        indent=1, line_length=len(max(parameter_names, key=len)) + 8
+    )
+
+    for i, prior_path in enumerate(samples.model.derived_quantities):
         value_result = frm.value_result_string_from(
             parameter_name=parameter_names[i],
             value=values[i],
@@ -48,14 +89,14 @@ def summary(
 
 
 def latex(
-        samples,
-        median_pdf_model=True,
-        sigma=3.0,
-        name_to_label=True,
-        include_name=True,
-        include_quickmath=False,
-        prefix="",
-        suffix=""
+    samples,
+    median_pdf_model=True,
+    sigma=3.0,
+    name_to_label=True,
+    include_name=True,
+    include_quickmath=False,
+    prefix="",
+    suffix="",
 ) -> str:
     """
     Create a string summarizing the results of the `NonLinearSearch` at an input sigma value.
@@ -65,7 +106,8 @@ def latex(
     Parameters
     ----------
     sigma
-        The sigma within which the PDF is used to estimate errors (e.g. sigma = 1.0 uses 0.6826 of the PDF)."""
+        The sigma within which the PDF is used to estimate errors (e.g. sigma = 1.0 uses 0.6826 of the PDF).
+    """
 
     values = values_from_samples(samples=samples, median_pdf_model=median_pdf_model)
     errors_at_sigma = samples.errors_at_sigma(sigma=sigma, as_instance=False)
@@ -73,7 +115,6 @@ def latex(
     table = []
 
     for i in range(samples.model.prior_count):
-
         label_value = frm.parameter_result_latex_from(
             parameter_name=samples.model.parameter_names[i],
             value=values[i],
@@ -81,7 +122,7 @@ def latex(
             superscript=samples.model.superscripts[i],
             name_to_label=name_to_label,
             include_name=include_name,
-            include_quickmath=include_quickmath
+            include_quickmath=include_quickmath,
         )
 
         table.append(f"{label_value}")

--- a/autofit/text/text_util.py
+++ b/autofit/text/text_util.py
@@ -12,6 +12,43 @@ def padding(item, target=6):
     return f"{prefix}{string}"
 
 
+def derived_info_from(samples) -> str:
+    results = ["Maximum Log Likelihood Model:\n\n"]
+
+    formatter = frm.TextFormatter(line_length=info_whitespace())
+
+    max_log_likelihood_instance = samples.max_log_likelihood()
+    quantities = samples.derived_quantities_for_instance(max_log_likelihood_instance)
+
+    for path, value in zip(
+        samples.model.derived_quantities,
+        quantities,
+    ):
+        formatter.add(path, format_str().format(value))
+    results += [formatter.text + "\n"]
+
+    if hasattr(samples, "pdf_converged"):
+        if samples.pdf_converged:
+            results += samples_text.derived_quantity_summary(
+                samples=samples, sigma=3.0, indent=4, line_length=info_whitespace()
+            )
+            results += ["\n"]
+            results += samples_text.derived_quantity_summary(
+                samples=samples, sigma=1.0, indent=4, line_length=info_whitespace()
+            )
+
+        else:
+            results += [
+                "\n WARNING: The samples have not converged enough to compute a PDF and model errors. \n "
+                "The model below over estimates errors. \n\n"
+            ]
+            results += samples_text.derived_quantity_summary(
+                samples=samples, sigma=1.0, indent=4, line_length=info_whitespace()
+            )
+
+    return "".join(results)
+
+
 def result_info_from(samples) -> str:
     """
     Output the full model.results file, which include the most-likely model, most-probable model at 1 and 3
@@ -112,10 +149,10 @@ def search_summary_to_file(samples, log_likelihood_function_time, filename):
         f"Log Likelihood Function Evaluation Time (seconds) = {log_likelihood_function_time}\n"
     )
 
-    expected_time = dt.timedelta(seconds=float(samples.total_samples * log_likelihood_function_time))
-    summary.append(
-        f"Expected Time To Run (seconds) = {expected_time}\n"
+    expected_time = dt.timedelta(
+        seconds=float(samples.total_samples * log_likelihood_function_time)
     )
+    summary.append(f"Expected Time To Run (seconds) = {expected_time}\n")
 
     try:
         speed_up_factor = float(expected_time.total_seconds()) / float(samples.time)

--- a/autofit/text/text_util.py
+++ b/autofit/text/text_util.py
@@ -13,6 +13,10 @@ def padding(item, target=6):
 
 
 def derived_info_from(samples) -> str:
+    """
+    Format a string describing the values of derived quantities associated with the model
+    at the maximum log likelihood model, 1 sigma and 3 sigma error estimates.
+    """
     results = ["Maximum Log Likelihood Model:\n\n"]
 
     formatter = frm.TextFormatter(line_length=info_whitespace())

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -1,7 +1,7 @@
 import pytest
 
 import autofit as af
-from autofit import Samples, DirectoryPaths, DatabasePaths, SamplesPDF
+from autofit import DirectoryPaths, DatabasePaths, SamplesPDF
 from autofit.text.samples_text import derived_quantity_summary
 from autofit.text.text_util import derived_info_from
 

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -1,10 +1,16 @@
-from autofit import Gaussian
+import autofit as af
 
 
 def test_derived_quantities():
-    gaussian = Gaussian()
+    gaussian = af.Gaussian()
 
     assert gaussian.upper_bound == 0.05
 
     gaussian.upper_bound = 0.1
     assert gaussian.upper_bound == 0.1
+
+
+def test_model_derived_quantities():
+    model = af.Model(af.Gaussian)
+
+    assert len(model.derived_quantities) == 2

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -1,0 +1,10 @@
+from autofit import Gaussian
+
+
+def test_derived_quantities():
+    gaussian = Gaussian()
+
+    assert gaussian.upper_bound == 0.05
+
+    gaussian.upper_bound = 0.1
+    assert gaussian.upper_bound == 0.1

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -126,3 +126,12 @@ Summary (1.0 sigma limits):
 lower_bound                                                                     -5.0000 (-5.0000, -5.0000)
 upper_bound                                                                     5.0000 (5.0000, 5.0000)"""
     )
+
+
+def test_derived_quantities_summary_dict(samples):
+    assert samples.derived_quantities_summary_dict == {
+        "max_log_likelihood_sample": {
+            "lower_bound": -5.0,
+            "upper_bound": 5.0,
+        },
+    }

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -3,6 +3,7 @@ import pytest
 import autofit as af
 from autofit import Samples, DirectoryPaths, DatabasePaths, SamplesPDF
 from autofit.text.samples_text import derived_quantity_summary
+from autofit.text.text_util import derived_info_from
 
 
 def test_derived_quantities():
@@ -104,4 +105,24 @@ Summary (3.0 sigma limits):
 
 lower_bound        -5.0000 (-5.0000, -5.0000)
 upper_bound        5.0000 (5.0000, 5.0000)"""
+    )
+
+
+def test_derived_info_from(samples):
+    assert (
+        derived_info_from(samples)
+        == """Maximum Log Likelihood Model:
+
+lower_bound                                                                     -5.000
+upper_bound                                                                     5.000
+
+ WARNING: The samples have not converged enough to compute a PDF and model errors. 
+ The model below over estimates errors. 
+
+
+
+Summary (1.0 sigma limits):
+
+lower_bound                                                                     -5.0000 (-5.0000, -5.0000)
+upper_bound                                                                     5.0000 (5.0000, 5.0000)"""
     )

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -1,7 +1,8 @@
 import pytest
 
 import autofit as af
-from autofit import Samples, DirectoryPaths, DatabasePaths
+from autofit import Samples, DirectoryPaths, DatabasePaths, SamplesPDF
+from autofit.text.samples_text import derived_quantity_summary
 
 
 def test_derived_quantities():
@@ -57,7 +58,7 @@ def make_model():
 
 @pytest.fixture(name="samples")
 def make_samples(model):
-    return Samples(
+    return SamplesPDF(
         model=model,
         sample_list=[
             af.Sample(
@@ -92,3 +93,15 @@ def test_persist_database(samples, model, session):
     paths.save_derived_quantities(samples)
 
     assert paths.fit["derived_quantities"].shape == (1, 2)
+
+
+def test_summary(samples):
+    assert (
+        derived_quantity_summary(samples, median_pdf_model=False)
+        == """
+
+Summary (3.0 sigma limits):
+
+lower_bound        -5.0000 (-5.0000, -5.0000)
+upper_bound        5.0000 (5.0000, 5.0000)"""
+    )

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -60,9 +60,11 @@ def test_samples():
                 weight=3.0,
                 kwargs={
                     "centre": 0.0,
+                    "normalization": 1.0,
+                    "sigma": 1.0,
                 },
             ),
         ],
     )
     derived_quantities = samples.derived_quantities_list[0]
-    assert derived_quantities["upper_bound"] == 0.05
+    assert derived_quantities == [-5.0, 5.0]

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -1,4 +1,5 @@
 import autofit as af
+from autofit import Samples
 
 
 def test_derived_quantities():
@@ -47,3 +48,21 @@ def test_multiple_levels():
         ("two", "three", "upper_bound"),
         ("two", "three", "lower_bound"),
     }
+
+
+def test_samples():
+    samples = Samples(
+        model=af.Model(af.Gaussian),
+        sample_list=[
+            af.Sample(
+                log_likelihood=1.0,
+                log_prior=2.0,
+                weight=3.0,
+                kwargs={
+                    "centre": 0.0,
+                },
+            ),
+        ],
+    )
+    derived_quantities = samples.derived_quantities_list[0]
+    assert derived_quantities["upper_bound"] == 0.05

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -13,7 +13,10 @@ def test_derived_quantities():
 def test_model_derived_quantities():
     model = af.Model(af.Gaussian)
 
-    assert len(model.derived_quantities) == 2
+    assert set(model.derived_quantities) == {
+        ("upper_bound",),
+        ("lower_bound",),
+    }
 
 
 def test_embedded_derived_quantities():
@@ -22,4 +25,25 @@ def test_embedded_derived_quantities():
         two=af.Gaussian,
     )
 
-    assert len(collection.derived_quantities) == 4
+    assert set(collection.derived_quantities) == {
+        ("one", "upper_bound"),
+        ("one", "lower_bound"),
+        ("two", "upper_bound"),
+        ("two", "lower_bound"),
+    }
+
+
+def test_multiple_levels():
+    collection = af.Collection(
+        one=af.Gaussian,
+        two=af.Collection(
+            three=af.Gaussian,
+        ),
+    )
+
+    assert set(collection.derived_quantities) == {
+        ("one", "upper_bound"),
+        ("one", "lower_bound"),
+        ("two", "three", "upper_bound"),
+        ("two", "three", "lower_bound"),
+    }

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -14,3 +14,12 @@ def test_model_derived_quantities():
     model = af.Model(af.Gaussian)
 
     assert len(model.derived_quantities) == 2
+
+
+def test_embedded_derived_quantities():
+    collection = af.Collection(
+        one=af.Gaussian,
+        two=af.Gaussian,
+    )
+
+    assert len(collection.derived_quantities) == 4

--- a/test_autofit/non_linear/samples/test_pdf.py
+++ b/test_autofit/non_linear/samples/test_pdf.py
@@ -477,7 +477,7 @@ def test__covariance_matrix(make_samples):
         parameters=[[2.0, 2.0], [1.0, 1.0], [0.0, 0.0]],
     )
 
-    assert samples_x5.covariance_matrix() == pytest.approx(
+    assert samples_x5.covariance_matrix == pytest.approx(
         np.array([[1.0, 1.0], [1.0, 1.0]]), 1.0e-4
     )
 
@@ -485,7 +485,7 @@ def test__covariance_matrix(make_samples):
 
     samples_x5 = make_samples(parameters)
 
-    assert samples_x5.covariance_matrix() == pytest.approx(
+    assert samples_x5.covariance_matrix == pytest.approx(
         np.array([[1.0, -1.0], [-1.0, 1.0]]), 1.0e-4
     )
 
@@ -494,6 +494,6 @@ def test__covariance_matrix(make_samples):
         weight_list=[0.1, 0.2, 0.3],
     )
 
-    assert samples_x5.covariance_matrix() == pytest.approx(
+    assert samples_x5.covariance_matrix == pytest.approx(
         np.array([[0.90909, -0.90909], [-0.90909, 0.90909]]), 1.0e-4
     )

--- a/test_autofit/serialise/test_samples.py
+++ b/test_autofit/serialise/test_samples.py
@@ -53,15 +53,6 @@ def test_summary(summary, model, sample):
 def make_summary_dict():
     return {
         "arguments": {
-            "covariance_matrix": {
-                "array": [
-                    [2.0, 3.0, 3.9999999999999996],
-                    [3.0, 4.5, 6.0],
-                    [4.0, 6.0, 7.999999999999999],
-                ],
-                "dtype": "float64",
-                "type": "ndarray",
-            },
             "log_evidence": None,
             "max_log_likelihood_sample": {
                 "arguments": {

--- a/test_autofit/serialise/test_samples.py
+++ b/test_autofit/serialise/test_samples.py
@@ -46,13 +46,22 @@ def make_summary(samples_pdf):
 def test_summary(summary, model, sample):
     assert summary.model is model
     assert summary.max_log_likelihood_sample == sample
-    assert isinstance(summary.covariance_matrix(), np.ndarray)
+    assert isinstance(summary.covariance_matrix, np.ndarray)
 
 
 @pytest.fixture(name="summary_dict")
 def make_summary_dict():
     return {
         "arguments": {
+            "covariance_matrix": {
+                "array": [
+                    [2.0, 3.0, 3.9999999999999996],
+                    [3.0, 4.5, 6.0],
+                    [4.0, 6.0, 7.999999999999999],
+                ],
+                "dtype": "float64",
+                "type": "ndarray",
+            },
             "log_evidence": None,
             "max_log_likelihood_sample": {
                 "arguments": {
@@ -107,7 +116,7 @@ def test_from_dict(summary_dict):
     assert isinstance(summary, SamplesSummary)
     assert isinstance(summary.model, af.Model)
     assert isinstance(summary.max_log_likelihood_sample, af.Sample)
-    assert isinstance(summary.covariance_matrix(), np.ndarray)
+    assert isinstance(summary.covariance_matrix, np.ndarray)
 
     assert isinstance(summary.max_log_likelihood(), af.Gaussian)
 
@@ -117,7 +126,7 @@ def test_generic_from_dict(summary_dict):
     assert isinstance(summary, SamplesSummary)
     assert isinstance(summary.model, af.Model)
     assert isinstance(summary.max_log_likelihood_sample, af.Sample)
-    assert isinstance(summary.covariance_matrix(), np.ndarray)
+    assert isinstance(summary.covariance_matrix, np.ndarray)
 
 
 def test_covariance_interpolator(summary):


### PR DESCRIPTION
- Mark derived quanities using a decorator

```python
class Gaussian:
    ...
    @derived_quantity
    def my_quantity(self):
        ...
```

If these values are computed they are cached.

Values for each sample are output to derived_quantities.csv. They are also added to the database as an array with the same name.

derived.results are output for the highest likelihood sample along with 1 and 3 sigma

Currently derived quantities are not used for efficiency when aggegating. Derived quantities are computed for each sample when an optimisation completes

Partially resolves #908
