### PR TITLE
Correct docs for LogGaussianPrior

### DIFF
--- a/autofit/mapper/prior/log_gaussian.py
+++ b/autofit/mapper/prior/log_gaussian.py
@@ -21,7 +21,7 @@ class LogGaussianPrior(Prior):
         id_: Optional[int] = None,
     ):
         """
-        A prior with a log base 10 uniform distribution, defined between a lower limit and upper limit.
+        A prior for a variable whose logarithm is gaussian distributed. Work in natural log.
 
         The conversion of an input unit value, ``u``, to a physical value, ``p``, via the prior is as follows:
 
@@ -37,13 +37,14 @@ class LogGaussianPrior(Prior):
         Parameters
         ----------
         mean
-            The mean of the Gaussian distribution defining the prior.
+            The *natural log* of the distribution's mean.
         sigma
-            The sigma value of the Gaussian distribution defining the prior.
+            The spread of this distribution in *natural log* space, e.g. sigma=1.0 means P(ln x) has a
+            standard deviation of 1.
         lower_limit
-            A lower limit of the Gaussian distribution; physical values below this value are rejected.
+            A lower limit in *real space* (not log); physical values below this are rejected.
         upper_limit
-            A upper limit of the Gaussian distribution; physical values below this value are rejected.
+            A upper limit in *real space* (not log); physical values above this are rejected.
 
         Examples
         --------


### PR DESCRIPTION
Per discussion in #932, this corrects the documentation of LogGaussianPrior to specify that it works in natural log, not base 10.