### PR TITLE
feature/custom derived quantities

### DIFF
--- a/autofit/database/model/prior.py
+++ b/autofit/database/model/prior.py
@@ -63,30 +63,14 @@ class Model(Object):
                 for i, assertion in enumerate(model.assertions)
             ]
         )
-        if model.custom_derived_quantities:
-            instance._add_children(
-                [
-                    (
-                        "custom_derived_quantities",
-                        Collection.from_object(
-                            model.custom_derived_quantities,
-                            name="custom_derived_quantities",
-                        ),
-                    )
-                ]
-            )
         return instance
 
     def _make_instance(self):
         instance = object.__new__(prior_model.Model)
         instance.cls = self.cls
         instance._assertions = []
-        try:
-            instance._custom_derived_quantities = (
-                self.custom_derived_quantities.children
-            )
-        except AttributeError:
-            instance._custom_derived_quantities = {}
+
+        instance._custom_derived_quantities = {}
         return instance
 
 

--- a/autofit/database/model/prior.py
+++ b/autofit/database/model/prior.py
@@ -63,12 +63,30 @@ class Model(Object):
                 for i, assertion in enumerate(model.assertions)
             ]
         )
+        if model.custom_derived_quantities:
+            instance._add_children(
+                [
+                    (
+                        "custom_derived_quantities",
+                        Collection.from_object(
+                            model.custom_derived_quantities,
+                            name="custom_derived_quantities",
+                        ),
+                    )
+                ]
+            )
         return instance
 
     def _make_instance(self):
         instance = object.__new__(prior_model.Model)
         instance.cls = self.cls
         instance._assertions = []
+        try:
+            instance._custom_derived_quantities = (
+                self.custom_derived_quantities.children
+            )
+        except AttributeError:
+            instance._custom_derived_quantities = {}
         return instance
 
 

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -163,6 +163,10 @@ class AbstractPriorModel(AbstractModel):
         self._custom_derived_quantities = custom_derived_quantities or dict()
 
     @property
+    def custom_derived_quantities(self):
+        return self._custom_derived_quantities
+
+    @property
     def assertions(self):
         return self._assertions
 
@@ -1317,7 +1321,7 @@ class AbstractPriorModel(AbstractModel):
         instance = self._instance_for_arguments(
             arguments,
         )
-        for key, value in self._custom_derived_quantities.items():
+        for key, value in self.custom_derived_quantities.items():
             setattr(instance, key, value(instance))
         return instance
 

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -157,9 +157,10 @@ class AbstractPriorModel(AbstractModel):
     @DynamicAttrs
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, custom_derived_quantities=None):
         super().__init__(label=label)
         self._assertions = list()
+        self._custom_derived_quantities = custom_derived_quantities or dict()
 
     @property
     def assertions(self):
@@ -1313,9 +1314,12 @@ class AbstractPriorModel(AbstractModel):
             self.check_assertions(arguments)
 
         logger.debug(f"Creating an instance for arguments")
-        return self._instance_for_arguments(
+        instance = self._instance_for_arguments(
             arguments,
         )
+        for key, value in self._custom_derived_quantities.items():
+            setattr(instance, key, value(instance))
+        return instance
 
     def path_for_name(self, name: str) -> Tuple[str, ...]:
         """

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -249,7 +249,7 @@ class Model(AbstractPriorModel):
                 for key, value in self.cls.__dict__.items()
                 if isinstance(value, derived_quantity)
             ]
-            + [(key,) for key in self._custom_derived_quantities.keys()]
+            + [(key,) for key in self.custom_derived_quantities.keys()]
         )
 
     def instance_flatten(self, instance):

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -55,7 +55,7 @@ class Model(AbstractPriorModel):
             )
         return super().__add__(other)
 
-    def __init__(self, cls, **kwargs):
+    def __init__(self, cls, custom_derived_quantities=None, **kwargs):
         """
         The object a Python class is input into to create a model-component, which has free parameters that are fitted
         by a non-linear search.
@@ -98,7 +98,10 @@ class Model(AbstractPriorModel):
 
         model = af.Model(Gaussian)
         """
-        super().__init__(label=namer(cls.__name__) if inspect.isclass(cls) else None)
+        super().__init__(
+            label=namer(cls.__name__) if inspect.isclass(cls) else None,
+            custom_derived_quantities=custom_derived_quantities,
+        )
         if cls is self:
             return
 

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -87,6 +87,9 @@ class Model(AbstractPriorModel):
         ----------
         cls
             The class associated with this instance
+        custom_derived_quantities
+            A dictionary of quantities that can be derived from the model and should
+            be output as derived quantities.
 
         Examples
         --------
@@ -239,11 +242,15 @@ class Model(AbstractPriorModel):
         The paths to attributes of the model which are derived (i.e.
         methods marked with the derived_quantity decorator)
         """
-        return super().derived_quantities + [
-            (key,)
-            for key, value in self.cls.__dict__.items()
-            if isinstance(value, derived_quantity)
-        ]
+        return (
+            super().derived_quantities
+            + [
+                (key,)
+                for key, value in self.cls.__dict__.items()
+                if isinstance(value, derived_quantity)
+            ]
+            + [(key,) for key in self._custom_derived_quantities.keys()]
+        )
 
     def instance_flatten(self, instance):
         """

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -55,7 +55,14 @@ class Model(AbstractPriorModel):
             )
         return super().__add__(other)
 
-    def __init__(self, cls, custom_derived_quantities=None, **kwargs):
+    def __init__(
+        self,
+        cls,
+        custom_derived_quantities: typing.Optional[
+            typing.Dict[str, typing.Callable]
+        ] = None,
+        **kwargs,
+    ):
         """
         The object a Python class is input into to create a model-component, which has free parameters that are fitted
         by a non-linear search.

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -123,3 +123,14 @@ def test_derived_quantities_summary_dict(samples):
             "fwhm": 2.3548200450309493,
         },
     }
+
+
+def test_custom_derived_quantity():
+    model = af.Model(
+        af.Gaussian,
+        custom_derived_quantities={
+            "custom": lambda instance: 1.0,
+        },
+    )
+    instance = model.instance_from_prior_medians()
+    assert instance.custom == 1.0

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -146,3 +146,22 @@ def test_custom_derived_in_list(custom_model):
         ("fwhm",),
         ("custom",),
     }
+
+
+def test_custom_derived_samples(samples, custom_model):
+    samples.model = custom_model
+    derived_quantities = samples.derived_quantities_list[0]
+    assert derived_quantities == [2.3548200450309493, 0.0]
+
+
+def test_custom_derived_summary(samples, custom_model):
+    samples.model = custom_model
+    assert (
+        derived_quantity_summary(samples, median_pdf_model=False)
+        == """
+
+Summary (3.0 sigma limits):
+
+fwhm          2.3548 (2.3548, 2.3548)
+custom        0.0000 (0.0000, 0.0000)"""
+    )

--- a/test_autofit/mapper/model/test_derived_quantities.py
+++ b/test_autofit/mapper/model/test_derived_quantities.py
@@ -125,12 +125,24 @@ def test_derived_quantities_summary_dict(samples):
     }
 
 
-def test_custom_derived_quantity():
-    model = af.Model(
+@pytest.fixture(name="custom_model")
+def make_custom_model():
+    return af.Model(
         af.Gaussian,
         custom_derived_quantities={
-            "custom": lambda instance: 1.0,
+            "custom": lambda instance: 2 * instance.centre,
         },
     )
-    instance = model.instance_from_prior_medians()
+
+
+def test_custom_derived_quantity(custom_model):
+    instance = custom_model.instance_from_prior_medians()
+    assert instance.centre == 0.5
     assert instance.custom == 1.0
+
+
+def test_custom_derived_in_list(custom_model):
+    assert set(custom_model.derived_quantities) == {
+        ("fwhm",),
+        ("custom",),
+    }


### PR DESCRIPTION
Adds the ability to define custom derived quantities as an argument of during model creation.

```python
model = af.Model(
    af.Gaussian,
    custom_derived_quantities={
        "custom": lambda instance: 2 * instance.centre,
    },
}
```

These quantities are computed at instantiation and associated with the instance. They appear in the output in the same way as ordinary derived quantities but as yet are not efficiently loaded in the same way
