### PR TITLE
Update `assert_within_limits` on the `Prior` class

### DIFF
--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -116,16 +116,28 @@ class Prior(Variable, ABC, ArithmeticMixin):
 
     def assert_within_limits(self, value):
 
-        if jax_wrapper.use_jax:
-            return
-
-        if not (self.lower_limit <= value <= self.upper_limit):
+        def exception_message():
             raise exc.PriorLimitException(
                 "The physical value {} for a prior "
                 "was not within its limits {}, {}".format(
                     value, self.lower_limit, self.upper_limit
                 )
             )
+
+        if jax_wrapper.use_jax:
+            import jax
+            jax.lax.cond(
+                jax.numpy.logical_or(
+                    value < self.lower_limit,
+                    value > self.upper_limit
+                ),
+                lambda _: jax.debug.callback(exception_message),
+                lambda _: None,
+                None
+            )
+
+        elif not (self.lower_limit <= value <= self.upper_limit):
+            exception_message()
 
     @staticmethod
     def for_class_and_attribute_name(cls, attribute_name):


### PR DESCRIPTION
This update makes the `assert_within_limits` method of the `Prior` class play nicely with JAX.  As the `value` passed into the function will be a JAX traced array a `jax.lax.cond` must be used in place of a traditional `if` block.

As one branch will `raise` an exception it must be wrapped in a `jax.debug.callback()` to ensure it does not evaluate until the `jit`ed function exits.

Also the `jax.numpy.logical_or` is used in the condition definition to make it work on the traced array as expected.

Side note: the `if jax_wrapper.use_jax:` block does not need this kind of treatment as it is a static value when the function is `jit`ed and the compiler knows what branch to take.