### PR TITLE
model.paramnames file no longer output

### DIFF
--- a/autofit/non_linear/paths/directory.py
+++ b/autofit/non_linear/paths/directory.py
@@ -239,7 +239,6 @@ class DirectoryPaths(AbstractPaths):
         self.save_identifier()
         self.save_parent_identifier()
         self._save_model_info(model=self.model)
-        self._save_parameter_names_file(model=self.model)
         if info:
             self.save_json("info", info)
         self.save_json("search", to_dict(self.search))

--- a/autofit/non_linear/samples/pdf.py
+++ b/autofit/non_linear/samples/pdf.py
@@ -407,6 +407,7 @@ class SamplesPDF(Samples):
         """
         if len(self.parameter_lists) == 1:
             return np.eye(1)
+        
         return np.cov(m=self.parameter_lists, rowvar=False, aweights=self.weight_list)
 
     def save_covariance_matrix(self, filename: Union[Path, str]):


### PR DESCRIPTION
GetDist uses a `model.paramnames` file to load the name of every parameter in the model-fit and pair it with the
latex symbol used to represent it in plots.

This file is not created by autofit by default anymore.

The function to create this file is retained as users using GetDist will call it independently.