### PR TITLE
naive implementation of physical_centres_from

### DIFF
--- a/autofit/non_linear/grid/grid_search/result.py
+++ b/autofit/non_linear/grid/grid_search/result.py
@@ -41,6 +41,25 @@ class GridSearchResult:
 
         self.parent = parent
 
+    @as_grid_list
+    def physical_centres_lists_from(self, path: str):
+        """
+        Get the physical centres of the grid search from a path to an attribute of the instance in the samples.
+
+        Parameters
+        ----------
+        path
+            The path to the attribute to get from the instance
+
+        Returns
+        -------
+        A list of lists of physical values
+        """
+        return [
+            samples.model.object_for_path(path.split(".")).mean
+            for samples in self.samples
+        ]
+
     @property
     @as_grid_list
     def physical_lower_limits_lists(self) -> GridList:
@@ -209,7 +228,8 @@ class GridSearchResult:
 
     @as_grid_list
     def log_likelihoods(
-        self, relative_to_value: float = 0.0,
+        self,
+        relative_to_value: float = 0.0,
     ) -> GridList:
         """
         The maximum log likelihood of every grid search on a NumPy array whose shape is the native dimensions of the

--- a/test_autofit/non_linear/grid/test_quantities_for_path.py
+++ b/test_autofit/non_linear/grid/test_quantities_for_path.py
@@ -1,0 +1,51 @@
+import autofit as af
+
+
+def test_physical_centres_from():
+    model = af.Model(
+        af.Gaussian,
+    )
+    grid_priors = [model.centre]
+    lower_limits_lists = [[0.0], [2.0]]
+
+    sample = af.Sample(
+        1.0,
+        1.0,
+        1.0,
+        {
+            "centre": 1.0,
+            "normalization": 2.0,
+            "sigma": 3.0,
+        },
+    )
+
+    samples = [
+        af.Samples(
+            model=af.Model(
+                af.Gaussian,
+                centre=af.UniformPrior(
+                    lower_limit=0.0,
+                    upper_limit=2.0,
+                ),
+            ),
+            sample_list=[sample],
+        ),
+        af.Samples(
+            model=af.Model(
+                af.Gaussian,
+                centre=af.UniformPrior(
+                    lower_limit=2.0,
+                    upper_limit=4.0,
+                ),
+            ),
+            sample_list=[sample],
+        ),
+    ]
+
+    result = af.GridSearchResult(
+        samples=samples,
+        lower_limits_lists=lower_limits_lists,
+        grid_priors=grid_priors,
+    )
+
+    assert result.physical_centres_lists_from("centre") == [[1.0], [3.0]]


### PR DESCRIPTION
Pretty sure this does what you want as it uses the model passed to the samples for each grid search run. For any prior which is a grid prior this new function would give you the mean of that prior for each model
