### PR TITLE
Feature/silence tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12'], '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11', '3.12']
     steps:
     - name: Checkout PyAutoConf
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11', '3.12'], '3.10', '3.11']
     steps:
     - name: Checkout PyAutoConf
       uses: actions/checkout@v2

--- a/autofit/database/model/model.py
+++ b/autofit/database/model/model.py
@@ -6,9 +6,10 @@ from typing import List, Tuple, Any, Iterable, Union, ItemsView, Type
 import numpy as np
 
 from autoconf.class_path import get_class, get_class_path
-from ..sqlalchemy_ import sa, declarative
+from ..sqlalchemy_ import sa
+from sqlalchemy.orm import declarative_base
 
-Base = declarative.declarative_base()
+Base = declarative_base()
 
 _schema_version = 1
 

--- a/autofit/interpolator/linear.py
+++ b/autofit/interpolator/linear.py
@@ -1,4 +1,4 @@
-from scipy.stats import stats
+from scipy.stats import linregress
 from .abstract import AbstractInterpolator
 
 
@@ -9,5 +9,5 @@ class LinearInterpolator(AbstractInterpolator):
 
     @staticmethod
     def _interpolate(x, y, value):
-        slope, intercept, r, p, std_err = stats.linregress(x, y)
+        slope, intercept, r, p, std_err = linregress(x, y)
         return slope * value + intercept

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -9,8 +9,6 @@ from autofit.non_linear.samples.pdf import SamplesPDF
 from autofit.non_linear.result import Result
 from autofit.non_linear.samples.samples import Samples
 from autofit.non_linear.samples.sample import Sample
-from autofit.mapper.prior_model.collection import Collection
-from autofit.mapper.prior.gaussian import GaussianPrior
 
 from .visualize import Visualizer
 from ..samples.util import simple_model_for_kwargs

--- a/autofit/non_linear/search/mcmc/emcee/search.py
+++ b/autofit/non_linear/search/mcmc/emcee/search.py
@@ -4,6 +4,8 @@ from typing import Dict, Optional
 import emcee
 import numpy as np
 
+from autoconf import conf
+
 from autofit.database.sqlalchemy_ import sa
 from autofit.mapper.model_mapper import ModelMapper
 from autofit.mapper.prior_model.abstract import AbstractPriorModel

--- a/docs/installation/overview.rst
+++ b/docs/installation/overview.rst
@@ -3,7 +3,7 @@
 Overview
 ========
 
-**PyAutoFit** requires Python 3.8 - 3.11 and support the Linux, MacOS and Windows operating systems.
+**PyAutoFit** requires Python 3.9 - 3.11 and support the Linux, MacOS and Windows operating systems.
 
 **PyAutoFit** can be installed via the Python distribution `Anaconda <https://www.anaconda.com/>`_ or using
 `Pypi <https://pypi.org/>`_ to ``pip install`` **PyAutoFit** into your Python distribution.

--- a/test_autofit/interpolator/test_covariance.py
+++ b/test_autofit/interpolator/test_covariance.py
@@ -44,23 +44,23 @@ def test_covariance_matrix(interpolator):
 #     )
 
 
-def n_effective(func):
+def maxcall(func):
     return with_config(
         "non_linear",
         "nest",
         "DynestyStatic",
         "run",
-        "n_effective",
-        value=0,
+        "maxcall",
+        value=1,
     )(func)
 
 
-@n_effective
+@maxcall
 def test_interpolate(interpolator):
     assert isinstance(interpolator[interpolator.t == 0.5].gaussian.centre, float)
 
 
-@n_effective
+@maxcall
 def test_interpolate_other_field(interpolator):
     assert isinstance(
         interpolator[interpolator.gaussian.centre == 0.5].gaussian.centre,
@@ -79,7 +79,7 @@ def test_model(interpolator):
     assert model.prior_count == 6
 
 
-@n_effective
+@maxcall
 def test_single_variable():
     samples_list = [
         af.SamplesPDF(
@@ -106,7 +106,7 @@ def test_single_variable():
     assert interpolator[interpolator.t == 50.0].v == pytest.approx(50.0, abs=1.0)
 
 
-@n_effective
+@maxcall
 def test_variable_and_constant():
     samples_list = [
         af.SamplesPDF(

--- a/test_autofit/test_correspondence.py
+++ b/test_autofit/test_correspondence.py
@@ -109,4 +109,4 @@ def test_regression():
 
     assert log_likelihood == numerical_log_likelihood
     assert float(gradient) == pytest.approx(numerical_gradient, rel=0.001)
-    assert float(approx_gradient) == pytest.approx(numerical_gradient, rel=0.001)
+    assert float(approx_gradient[0]) == pytest.approx(numerical_gradient, rel=0.001)


### PR DESCRIPTION
Silences a number of warning that show after running `pytest`.

The update to SQLAlchemy====2.0.32 has produced the following warning:

```
test_autolens/aggregator/test_aggregator_fit_imaging.py::test__fit_imaging_randomly_drawn_via_pdf_gen_from
  /mnt/c/Users/Jammy/Code/PyAuto/PyAutoFit/autofit/database/aggregator/scrape.py:147: SAWarning: relationship 'Object.children' will copy column object.id to column object.parent_id, which conflicts with relationship(s): 'Object.parent' (copies object.id to object.parent_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="parent"' to the 'Object.children' relationship. (Background on this warning at: https://sqlalche.me/e/20/qzyx) (This warning originated from the `configure_mappers()` process, which was invoked automatically in response to a user-initiated operation.)
    return self.session.query(m.Fit).filter(m.Fit.id == item.id).one()
```

Could you update the code so that this is also suppressed and then we merge?