### PR TITLE
feature/latent variables

### DIFF
--- a/autofit/aggregator/search_output.py
+++ b/autofit/aggregator/search_output.py
@@ -264,7 +264,7 @@ class SearchOutput(AbstractSearchOutput):
         """
         The latent variables of the search, parsed from a CSV file.
         """
-        with open(self.files_path / "latent_variables.csv") as f:
+        with open(self.files_path / "latent.csv") as f:
             reader = csv.reader(f)
             headers = next(reader)
             from autofit.non_linear.analysis.latent_variables import LatentVariables

--- a/autofit/config/output.yaml
+++ b/autofit/config/output.yaml
@@ -60,7 +60,7 @@ search_internal: false
 # which is not directly sampled but related to the Gaussian's sigma value.
 
 # By overwritting an Analysis class's `compute_latent_variable` method one can manuually specify the latent variables
-# that are calculated and output to a `latent_variables.csv` file which mirrors the `samples.csv` file (including
+# that are calculated and output to a `latent.csv` file which mirrors the `samples.csv` file (including
 # weight resampling set by the `samples_weight_threshold` above. There can also be a `latent.results`
 #  and `latent_summary.json` files output.
 
@@ -71,7 +71,7 @@ search_internal: false
 # output and perform it manually. This will ensure computation run time is not wasted computing latent variables
 # during a model-fit (which may go to an inaccurate solution).
 
-latent_during_fit: false # Whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files during the fit when it performs on-the-fly output.
+latent_during_fit: true # Whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files during the fit when it performs on-the-fly output.
 latent_after_fit: true # If `latent_during_fit` is False, whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files after the fit is complete.
 latent_csv: true # Whether to ouptut the `latent.csv` file.
 latent_results: true # Whether to output the `latent.results` file.

--- a/autofit/config/output.yaml
+++ b/autofit/config/output.yaml
@@ -1,13 +1,6 @@
 # Determines whether files saved by the search are output to the hard-disk. This is true both when saving to the
 # directory structure and when saving to database.
 
-# Files can be listed name: bool where the name is the name of the file without a suffix (e.g. model not model.json)
-# and bool is true or false.
-
-# If a given file is not listed then the default value is used.
-
-default: true # If true then files which are not explicitly listed here are output anyway. If false then they are not.
-
 ### Samples ###
 
 # The `samples.csv`file contains every sampled value of every free parameter with its log likelihood and weight.
@@ -22,17 +15,17 @@ default: true # If true then files which are not explicitly listed here are outp
 samples: true
 
 # The `samples.csv` file contains every accepted sampled value of every free parameter with its log likelihood and
-# weight. For certain searches, the majority of samples have a very low weight, which has no numerical impact on the
-# results of the model-fit. However, these samples are still output to the `samples.csv` file, taking up hard-disk space
-# and slowing down analysis of the samples (e.g. via the database).
+# weight. For certain searches, the majority of samples have a very low weight and have no numerical impact on the
+# results of the model-fit. However, these samples are still output to the `samples.csv` file, taking up hard-disk
+# space and slowing down analysis of the samples (e.g. via the database).
 
 # The `samples_weight_threshold` below specifies the threshold value of the weight such that samples with a weight
 # below this value are not output to the `samples.csv` file. This can be used to reduce the size of the `samples.csv`
 # file and speed up analysis of the samples.
 
-# Note that for many searches (e.g. MCMC) all samples have equal weight, and thus this threshold has no impact and
-# there is no simple way to save hard-disk space. However, for nested sampling, the majority of samples have a very
-# low weight and this threshold can be used to save hard-disk space.
+# For many searches (e.g. MCMC) all samples have an equal weight of 1.0, and this threshold therefore has no impact.
+# For these searches, there is no simple way to save hard-disk space. This input is more suited to nested sampling,
+# where the majority of samples have a very low weight..
 
 # Set value to empty (e.g. delete 1.0e-10 below) to disable this feature.
 
@@ -40,7 +33,11 @@ samples_weight_threshold: 1.0e-10
 
 ### Search Internal ###
 
-# The search internal folder which contains a saved state of the non-linear search, as a .pickle or .dill file.
+# The search internal folder which contains a saved state of the non-linear search in its internal reprsenetation,
+# as a .pickle or .dill file.
+
+# For example, for the nested sampling dynesty, this .dill file is the `DynestySampler` object which is used to
+# perform sampling, and it therefore contains all internal dynesty representations of the results, samples, weights, etc.
 
 # If the entry below is false, the folder is still output during the model-fit, as it is required to resume the fit
 # from where it left off. Therefore, settings `false` below does not impact model-fitting checkpointing and resumption.
@@ -49,11 +46,35 @@ samples_weight_threshold: 1.0e-10
 # The search internal folder file is often large, therefore deleting it after a fit is complete can significantly
 # reduce hard-disk space use.
 
-# The search internal representation (e.g. what you can load from the output .pickle file) may have additional
-# quantities specific to the non-linear search that you are interested in inspecting. Deleting the folder means this
-# information is list.
+# The search internal representation that can be loaded from the .dill file has many additional quantities specific to
+# the non-linear search that the standardized autofit forms do not. For example, for emcee, it contains information on
+# every walker. This information is required to do certain analyes and make certain plots, therefore deleting the
+# folder means this information is list.
 
 search_internal: false
+
+### Latent Variables ###
+
+# A latent variable is a parameter related to the model that one may be interested in knowing the estimate and errors
+# of. For example, for the simple 1D Gaussian example, it could be the full-width half maximum (FWHM) of the Gaussian,
+# which is not directly sampled but related to the Gaussian's sigma value.
+
+# By overwritting an Analysis class's `compute_latent_variable` method one can manuually specify the latent variables
+# that are calculated and output to a `latent_variables.csv` file which mirrors the `samples.csv` file (including
+# weight resampling set by the `samples_weight_threshold` above. There can also be a `latent.results`
+#  and `latent_summary.json` files output.
+
+# The inputs below control how often latent variables are computed and what files are output.
+
+# Outputting latent variables manually is very simple, it simply requires calling the analysis object's
+# `compute_all_latent_variables` function. For many users, the best set up may be to disable autofit latent variable
+# output and perform it manually. This will ensure computation run time is not wasted computing latent variables
+# during a model-fit (which may go to an inaccurate solution).
+
+latent_during_fit: false # Whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files during the fit when it performs on-the-fly output.
+latent_after_fit: true # If `latent_during_fit` is False, whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files after the fit is complete.
+latent_csv: true # Whether to ouptut the `latent.csv` file.
+latent_results: true # Whether to output the `latent.results` file.
 
 # Other Files:
 

--- a/autofit/config/output.yaml
+++ b/autofit/config/output.yaml
@@ -55,21 +55,25 @@ search_internal: false
 
 ### Latent Variables ###
 
-# A latent variable is a parameter related to the model that one may be interested in knowing the estimate and errors
-# of. For example, for the simple 1D Gaussian example, it could be the full-width half maximum (FWHM) of the Gaussian,
-# which is not directly sampled but related to the Gaussian's sigma value.
+# A latent variable is not a model parameter but can be derived from the model. Its value and errors may be of interest
+# and aid in the interpretation of a model-fit.
 
-# By overwritting an Analysis class's `compute_latent_variable` method one can manuually specify the latent variables
-# that are calculated and output to a `latent.csv` file which mirrors the `samples.csv` file (including
-# weight resampling set by the `samples_weight_threshold` above. There can also be a `latent.results`
-#  and `latent_summary.json` files output.
+# For example, for the simple 1D Gaussian example, it could be the full-width half maximum (FWHM) of the Gaussian. This
+# is not included in the model but can be easily derived from the Gaussian's sigma value.
 
-# The inputs below control how often latent variables are computed and what files are output.
+# By overwriting an Analysis class's `compute_latent_variable` method we can manually specify latent variables that
+# are calculated and output to a `latent.csv` file, which mirrors the `samples.csv` file. The `latent.csv` file has
+# the same weight resampling performed on the `samples.csv` file, controlled via the `samples_weight_threshold` above.
 
-# Outputting latent variables manually is very simple, it simply requires calling the analysis object's
-# `compute_all_latent_variables` function. For many users, the best set up may be to disable autofit latent variable
-# output and perform it manually. This will ensure computation run time is not wasted computing latent variables
-# during a model-fit (which may go to an inaccurate solution).
+# There may also be a `latent.results` and `latent_summary.json` files output, which the inputs below control whether
+# they are output and how often.
+
+# Outputting latent variables manually after a fit is complete is simple, just call
+# the `analysis.compute_all_latent_variables()` function.
+
+# For many use cases, the best set up may be to disable autofit latent variable output during the fit and perform it
+# manually after completing a successful model-fit. This will save computational run time by not computing latent
+# variables during a any model-fit which is unsuccessful.
 
 latent_during_fit: true # Whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files during the fit when it performs on-the-fly output.
 latent_after_fit: true # If `latent_during_fit` is False, whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files after the fit is complete.

--- a/autofit/example/analysis.py
+++ b/autofit/example/analysis.py
@@ -1,6 +1,6 @@
 import os
 import matplotlib.pyplot as plt
-from typing import List, Optional
+from typing import Dict, List
 
 from autofit.jax_wrapper import numpy as np
 
@@ -59,13 +59,6 @@ class Analysis(af.Analysis):
         residual_map = self.data - model_data_1d
         chi_squared_map = (residual_map / self.noise_map) ** 2.0
         log_likelihood = -0.5 * sum(chi_squared_map)
-
-        try:
-            self.save_latent_variables(
-                fwmh=instance.fwhm
-            )
-        except AttributeError:
-            pass
 
         return log_likelihood
 
@@ -176,4 +169,7 @@ class Analysis(af.Analysis):
         paths.save_json(name="data", object_dict=self.data.tolist(), prefix="dataset")
         paths.save_json(name="noise_map", object_dict=self.noise_map.tolist(), prefix="dataset")
 
-
+    def compute_latent_variable(self, instance) -> Dict[str, float]:
+        return {
+            "fwhm": instance.fwhm
+        }

--- a/autofit/example/analysis.py
+++ b/autofit/example/analysis.py
@@ -170,6 +170,31 @@ class Analysis(af.Analysis):
         paths.save_json(name="noise_map", object_dict=self.noise_map.tolist(), prefix="dataset")
 
     def compute_latent_variable(self, instance) -> Dict[str, float]:
+        """
+        A latent variable is not a model parameter but can be derived from the model. Its value and errors may be
+        of interest and aid in the interpretation of a model-fit.
+
+        For example, for the simple 1D Gaussian example, it could be the full-width half maximum (FWHM) of the
+        Gaussian. This is not included in the model but can be easily derived from the Gaussian's sigma value.
+
+        By overwriting this method we can manually specify latent variables that are calculated and output to
+        a `latent.csv` file, which mirrors the `samples.csv` file.
+
+        In the example below, the `latent.csv` file will contain one column with the FWHM of every Gausian model
+        sampled by the non-linear search.
+
+        This function is called for every non-linear search sample, where the `instance` passed in corresponds to
+        each sample.
+
+        Parameters
+        ----------
+        instance
+            The instances of the model which the latent variable is derived from.
+
+        Returns
+        -------
+
+        """
         return {
             "fwhm": instance.fwhm
         }

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC
 import os
-from typing import Optional, Dict, List
+from typing import Optional, Dict
 
 from autoconf import conf
 

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC
 import os
-from typing import Optional
+from typing import Optional, Dict, List
 
 from autoconf import conf
 
@@ -11,6 +11,7 @@ from autofit.non_linear.paths.abstract import AbstractPaths
 from autofit.non_linear.paths.database import DatabasePaths
 from autofit.non_linear.paths.null import NullPaths
 from autofit.non_linear.result import Result
+from autofit.non_linear.samples.samples import Samples
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,35 @@ class Analysis(ABC):
             # noinspection PyAttributeOutsideInit
             self._latent_variables = LatentVariables()
         self._latent_variables.add(**kwargs)
+
+    def compute_all_latent_variables(
+        self, samples: Samples
+    ) -> Optional[LatentVariables]:
+        try:
+            latent_variables = LatentVariables()
+            model = samples.model
+            for sample in samples.sample_list:
+                latent_variables.add(
+                    **self.compute_latent_variable(sample.instance_for_model(model))
+                )
+            return latent_variables
+        except NotImplementedError:
+            return None
+
+    def compute_latent_variable(self, instance) -> Dict[str, float]:
+        """
+        Compute latent variables from the instance.
+
+        Parameters
+        ----------
+        instance
+            An instance of the model.
+
+        Returns
+        -------
+        The computed latent variables.
+        """
+        raise NotImplementedError()
 
     def with_model(self, model):
         """

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -26,6 +26,18 @@ class Analysis(ABC):
     def compute_all_latent_variables(
         self, samples: Samples
     ) -> Optional[LatentVariables]:
+        """
+        Internal method that manages computation of latent variables from samples.
+
+        Parameters
+        ----------
+        samples
+            The samples from the non-linear search.
+
+        Returns
+        -------
+        The computed latent variables or None if compute_latent_variable is not implemented.
+        """
         try:
             latent_variables = LatentVariables()
             model = samples.model
@@ -39,7 +51,7 @@ class Analysis(ABC):
 
     def compute_latent_variable(self, instance) -> Dict[str, float]:
         """
-        Compute latent variables from the instance.
+        Override to compute latent variables from the instance.
 
         Parameters
         ----------

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -23,39 +23,6 @@ class Analysis(ABC):
     likelihood that some instance fits some data.
     """
 
-    @property
-    def latent_variables(self) -> Optional[LatentVariables]:
-        """
-        Custom quantities that are computed during the analysis.
-
-        If no latent variables have been saved, this will return None.
-        """
-        try:
-            return self._latent_variables
-        except AttributeError:
-            return None
-
-    def save_latent_variables(self, **kwargs: float):
-        """
-        Save latent variables that are computed during the analysis.
-
-        This should only be called once per a fit and must always be passed the same latent variables.
-
-        Parameters
-        ----------
-        kwargs
-            The latent variables to save.
-
-        Raises
-        ------
-        SamplesException
-            If the same latent variables are not passed to `add` each iteration.
-        """
-        if not hasattr(self, "_latent_variables"):
-            # noinspection PyAttributeOutsideInit
-            self._latent_variables = LatentVariables()
-        self._latent_variables.add(**kwargs)
-
     def compute_all_latent_variables(
         self, samples: Samples
     ) -> Optional[LatentVariables]:
@@ -204,7 +171,7 @@ class Analysis(ABC):
     def make_result(self, samples, search_internal=None):
         return Result(
             samples=samples,
-            latent_variables=self.latent_variables,
+            latent_variables=self.compute_all_latent_variables(samples),
             search_internal=search_internal,
         )
 

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -454,7 +454,7 @@ class AbstractPaths(ABC):
 
     @property
     def _latent_variables_file(self) -> Path:
-        return self._files_path / "latent_variables.csv"
+        return self._files_path / "latent.csv"
 
     @property
     def _covariance_file(self) -> Path:

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -937,12 +937,18 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
             self.paths.save_samples(samples=samples_for_csv)
 
-            latent_variables = analysis.compute_all_latent_variables(samples)
-            if latent_variables:
-                self.paths.save_latent_variables(
-                    latent_variables,
-                    samples=samples,
-                )
+            if (
+                    (during_analysis and conf.instance["output"]["latent_during_fit"]) or
+                    (not during_analysis and conf.instance["output"]["latent_after_fit"])
+            ):
+
+                latent_variables = analysis.compute_all_latent_variables(samples_for_csv)
+
+                if latent_variables:
+                    self.paths.save_latent_variables(
+                        latent_variables,
+                        samples=samples,
+                    )
 
             if not self.skip_save_samples:
                 self.paths.save_json("samples_summary", to_dict(samples.summary()))

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -560,7 +560,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
             self.post_fit_output(
                 bypass_nuclear_if_on=bypass_nuclear_if_on,
-                search_internal=result.search_internal
+                search_internal=result.search_internal,
             )
 
         return result
@@ -673,9 +673,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             during_analysis=False,
         )
 
-        result = analysis.make_result(
-            samples=samples, search_internal=search_internal
-        )
+        result = analysis.make_result(samples=samples, search_internal=search_internal)
 
         if self.is_master:
             analysis.save_results(paths=self.paths, result=result)
@@ -688,7 +686,9 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         return result
 
     def result_via_completed_fit(
-        self, analysis: Analysis, model: AbstractPriorModel,
+        self,
+        analysis: Analysis,
+        model: AbstractPriorModel,
     ) -> Result:
         """
         Returns the result of the non-linear search of a completed model-fit.
@@ -734,9 +734,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             except FileNotFoundError:
                 search_internal = None
 
-        result = analysis.make_result(
-            samples=samples, search_internal=search_internal
-        )
+        result = analysis.make_result(samples=samples, search_internal=search_internal)
 
         if self.is_master:
             self.logger.info(f"Fit Already Completed: skipping non-linear search.")
@@ -921,10 +919,11 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             return samples
 
         if self.is_master:
-
             samples_for_csv = samples
 
-            samples_weight_threshold = conf.instance["output"]["samples_weight_threshold"]
+            samples_weight_threshold = conf.instance["output"][
+                "samples_weight_threshold"
+            ]
 
             if samples_weight_threshold is not None:
                 samples_for_csv = samples_for_csv.samples_above_weight_threshold_from(
@@ -938,7 +937,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
             self.paths.save_samples(samples=samples_for_csv)
 
-            latent_variables = analysis.latent_variables
+            latent_variables = analysis.compute_all_latent_variables(samples)
             if latent_variables:
                 self.paths.save_latent_variables(
                     latent_variables,

--- a/test_autofit/analysis/test_latent_variables.py
+++ b/test_autofit/analysis/test_latent_variables.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 import autofit as af
-from autofit import DirectoryPaths
+from autofit import DirectoryPaths, Samples
 from autofit.exc import SamplesException
 from autofit.non_linear.analysis.latent_variables import LatentVariables
 
@@ -11,6 +11,9 @@ class Analysis(af.Analysis):
     def log_likelihood_function(self, instance):
         self.save_latent_variables(centre=instance.centre)
         return 1.0
+
+    def compute_latent_variable(self, instance):
+        return {"fwhm": instance.fwhm}
 
 
 def test_latent_variables():
@@ -84,7 +87,8 @@ class MockSamples:
 def test_set_database_paths(session, latent_variables):
     database_paths = af.DatabasePaths(session)
     database_paths.save_latent_variables(
-        latent_variables=latent_variables, samples=MockSamples()
+        latent_variables=latent_variables,
+        samples=MockSamples(),
     )
     loaded = database_paths.load_latent_variables()
     assert loaded.names == ["centre"]
@@ -100,3 +104,25 @@ def test_iter(latent_variables):
 def test_minimise(latent_variables):
     latent_variables.minimise(0)
     assert latent_variables.values == [[1.0]]
+
+
+def test_compute_all_latent_variables():
+    analysis = Analysis()
+    latent_variables = analysis.compute_all_latent_variables(
+        Samples(
+            model=af.Model(af.Gaussian),
+            sample_list=[
+                af.Sample(
+                    log_likelihood=1.0,
+                    log_prior=0.0,
+                    weight=1.0,
+                    kwargs={
+                        "centre": 1.0,
+                        "normalization": 2.0,
+                        "sigma": 3.0,
+                    },
+                )
+            ],
+        ),
+    )
+    assert latent_variables.names == ["fwhm"]

--- a/test_autofit/analysis/test_latent_variables.py
+++ b/test_autofit/analysis/test_latent_variables.py
@@ -9,7 +9,6 @@ from autofit.non_linear.analysis.latent_variables import LatentVariables
 
 class Analysis(af.Analysis):
     def log_likelihood_function(self, instance):
-        self.save_latent_variables(centre=instance.centre)
         return 1.0
 
     def compute_latent_variable(self, instance):
@@ -46,16 +45,6 @@ def test_split_addition():
     latent_variables.add(centre=1.0)
     with pytest.raises(SamplesException):
         latent_variables.add(intensity=2.0)
-
-
-def test_analysis_latent_variables():
-    analysis = Analysis()
-    instance = af.Gaussian()
-    analysis.log_likelihood_function(instance=instance)
-
-    latent_variables = analysis.latent_variables
-    assert latent_variables.names == ["centre"]
-    assert latent_variables.values == [[instance.centre]]
 
 
 @pytest.fixture(name="latent_variables")

--- a/test_autofit/non_linear/test_analysis.py
+++ b/test_autofit/non_linear/test_analysis.py
@@ -100,7 +100,12 @@ def test_make_result():
     analysis_1 = Analysis()
     analysis_2 = Analysis()
 
-    result = (analysis_1 + analysis_2).make_result(samples=None)
+    result = (analysis_1 + analysis_2).make_result(
+        samples=af.Samples(
+            model=af.Model(af.Gaussian),
+            sample_list=[],
+        )
+    )
 
     assert len(result) == 2
 


### PR DESCRIPTION
Resolve #966 although may inefficient

The user can now provide latent variables by overriding `compute_latent_variable` in the Analysis class.

```python
def compute_latent_variable(self, instance) -> Dict[str, float]:
    return {"my_variable": instance.my_variable}
```

If this method is not overridden no latent variable output is written. 

Currently this is called for every sample every time output is written. It is also called when creating a result. It may be desirable to map instances or samples to the latent variables dictionaries that were computed for them.
