### PR TITLE
feature/other concise examples

### DIFF
--- a/autofit/mapper/prior/arithmetic/compound.py
+++ b/autofit/mapper/prior/arithmetic/compound.py
@@ -217,6 +217,8 @@ class SumPrior(CompoundPrior):
     def __str__(self):
         return f"{self._left} + {self._right}"
 
+    __repr__ = __str__
+
 
 class MultiplePrior(CompoundPrior):
     """
@@ -225,6 +227,8 @@ class MultiplePrior(CompoundPrior):
 
     def __str__(self):
         return f"{self._left} * {self._right}"
+
+    __repr__ = __str__
 
     def _instance_for_arguments(
         self,
@@ -258,6 +262,11 @@ class DivisionPrior(CompoundPrior):
             ignore_assertions=ignore_assertions,
         )
 
+    def __str__(self):
+        return f"{self._left} / {self._right}"
+
+    __repr__ = __str__
+
 
 class FloorDivPrior(CompoundPrior):
     """
@@ -276,6 +285,11 @@ class FloorDivPrior(CompoundPrior):
             arguments,
             ignore_assertions=ignore_assertions,
         )
+
+    def __str__(self):
+        return f"{self._left} // {self._right}"
+
+    __repr__ = __str__
 
 
 class ModPrior(CompoundPrior):
@@ -296,6 +310,11 @@ class ModPrior(CompoundPrior):
             ignore_assertions=ignore_assertions,
         )
 
+    def __str__(self):
+        return f"{self._left} % {self._right}"
+
+    __repr__ = __str__
+
 
 class PowerPrior(CompoundPrior):
     """
@@ -314,6 +333,11 @@ class PowerPrior(CompoundPrior):
             arguments,
             ignore_assertions=ignore_assertions,
         )
+
+    def __str__(self):
+        return f"{self._left} ** {self._right}"
+
+    __repr__ = __str__
 
 
 class ModifiedPrior(AbstractPriorModel, ABC, ArithmeticMixin):
@@ -349,6 +373,11 @@ class ModifiedPrior(AbstractPriorModel, ABC, ArithmeticMixin):
             pass
         return new
 
+    def __str__(self):
+        return f"{self.prior}"
+
+    __repr__ = __str__
+
 
 class NegativePrior(ModifiedPrior):
     """
@@ -364,6 +393,11 @@ class NegativePrior(ModifiedPrior):
             arguments,
             ignore_assertions=ignore_assertions,
         )
+
+    def __str__(self):
+        return f"-{self.prior}"
+
+    __repr__ = __str__
 
 
 class AbsolutePrior(ModifiedPrior):
@@ -383,6 +417,11 @@ class AbsolutePrior(ModifiedPrior):
             )
         )
 
+    def __str__(self):
+        return f"abs({self.prior})"
+
+    __repr__ = __str__
+
 
 class Log(ModifiedPrior):
     """
@@ -401,6 +440,11 @@ class Log(ModifiedPrior):
             )
         )
 
+    def __str__(self):
+        return f"log({self.prior})"
+
+    __repr__ = __str__
+
 
 class Log10(ModifiedPrior):
     """
@@ -418,3 +462,8 @@ class Log10(ModifiedPrior):
                 ignore_assertions=ignore_assertions,
             )
         )
+
+    def __str__(self):
+        return f"log10({self.prior})"
+
+    __repr__ = __str__

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1655,7 +1655,11 @@ class AbstractPriorModel(AbstractModel):
                 else:
                     name = type(obj).__name__
 
-                formatter.add(("model",) + path, f"{name} (N={n})")
+                formatter.add(
+                    ("model",) + path,
+                    obj,
+                    string_value=f"{name} (N={n})",
+                )
 
         return formatter.text
 

--- a/autofit/text/formatter.py
+++ b/autofit/text/formatter.py
@@ -12,7 +12,16 @@ logger = logging.getLogger(__name__)
 class FormatNode:
     def __init__(self):
         self._dict = dict()
-        self.value = None
+        self._value = None
+        self._string_value = None
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._value = value
 
     def __getitem__(self, item):
         if item not in self._dict:
@@ -33,7 +42,7 @@ class FormatNode:
         for key, value in self.groups():
             indent_string = indent * " "
             if value.value is not None:
-                value_string = str(value.value)
+                value_string = value.string_value or str(value.value)
                 space_string = max((line_length - len(str(key))), 1) * " "
                 lines.append(f"{key}{space_string}{value_string}")
 
@@ -61,16 +70,23 @@ class TextFormatter:
         self.line_length = line_length
         self.indent = indent
 
-    def add_to_dict(self, path: Tuple[str, ...], value: str, info_dict: FormatNode):
+    def add_to_dict(
+        self,
+        path: Tuple[str, ...],
+        value: str,
+        info_dict: FormatNode,
+        string_value=None,
+    ):
         key = path[0]
         node = info_dict[key]
         if len(path) == 1:
             node.value = value
+            node.string_value = string_value
         else:
-            self.add_to_dict(path[1:], value, node)
+            self.add_to_dict(path[1:], value, node, string_value)
 
-    def add(self, path: Tuple[str, ...], value):
-        self.add_to_dict(path, value, self.dict)
+    def add(self, path: Tuple[str, ...], value, string_value=None):
+        self.add_to_dict(path, value, self.dict, string_value)
 
     @property
     def text(self):

--- a/autofit/text/formatter.py
+++ b/autofit/text/formatter.py
@@ -12,16 +12,8 @@ logger = logging.getLogger(__name__)
 class FormatNode:
     def __init__(self):
         self._dict = dict()
-        self._value = None
-        self._string_value = None
-
-    @property
-    def value(self):
-        return self._value
-
-    @value.setter
-    def value(self, value):
-        self._value = value
+        self.value = None
+        self.string_value = None
 
     def __getitem__(self, item):
         if item not in self._dict:
@@ -57,11 +49,11 @@ class FormatNode:
                     lines.append(f"{indent_string}{line}")
         return lines
 
-    def __getattr__(self, item):
-        try:
-            return getattr(self.value, item)
-        except AttributeError:
-            raise AttributeError(f"Attribute {item} not found in {self}")
+    # def __getattr__(self, item):
+    #     try:
+    #         return getattr(self.value, item)
+    #     except AttributeError:
+    #         raise AttributeError(f"Attribute {item} not found in {self}")
 
 
 class TextFormatter:
@@ -80,8 +72,8 @@ class TextFormatter:
         key = path[0]
         node = info_dict[key]
         if len(path) == 1:
-            node.value = value
             node.string_value = string_value
+            node.value = value
         else:
             self.add_to_dict(path[1:], value, node, string_value)
 

--- a/autofit/text/representative.py
+++ b/autofit/text/representative.py
@@ -164,7 +164,10 @@ class Representative:
             path_priors = obj.path_instance_tuples_for_class(
                 af.Prior, ignore_children=True
             )
-            min_id = min(pp[1].id for pp in path_priors)
+            try:
+                min_id = min(pp[1].id for pp in path_priors)
+            except ValueError:
+                min_id = 0
             blueprint += tuple(
                 (path, prior.id - min_id, cls.get_blueprint(prior))
                 for path, prior in obj.path_instance_tuples_for_class(
@@ -174,7 +177,12 @@ class Representative:
             if isinstance(obj, af.Model):
                 return blueprint + (obj.cls,)
             return blueprint
-        raise ValueError(f"Cannot get blueprint for {obj} of type {type(obj)}")
+
+        return (type(obj),) + tuple(
+            (key, value)
+            for key, value in obj.__dict__.items()
+            if key != "id" and isinstance(value, (float, int))
+        )
 
     @classmethod
     def shared_descendents(cls, objects) -> Set[Prior]:

--- a/autofit/text/representative.py
+++ b/autofit/text/representative.py
@@ -141,12 +141,16 @@ class Representative:
         from autofit.text.formatter import FormatNode
 
         if obj is None:
-            return None
+            return ()
 
         if isinstance(obj, FormatNode):
-            return cls.get_blueprint(obj.value)
+            blueprint = cls.get_blueprint(obj.value)
+            for key, value in obj.items():
+                blueprint += (key,)
+                blueprint += cls.get_blueprint(value)
+            return blueprint
         if isinstance(obj, (float, int, tuple, str)):
-            return obj
+            return (obj,)
         if isinstance(obj, af.Prior):
             return type(obj), obj.parameter_string
         if isinstance(obj, af.AbstractModel):

--- a/autofit/visualise.py
+++ b/autofit/visualise.py
@@ -148,12 +148,19 @@ class VisualiseGraph:
         -------
         A network of the model.
         """
-
         net = Network(
             notebook=notebook,
             directed=True,
             cdn_resources="remote",
         )
+        added_edges = set()
+
+        def add_edge(from_, to, label):
+            key = (from_, to, label)
+            if key in added_edges:
+                return
+            added_edges.add(key)
+            net.add_edge(from_, to, label=label)
 
         def add_model(obj, **kwargs):
             net.add_node(
@@ -207,7 +214,7 @@ class VisualiseGraph:
                     color=self.colours[type(prior)],
                     size=10,
                 )
-                net.add_edge(
+                add_edge(
                     model_name,
                     prior_name,
                     label=name,
@@ -222,7 +229,7 @@ class VisualiseGraph:
                     child_model = representative
 
                 add_component(child_model)
-                net.add_edge(
+                add_edge(
                     model_name,
                     str_for_object(child_model),
                     label=name,

--- a/autofit/visualise.py
+++ b/autofit/visualise.py
@@ -4,6 +4,7 @@ from pyvis.network import Network
 import colorsys
 
 from autoconf import cached_property
+from autofit.mapper.prior.arithmetic.compound import CompoundPrior
 
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.mapper.prior.uniform import UniformPrior
@@ -87,6 +88,7 @@ class VisualiseGraph:
             GaussianPrior,
             LogGaussianPrior,
             LogUniformPrior,
+            CompoundPrior,
         } | {model.cls for _, model in self.model.attribute_tuples_with_type(Model)}
         if isinstance(self.model, Model):
             types.add(self.model.cls)
@@ -139,6 +141,15 @@ class VisualiseGraph:
                 **kwargs,
             )
 
+        def add_compound_prior(obj, **kwargs):
+            net.add_node(
+                str_for_object(obj),
+                shape="triangle",
+                color=self.colours[CompoundPrior],
+                size=15,
+                **kwargs,
+            )
+
         def add_component(component):
             model_name = str_for_object(component)
 
@@ -146,6 +157,8 @@ class VisualiseGraph:
                 add_model(component)
             elif isinstance(component, Collection):
                 add_collection(component)
+            elif isinstance(component, CompoundPrior):
+                add_compound_prior(component)
 
             for name, representative in Representative.find_representatives(
                 component.direct_prior_tuples

--- a/autofit/visualise.py
+++ b/autofit/visualise.py
@@ -4,7 +4,20 @@ from pyvis.network import Network
 import colorsys
 
 from autoconf import cached_property
-from autofit.mapper.prior.arithmetic.compound import CompoundPrior
+from autofit.mapper.prior.arithmetic.compound import (
+    CompoundPrior,
+    SumPrior,
+    MultiplePrior,
+    DivisionPrior,
+    FloorDivPrior,
+    ModPrior,
+    PowerPrior,
+    ModifiedPrior,
+    NegativePrior,
+    AbsolutePrior,
+    Log,
+    Log10,
+)
 
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.mapper.prior.uniform import UniformPrior
@@ -15,6 +28,20 @@ from autofit.mapper.prior_model.prior_model import ModelObject
 from autofit.mapper.prior_model.prior_model import Model
 from autofit.mapper.prior_model.collection import Collection
 from autofit.text.representative import Representative
+
+operation_map = {
+    SumPrior: "+",
+    MultiplePrior: "*",
+    DivisionPrior: "/",
+    FloorDivPrior: "//",
+    ModPrior: "%",
+    PowerPrior: "**",
+    ModifiedPrior: "modified",
+    NegativePrior: "-",
+    AbsolutePrior: "abs",
+    Log: "log",
+    Log10: "log10",
+}
 
 
 def str_for_object(obj: ModelObject) -> str:
@@ -31,6 +58,11 @@ def str_for_object(obj: ModelObject) -> str:
     -------
     A string representation of the object.
     """
+    try:
+        return operation_map[obj.__class__]
+    except KeyError:
+        pass
+
     if isinstance(obj, Representative):
         return str_for_object(obj.representative)
     if isinstance(obj, Collection):

--- a/test_autofit/graphical/info/test_info.py
+++ b/test_autofit/graphical/info/test_info.py
@@ -24,15 +24,11 @@ AnalysisFactors
 
 AnalysisFactor0
 
-centre (AnalysisFactor1.centre, PriorFactor2)                                             0.5
-normalization (PriorFactor4)                                                              0.5
-sigma (PriorFactor3)                                                                      0.5
+centre (AnalysisFactor1.centre, PriorFactor2) - sigma (PriorFactor3)                      0.5
 
 AnalysisFactor1
 
-centre (AnalysisFactor0.centre, PriorFactor2)                                             0.5
-normalization (PriorFactor1)                                                              0.5
-sigma (PriorFactor0)                                                                      0.5"""
+centre (AnalysisFactor0.centre, PriorFactor2) - sigma (PriorFactor0)                      0.5"""
     )
 
 

--- a/test_autofit/text/test_concise.py
+++ b/test_autofit/text/test_concise.py
@@ -3,7 +3,7 @@ import itertools
 import autofit as af
 import pytest
 
-from autofit.text.representative import Representative
+from autofit.text.representative import Representative, RepresentativesFinder
 from autofit.text.text_util import result_info_from
 from autofit.visualise import VisualiseGraph
 
@@ -62,6 +62,26 @@ def test_mid_collection_anomaly(collection):
 def test_shared_prior(collection):
     collection[5].centre = collection[0].centre
     assert len(Representative.find_representatives(collection.items())) == 4
+
+
+@pytest.fixture(name="shared_collection")
+def make_shared_collection(collection):
+    prior = af.UniformPrior(0.0, 1.0)
+    collection[0].centre = prior
+    collection[1].centre = prior
+    return collection
+
+
+def test_shared_external_prior(shared_collection):
+    assert len(Representative.find_representatives(shared_collection.items())) == 2
+
+
+def test_shared_external_blueprint(shared_collection):
+    finder = RepresentativesFinder(shared_collection.items())
+    assert len(finder.shared_descendents) == 1
+    assert finder.get_blueprint(shared_collection[0].centre) == finder.get_blueprint(
+        shared_collection[1].centre
+    )
 
 
 def test_shared_descendents(collection):

--- a/test_autofit/text/test_concise.py
+++ b/test_autofit/text/test_concise.py
@@ -176,7 +176,6 @@ def make_multi_wavelength_model():
 
 
 def test_wavelength_info(multi_wavelength_model):
-    print(multi_wavelength_model.info)
     assert (
         multi_wavelength_model.info
         == """Total Free Parameters = 14
@@ -216,12 +215,78 @@ model                                                                           
                     normalization                                               SumPrior (N=2)
                         self                                                    MultiplePrior (N=1)
 
-0 - 2
+0
     galaxies
-        lens - source
-            bulge - shear
-                centre - normalization                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
-                sigma                                                           UniformPrior [2], lower_limit = 0.0, upper_limit = 1.0"""
+        lens
+            bulge
+                centre                                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
+                normalization
+                    lens_c                                                      UniformPrior [13], lower_limit = -10.0, upper_limit = 10.0
+                    self
+                        lens_m                                                  UniformPrior [12], lower_limit = -0.1, upper_limit = 0.1
+                        wavelength                                              464
+                sigma                                                           UniformPrior [2], lower_limit = 0.0, upper_limit = 1.0
+            mass - shear
+                centre                                                          UniformPrior [3], lower_limit = 0.0, upper_limit = 1.0
+                normalization                                                   UniformPrior [4], lower_limit = 0.0, upper_limit = 1.0
+                sigma                                                           UniformPrior [5], lower_limit = 0.0, upper_limit = 1.0
+        source
+            bulge
+                centre                                                          UniformPrior [9], lower_limit = 0.0, upper_limit = 100.0
+                normalization
+                    self
+                        source_m                                                UniformPrior [14], lower_limit = -0.1, upper_limit = 0.1
+                        wavelength                                              464
+                    source_c                                                    UniformPrior [15], lower_limit = -10.0, upper_limit = 10.0
+                rate                                                            UniformPrior [11], lower_limit = 0.0, upper_limit = 10.0
+1
+    galaxies
+        lens
+            bulge
+                centre                                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
+                normalization
+                    lens_c                                                      UniformPrior [13], lower_limit = -10.0, upper_limit = 10.0
+                    self
+                        lens_m                                                  UniformPrior [12], lower_limit = -0.1, upper_limit = 0.1
+                        wavelength                                              658
+                sigma                                                           UniformPrior [2], lower_limit = 0.0, upper_limit = 1.0
+            mass - shear
+                centre                                                          UniformPrior [3], lower_limit = 0.0, upper_limit = 1.0
+                normalization                                                   UniformPrior [4], lower_limit = 0.0, upper_limit = 1.0
+                sigma                                                           UniformPrior [5], lower_limit = 0.0, upper_limit = 1.0
+        source
+            bulge
+                centre                                                          UniformPrior [9], lower_limit = 0.0, upper_limit = 100.0
+                normalization
+                    self
+                        source_m                                                UniformPrior [14], lower_limit = -0.1, upper_limit = 0.1
+                        wavelength                                              658
+                    source_c                                                    UniformPrior [15], lower_limit = -10.0, upper_limit = 10.0
+                rate                                                            UniformPrior [11], lower_limit = 0.0, upper_limit = 10.0
+2
+    galaxies
+        lens
+            bulge
+                centre                                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
+                normalization
+                    lens_c                                                      UniformPrior [13], lower_limit = -10.0, upper_limit = 10.0
+                    self
+                        lens_m                                                  UniformPrior [12], lower_limit = -0.1, upper_limit = 0.1
+                        wavelength                                              806
+                sigma                                                           UniformPrior [2], lower_limit = 0.0, upper_limit = 1.0
+            mass - shear
+                centre                                                          UniformPrior [3], lower_limit = 0.0, upper_limit = 1.0
+                normalization                                                   UniformPrior [4], lower_limit = 0.0, upper_limit = 1.0
+                sigma                                                           UniformPrior [5], lower_limit = 0.0, upper_limit = 1.0
+        source
+            bulge
+                centre                                                          UniformPrior [9], lower_limit = 0.0, upper_limit = 100.0
+                normalization
+                    self
+                        source_m                                                UniformPrior [14], lower_limit = -0.1, upper_limit = 0.1
+                        wavelength                                              806
+                    source_c                                                    UniformPrior [15], lower_limit = -10.0, upper_limit = 10.0
+                rate                                                            UniformPrior [11], lower_limit = 0.0, upper_limit = 10.0"""
     )
 
 

--- a/test_autofit/text/test_concise.py
+++ b/test_autofit/text/test_concise.py
@@ -132,3 +132,44 @@ def test_visualise(collection, output_directory):
     VisualiseGraph(collection).save(str(output_path))
 
     assert output_path.exists()
+
+
+def test_wavelength_example():
+    wavelength_list = [464, 658, 806]
+
+    lens = af.Collection(
+        redshift=0.5,
+        bulge=af.Gaussian,
+        mass=af.Gaussian,
+        shear=af.Gaussian,
+    )
+
+    source = af.Collection(
+        redshift=1.0,
+        bulge=af.Exponential,
+    )
+
+    model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+    lens_m = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+    lens_c = af.UniformPrior(lower_limit=-10.0, upper_limit=10.0)
+
+    source_m = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+    source_c = af.UniformPrior(lower_limit=-10.0, upper_limit=10.0)
+
+    collection = af.Collection()
+
+    for wavelength in wavelength_list:
+        lens_normalization = (wavelength * lens_m) + lens_c
+        source_normalization = (wavelength * source_m) + source_c
+
+        collection.append(
+            model.replacing(
+                {
+                    model.galaxies.lens.bulge.normalization: lens_normalization,
+                    model.galaxies.source.bulge.normalization: source_normalization,
+                }
+            )
+        )
+
+    VisualiseGraph(collection).save("test.html")

--- a/test_autofit/text/test_concise.py
+++ b/test_autofit/text/test_concise.py
@@ -134,7 +134,8 @@ def test_visualise(collection, output_directory):
     assert output_path.exists()
 
 
-def test_wavelength_example():
+@pytest.fixture(name="multi_wavelength_model")
+def make_multi_wavelength_model():
     wavelength_list = [464, 658, 806]
 
     lens = af.Collection(
@@ -171,5 +172,58 @@ def test_wavelength_example():
                 }
             )
         )
+    return collection
 
-    VisualiseGraph(collection).save("test.html")
+
+def test_wavelength_info(multi_wavelength_model):
+    print(multi_wavelength_model.info)
+    assert (
+        multi_wavelength_model.info
+        == """Total Free Parameters = 14
+
+model                                                                           Collection (N=14)
+    0                                                                           Collection (N=14)
+        galaxies                                                                Collection (N=14)
+            lens                                                                Collection (N=10)
+                bulge                                                           Gaussian (N=4)
+                    normalization                                               SumPrior (N=2)
+                        self                                                    MultiplePrior (N=1)
+                mass - shear                                                    Gaussian (N=3)
+            source                                                              Collection (N=4)
+                bulge                                                           Exponential (N=4)
+                    normalization                                               SumPrior (N=2)
+                        self                                                    MultiplePrior (N=1)
+    1                                                                           Collection (N=14)
+        galaxies                                                                Collection (N=14)
+            lens                                                                Collection (N=10)
+                bulge                                                           Gaussian (N=4)
+                    normalization                                               SumPrior (N=2)
+                        self                                                    MultiplePrior (N=1)
+                mass - shear                                                    Gaussian (N=3)
+            source                                                              Collection (N=4)
+                bulge                                                           Exponential (N=4)
+                    normalization                                               SumPrior (N=2)
+                        self                                                    MultiplePrior (N=1)
+    2                                                                           Collection (N=14)
+        galaxies                                                                Collection (N=14)
+            lens                                                                Collection (N=10)
+                bulge                                                           Gaussian (N=4)
+                    normalization                                               SumPrior (N=2)
+                        self                                                    MultiplePrior (N=1)
+                mass - shear                                                    Gaussian (N=3)
+            source                                                              Collection (N=4)
+                bulge                                                           Exponential (N=4)
+                    normalization                                               SumPrior (N=2)
+                        self                                                    MultiplePrior (N=1)
+
+0 - 2
+    galaxies
+        lens - source
+            bulge - shear
+                centre - normalization                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
+                sigma                                                           UniformPrior [2], lower_limit = 0.0, upper_limit = 1.0"""
+    )
+
+
+def test_wavelength_visualise(multi_wavelength_model):
+    VisualiseGraph(multi_wavelength_model).save("test.html")

--- a/test_autofit/text/test_concise.py
+++ b/test_autofit/text/test_concise.py
@@ -290,5 +290,11 @@ model                                                                           
     )
 
 
-def test_wavelength_visualise(multi_wavelength_model):
-    VisualiseGraph(multi_wavelength_model).save("test.html")
+def test_wavelength_visualise(
+    output_directory,
+    multi_wavelength_model,
+):
+    output_path = output_directory / "test.html"
+    VisualiseGraph(multi_wavelength_model).save(str(output_path))
+
+    assert output_path.exists()

--- a/test_autofit/text/test_concise.py
+++ b/test_autofit/text/test_concise.py
@@ -50,12 +50,12 @@ def test_reference_count(collection):
 def test_find_representatives(collection):
     assert len(Representative.find_representatives(collection.items())) == 1
 
-    collection[0].centre = af.UniformPrior(0.0, 1.0)
+    collection[0].centre = af.UniformPrior(0.0, 2.0)
     assert len(Representative.find_representatives(collection.items())) == 2
 
 
 def test_mid_collection_anomaly(collection):
-    collection[5].centre = af.UniformPrior(0.0, 1.0)
+    collection[5].centre = af.UniformPrior(0.0, 2.0)
     assert len(Representative.find_representatives(collection.items())) == 3
 
 
@@ -85,11 +85,11 @@ def test_shared_external_blueprint(shared_collection):
 
 
 def test_shared_descendents(collection):
-    assert Representative.shared_descendents(collection) == set()
+    assert RepresentativesFinder(collection.items()).shared_descendents == set()
 
     shared = collection[1].centre
     collection[0].centre = shared
-    assert Representative.shared_descendents(collection) == {shared}
+    assert RepresentativesFinder(collection.items()).shared_descendents == {shared}
 
 
 @pytest.fixture(name="samples")
@@ -239,12 +239,7 @@ model                                                                           
     galaxies
         lens
             bulge
-                centre                                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
-                normalization
-                    lens_c                                                      UniformPrior [13], lower_limit = -10.0, upper_limit = 10.0
-                    self
-                        lens_m                                                  UniformPrior [12], lower_limit = -0.1, upper_limit = 0.1
-                        wavelength                                              464
+                centre - normalization                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
                 sigma                                                           UniformPrior [2], lower_limit = 0.0, upper_limit = 1.0
             mass - shear
                 centre                                                          UniformPrior [3], lower_limit = 0.0, upper_limit = 1.0
@@ -252,23 +247,13 @@ model                                                                           
                 sigma                                                           UniformPrior [5], lower_limit = 0.0, upper_limit = 1.0
         source
             bulge
-                centre                                                          UniformPrior [9], lower_limit = 0.0, upper_limit = 100.0
-                normalization
-                    self
-                        source_m                                                UniformPrior [14], lower_limit = -0.1, upper_limit = 0.1
-                        wavelength                                              464
-                    source_c                                                    UniformPrior [15], lower_limit = -10.0, upper_limit = 10.0
+                centre - normalization                                          UniformPrior [9], lower_limit = 0.0, upper_limit = 100.0
                 rate                                                            UniformPrior [11], lower_limit = 0.0, upper_limit = 10.0
 1
     galaxies
         lens
             bulge
-                centre                                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
-                normalization
-                    lens_c                                                      UniformPrior [13], lower_limit = -10.0, upper_limit = 10.0
-                    self
-                        lens_m                                                  UniformPrior [12], lower_limit = -0.1, upper_limit = 0.1
-                        wavelength                                              658
+                centre - normalization                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
                 sigma                                                           UniformPrior [2], lower_limit = 0.0, upper_limit = 1.0
             mass - shear
                 centre                                                          UniformPrior [3], lower_limit = 0.0, upper_limit = 1.0
@@ -276,23 +261,13 @@ model                                                                           
                 sigma                                                           UniformPrior [5], lower_limit = 0.0, upper_limit = 1.0
         source
             bulge
-                centre                                                          UniformPrior [9], lower_limit = 0.0, upper_limit = 100.0
-                normalization
-                    self
-                        source_m                                                UniformPrior [14], lower_limit = -0.1, upper_limit = 0.1
-                        wavelength                                              658
-                    source_c                                                    UniformPrior [15], lower_limit = -10.0, upper_limit = 10.0
+                centre - normalization                                          UniformPrior [9], lower_limit = 0.0, upper_limit = 100.0
                 rate                                                            UniformPrior [11], lower_limit = 0.0, upper_limit = 10.0
 2
     galaxies
         lens
             bulge
-                centre                                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
-                normalization
-                    lens_c                                                      UniformPrior [13], lower_limit = -10.0, upper_limit = 10.0
-                    self
-                        lens_m                                                  UniformPrior [12], lower_limit = -0.1, upper_limit = 0.1
-                        wavelength                                              806
+                centre - normalization                                          UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
                 sigma                                                           UniformPrior [2], lower_limit = 0.0, upper_limit = 1.0
             mass - shear
                 centre                                                          UniformPrior [3], lower_limit = 0.0, upper_limit = 1.0
@@ -300,12 +275,7 @@ model                                                                           
                 sigma                                                           UniformPrior [5], lower_limit = 0.0, upper_limit = 1.0
         source
             bulge
-                centre                                                          UniformPrior [9], lower_limit = 0.0, upper_limit = 100.0
-                normalization
-                    self
-                        source_m                                                UniformPrior [14], lower_limit = -0.1, upper_limit = 0.1
-                        wavelength                                              806
-                    source_c                                                    UniformPrior [15], lower_limit = -10.0, upper_limit = 10.0
+                centre - normalization                                          UniformPrior [9], lower_limit = 0.0, upper_limit = 100.0
                 rate                                                            UniformPrior [11], lower_limit = 0.0, upper_limit = 10.0"""
     )
 


### PR DESCRIPTION
Doesn't actually resolve #930 but does resolve bugs - previously representation was seemingly working by luck.

Currently any models within a collection that share priors are considered separately. We need to be careful about how we represent a collection of models in a way that does not obfuscate what is going on.

For example, if we used a concise representation of a collection of models which all shared a prior it would in the current representation look the same as a collection of models which all had an independent prior of with the same name and parameters.
