### PR TITLE
Comment out JAX from optional requirements

### DIFF
--- a/autofit/aggregator/base.py
+++ b/autofit/aggregator/base.py
@@ -35,7 +35,7 @@ class AggBase(ABC):
         self, fit: af.Fit, instance: Optional[af.ModelInstance] = None
     ) -> object:
         """
-        For example, in the `PlaneAgg` object, this function is overwritten such that it creates a `Plane` from a
+        For example, in the `GalaxiesAgg` object, this function is overwritten such that it creates a `Plane` from a
         `ModelInstance` that contains the galaxies of a sample from a non-linear search.
 
         Parameters

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,7 +1,7 @@
 astropy>=5.0
 getdist==1.4
-jax>=0.4.13
-jaxlib>=0.4.13
+#jax>=0.4.13
+#jaxlib>=0.4.13
 nautilus-sampler==1.0.2
 ultranest==3.6.2
 zeus-mcmc==2.5.4


### PR DESCRIPTION
JAX is listed in the `optional_requirements.txt` file, which means build-server tests install it, causing tests to fail.

This PR comments it out to fix the build server.

Obviously, we will need to get everything working with JAX, but until actual functionality using it is live I would keep it commented out for simplicity.