### PR TITLE
do not throw away model when minimising samples

### DIFF
--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -407,7 +407,6 @@ class Samples(SamplesInterface, ABC):
         A copy of this object with only important samples retained
         """
         samples = copy(self)
-        samples.model = None
         samples.sample_list = list(
             {self.max_log_likelihood_sample, self.max_log_posterior_sample}
         )


### PR DESCRIPTION
This resolves the latent samples bug observed in #1042. When samples objects are minimised the model is retained so it can be used to recover instances etc.
