### PR TITLE
Revert "feature/build fixes"

### DIFF
--- a/autofit/database/model/array.py
+++ b/autofit/database/model/array.py
@@ -29,12 +29,7 @@ class Array(Object):
     _shape = sa.Column(sa.String)
 
     fit_id = sa.Column(sa.String, sa.ForeignKey("fit.id"))
-    fit = sa.orm.relationship(
-        "Fit",
-        uselist=False,
-        foreign_keys=[fit_id],
-        back_populates="arrays",
-    )
+    fit = sa.orm.relationship("Fit", uselist=False, foreign_keys=[fit_id])
 
     @property
     def shape(self):
@@ -88,13 +83,6 @@ class HDU(Array):
     __mapper_args__ = {
         "polymorphic_identity": "hdu",
     }
-
-    fit = sa.orm.relationship(
-        "Fit",
-        uselist=False,
-        foreign_keys=[Array.fit_id],
-        back_populates="hdus",
-    )
 
     @property
     def header(self):

--- a/autofit/database/model/common.py
+++ b/autofit/database/model/common.py
@@ -1,6 +1,10 @@
-from typing import Union, ItemsView, Any, Iterable, Tuple
+from typing import Union
 
 from ..sqlalchemy_ import sa
+
+from autofit.mapper.prior import abstract
+from autofit.mapper.prior_model import prior_model
+from autofit.mapper.prior_model import collection
 
 from .model import Object
 
@@ -22,15 +26,7 @@ class Dict(Object):
     __mapper_args__ = {"polymorphic_identity": "dict"}
 
     def __call__(self):
-        d = {}
-        for child in self.children:
-            instance = child()
-            if child.name != "":
-                d[child.name] = instance
-            else:
-                d[instance[0]] = instance[1]
-
-        return d
+        return {child.name: child() for child in self.children}
 
     @classmethod
     def _from_object(cls, source: dict):
@@ -38,22 +34,3 @@ class Dict(Object):
         instance._add_children(source.items())
         instance.cls = dict
         return instance
-
-    def _add_children(
-        self, items: Union[ItemsView[str, Any], Iterable[Tuple[str, Any]]]
-    ):
-        """
-        Add database representations of child attributes
-
-        Parameters
-        ----------
-        items
-            Attributes such as floats or priors that are associated
-            with the real object
-        """
-        self.children = [
-            Object.from_object(value, name=key)
-            if isinstance(key, str)
-            else Object.from_object((key, value))
-            for key, value in items
-        ]

--- a/autofit/database/model/fit.py
+++ b/autofit/database/model/fit.py
@@ -30,11 +30,7 @@ class Pickle(Base):
     name = sa.Column(sa.String)
     string = sa.Column(sa.String)
     fit_id = sa.Column(sa.String, sa.ForeignKey("fit.id"))
-    fit = sa.orm.relationship(
-        "Fit",
-        uselist=False,
-        back_populates="pickles",
-    )
+    fit = sa.orm.relationship("Fit", uselist=False)
 
     @property
     def value(self):
@@ -68,11 +64,7 @@ class JSON(Base):
     name = sa.Column(sa.String)
     string = sa.Column(sa.String)
     fit_id = sa.Column(sa.String, sa.ForeignKey("fit.id"))
-    fit = sa.orm.relationship(
-        "Fit",
-        uselist=False,
-        back_populates="jsons",
-    )
+    fit = sa.orm.relationship("Fit", uselist=False)
 
     @property
     def dict(self):
@@ -119,10 +111,7 @@ class NamedInstance(Base):
     instance_id = sa.Column(sa.Integer, sa.ForeignKey("object.id"))
 
     __instance = sa.orm.relationship(
-        "Object",
-        uselist=False,
-        backref="named_instance",
-        foreign_keys=[instance_id],
+        "Object", uselist=False, backref="named_instance", foreign_keys=[instance_id]
     )
 
     @property
@@ -193,10 +182,7 @@ class Fit(Base):
     )
     is_complete = sa.Column(sa.Boolean)
 
-    _named_instances: Mapped[List[NamedInstance]] = sa.orm.relationship(
-        "NamedInstance",
-        back_populates="fit",
-    )
+    _named_instances: Mapped[List[NamedInstance]] = sa.orm.relationship("NamedInstance")
 
     @property
     @try_none
@@ -218,7 +204,7 @@ class Fit(Base):
     def total_parameters(self):
         return self.model.prior_count if self.model else 0
 
-    _info: Mapped[List[Info]] = sa.orm.relationship("Info", back_populates="fit")
+    _info: Mapped[List[Info]] = sa.orm.relationship("Info")
 
     def __init__(self, **kwargs):
         try:
@@ -316,22 +302,17 @@ class Fit(Base):
     def model(self, model: AbstractPriorModel):
         self.__model = Object.from_object(model)
 
-    pickles: Mapped[List[Pickle]] = sa.orm.relationship(
-        "Pickle",
-        lazy="joined",
-    )
+    pickles: Mapped[List[Pickle]] = sa.orm.relationship("Pickle", lazy="joined")
     jsons: Mapped[List[JSON]] = sa.orm.relationship("JSON", lazy="joined")
     arrays: Mapped[List[Array]] = sa.orm.relationship(
         "Array",
         lazy="joined",
         foreign_keys=[Array.fit_id],
-        viewonly=True,
     )
     hdus: Mapped[List[HDU]] = sa.orm.relationship(
         "HDU",
         lazy="joined",
         foreign_keys=[HDU.fit_id],
-        viewonly=True,
     )
 
     def __getitem__(self, item: str):

--- a/autofit/database/model/model.py
+++ b/autofit/database/model/model.py
@@ -34,10 +34,7 @@ class Object(Base):
 
     samples_for_id = sa.Column(sa.String, sa.ForeignKey("fit.id"))
     samples_for = sa.orm.relationship(
-        "Fit",
-        uselist=False,
-        foreign_keys=[samples_for_id],
-        back_populates="_samples",
+        "Fit", uselist=False, foreign_keys=[samples_for_id]
     )
 
     latent_samples_for_id = sa.Column(sa.String, sa.ForeignKey("fit.id"))
@@ -45,13 +42,11 @@ class Object(Base):
         "Fit",
         uselist=False,
         foreign_keys=[latent_samples_for_id],
-        back_populates="_latent_samples",
     )
 
     children: Mapped[List["Object"]] = sa.orm.relationship(
         "Object",
         uselist=True,
-        back_populates="parent",
     )
 
     def __len__(self):

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 from abc import ABC
 from typing import Optional, Dict
@@ -41,10 +40,6 @@ class Analysis(ABC):
             raise AttributeError(f"Analysis has no attribute {item}")
 
         def method(*args, **kwargs):
-            parameters = inspect.signature(_method).parameters
-            if "analyses" in parameters:
-                logger.debug(f"Skipping {item} as this is not a combined analysis")
-                return
             return _method(self, *args, **kwargs)
 
         return method

--- a/test_autofit/database/test_regression.py
+++ b/test_autofit/database/test_regression.py
@@ -48,8 +48,3 @@ def test_samples_summary_model():
     fit.model = model
 
     assert fit["samples_summary"].model.cls == af.Gaussian
-
-
-def test_dict_with_tuple_keys():
-    d = {("a", "b"): 1}
-    assert db.Object.from_object(d)() == d


### PR DESCRIPTION
Reverts rhayes777/PyAutoFit#1044

These changes have led to the aggregator unit tests breaking on other projects:

```
test_autolens/aggregator/test_aggregator_fit_interferometer.py:123:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../PyAutoFit/autofit/database/aggregator/aggregator.py:255: in map
    yield func(fit)
../PyAutoFit/autofit/aggregator/base.py:161: in func_gen
    return [
../PyAutoFit/autofit/aggregator/base.py:162: in <listcomp>
    self.object_via_gen_from(
autolens/aggregator/fit_interferometer.py:167: in object_via_gen_from
    return _fit_interferometer_from(
autolens/aggregator/fit_interferometer.py:59: in _fit_interferometer_from
    dataset_list = _interferometer_from(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

fit = <Fit 4a97077027d1440b43bbd2c47aa20e12>, real_space_mask = None

    def _interferometer_from(
        fit: af.Fit,
        real_space_mask: Optional[aa.Mask2D] = None,
    ) -> List[aa.Interferometer]:
        """
        Returns a list of `Interferometer` objects from a `PyAutoFit` sqlite database `Fit` object.

        The results of a model-fit can be stored in a sqlite database, including the following attributes of the fit:

        - The interferometer visibilities data as a .fits file (`dataset/data.fits`).
        - The visibilities noise-map as a .fits file (`dataset/noise_map.fits`).
        - The uv wavelengths as a .fits file (`dataset/uv_wavelengths.fits`).
        - The real space mask defining the grid of the interferometer for the FFT (`dataset/real_space_mask.fits`).
        - The settings of the `Interferometer` data structure used in the fit (`dataset/settings.json`).

        Each individual attribute can be loaded from the database via the `fit.value()` method.

        This method combines all of these attributes and returns a `Interferometer` object, including having its
        settings updated to the values used by the model-fit.

        If multiple `Interferometer` objects were fitted simultaneously via analysis summing, the `fit.child_values()`
        method is instead used to load lists of the data, noise-map, PSF and mask and combine them into a list of
        `Interferometer` objects.

        Parameters
        ----------
        fit
            A `PyAutoFit` `Fit` object which contains the results of a model-fit as an entry in a sqlite database.
        """

        fit_list = [fit] if not fit.children else fit.children

        dataset_list = []

        for fit in fit_list:
            data = aa.Visibilities(
>               visibilities=fit.value(name="dataset.data").data.astype("float")
            )
E           AttributeError: 'NoneType' object has no attribute 'data'

../PyAutoGalaxy/autogalaxy/aggregator/interferometer/interferometer.py:44: AttributeError
--------------------------------------------------------------------------------------------- Captured stdout call ---------------------------------------------------------------------------------------------
2024-09-06 17:16:59,545 - autofit.non_linear.search.abstract_search - INFO - Starting non-linear search with 1 cores.
2024-09-06 17:16:59,548 - autolens.interferometer.model.analysis - INFO - PRELOADS - Setting up preloads, may take a few minutes for fits using an inversion.
2024-09-06 17:16:59,548 - autogalaxy.analysis.analysis.dataset - INFO - PRELOADS - Setting up preloads, may take a few minutes for fits using an inversion.
2024-09-06 17:16:59,565 - autolens.analysis.preloads - INFO - PRELOADS - Traced grid of planes (for inversion) preloaded for this model-fit.
2024-09-06 17:16:59,572 - root - INFO - The output path of this fit is /mnt/c/Users/Jammy/Code/PyAuto/PyAutoLens/test_autolens/output/db_fit_interferometer/4a97077027d1440b43bbd2c47aa20e12
2024-09-06 17:16:59,572 - root - INFO - Outputting pre-fit files (e.g. model.info, visualization).
2024-09-06 17:16:59,666 - root - INFO - Removing search internal folder.
2024-09-06 17:16:59,667 - root - INFO - Removing all files except for .zip file
2024-09-06 17:16:59,678 - root - INFO - Search complete, returning result
Aggregator loading search_outputs... could take some time.

 A total of 1 search_outputs and results were found.
2024-09-06 17:16:59,763 - autofit.database.aggregator.scrape - INFO - Scraping directory /mnt/c/Users/Jammy/Code/PyAuto/PyAutoLens/test_autolens/output/db_fit_interferometer
2024-09-06 17:16:59,764 - autofit.database.aggregator.scrape - INFO - 1 searches found
2024-09-06 17:17:00,006 - autofit.database.aggregator.scrape - INFO - Creating fit for: db_fit_interferometer None  4a97077027d1440b43bbd2c47aa20e12
2024-09-06 17:17:00,039 - autofit.database.aggregator.scrape - WARNING - Failed to load latent variables for 4a97077027d1440b43bbd2c47aa20e12
2024-09-06 17:17:00,166 - autofit.database.aggregator.aggregator - INFO - 1 fit(s) found matching query
---------------------------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------------------------
INFO     autofit.non_linear.search.abstract_search:abstract_search.py:576 Starting non-linear search with 1 cores.
INFO     autolens.interferometer.model.analysis:analysis.py:119 PRELOADS - Setting up preloads, may take a few minutes for fits using an inversion.
INFO     autogalaxy.analysis.analysis.dataset:dataset.py:109 PRELOADS - Setting up preloads, may take a few minutes for fits using an inversion.
INFO     autolens.analysis.preloads:preloads.py:182 PRELOADS - Traced grid of planes (for inversion) preloaded for this model-fit.
INFO     root:abstract_search.py:654 The output path of this fit is /mnt/c/Users/Jammy/Code/PyAuto/PyAutoLens/test_autolens/output/db_fit_interferometer/4a97077027d1440b43bbd2c47aa20e12
INFO     root:abstract_search.py:661 Outputting pre-fit files (e.g. model.info, visualization).
INFO     root:abstract_search.py:840 Removing search internal folder.
INFO     root:abstract_search.py:846 Removing all files except for .zip file
INFO     root:abstract_search.py:617 Search complete, returning result
INFO     autofit.database.aggregator.scrape:scrape.py:66 Scraping directory /mnt/c/Users/Jammy/Code/PyAuto/PyAutoLens/test_autolens/output/db_fit_interferometer
INFO     autofit.database.aggregator.scrape:scrape.py:67 1 searches found
INFO     autofit.database.aggregator.scrape:scrape.py:69 Creating fit for: db_fit_interferometer None  4a97077027d1440b43bbd2c47aa20e12
WARNING  autofit.database.aggregator.scrape:scrape.py:158 Failed to load latent variables for 4a97077027d1440b43bbd2c47aa20e12
INFO     autofit.database.aggregator.aggregator:aggregator.py:376 1 fit(s) found matching query
=============================================================================================== warnings summary ===============================================================================================
../../../../../../../home/jammy/venvs/PyAuto/lib/python3.10/site-packages/numpy/core/getlimits.py:542
  /home/jammy/venvs/PyAuto/lib/python3.10/site-packages/numpy/core/getlimits.py:542: UserWarning: Signature b'\x00\xd0\xcc\xcc\xcc\xcc\xcc\xcc\xfb\xbf\x00\x00\x00\x00\x00\x00' for <class 'numpy.longdouble'> does not match any known type: falling back to type probe function.
  This warnings indicates broken support for the dtype!
    machar = _get_machar(dtype)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```