### PR TITLE
feature/sensitivity skip

### DIFF
--- a/autofit/example/analysis.py
+++ b/autofit/example/analysis.py
@@ -132,7 +132,7 @@ class Analysis(af.Analysis):
         Parameters
         ----------
         paths
-            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            The paths object which manages all paths, e.g. where the non-linear search outputs are stored,
             visualization, and the pickled objects used by the aggregator output by this function.
         """
         paths.save_json(name="data", object_dict=self.data.tolist(), prefix="dataset")

--- a/autofit/example/visualize.py
+++ b/autofit/example/visualize.py
@@ -33,7 +33,7 @@ class VisualizerExample(af.Visualizer):
         analysis
             The analysis class used to perform the model-fit whose quantities are being visualized.
         paths
-            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            The paths object which manages all paths, e.g. where the non-linear search outputs are stored,
             visualization, and the pickled objects used by the aggregator output by this function.
         model
             The model which is fitted to the data, which may be used to customize the visualization.
@@ -84,7 +84,7 @@ class VisualizerExample(af.Visualizer):
         analysis
             The analysis class used to perform the model-fit whose quantities are being visualized.
         paths
-            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            The paths object which manages all paths, e.g. where the non-linear search outputs are stored,
             visualization, and the pickled objects used by the aggregator output by this function.
         instance
             An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
@@ -163,7 +163,7 @@ class VisualizerExample(af.Visualizer):
         analyses
             A list of the analysis classes used to perform the model-fit whose quantities are being visualized.
         paths
-            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            The paths object which manages all paths, e.g. where the non-linear search outputs are stored,
             visualization, and the pickled objects used by the aggregator output by this function.
         model
             The model which is fitted to the data, which may be used to customize the visualization.
@@ -202,7 +202,7 @@ class VisualizerExample(af.Visualizer):
         analyses
             A list of the analysis classes used to perform the model-fit whose quantities are being visualized.
         paths
-            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            The paths object which manages all paths, e.g. where the non-linear search outputs are stored,
             visualization, and the pickled objects used by the aggregator output by this function.
         model
             The model which is fitted to the data, which may be used to customize the visualization.

--- a/autofit/non_linear/analysis/visualize.py
+++ b/autofit/non_linear/analysis/visualize.py
@@ -32,7 +32,7 @@ class Visualizer:
         Parameters
         ----------
         paths
-            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            The paths object which manages all paths, e.g. where the non-linear search outputs are stored,
             visualization and the pickled objects used by the aggregator output by this function.
 
         Returns

--- a/autofit/non_linear/grid/sensitivity/__init__.py
+++ b/autofit/non_linear/grid/sensitivity/__init__.py
@@ -65,6 +65,10 @@ class Sensitivity:
             The number of steps for each dimension of the sensitivity grid. If input as a float the dimensions are
             all that value. If input as a tuple of length the number of dimensions, each tuple value is the number of
             steps in that dimension.
+        mask
+            A mask to apply to the sensitivity grid, such that all `True` values are not included in the sensitivity
+            mapping. This is useful for removing regions of the sensitivity grid that are expected to have no
+            sensitivity, for example because they have no signal.
         number_of_cores
             How many cores does this computer have?
         limit_scale

--- a/autofit/non_linear/grid/sensitivity/__init__.py
+++ b/autofit/non_linear/grid/sensitivity/__init__.py
@@ -1,7 +1,7 @@
-import csv
 import logging
 import os
 from copy import copy
+import numpy as np
 from pathlib import Path
 from typing import List, Generator, Callable, ClassVar, Optional, Union, Tuple
 
@@ -14,7 +14,6 @@ from autofit.non_linear.grid.sensitivity.job import JobResult
 from autofit.non_linear.grid.sensitivity.result import SensitivityResult
 from autofit.non_linear.parallel import Process
 from autofit.text.formatter import write_table
-from autofit.text.text_util import padding
 
 
 class Sensitivity:
@@ -30,6 +29,7 @@ class Sensitivity:
         job_cls: ClassVar = Job,
         perturb_model_prior_func: Optional[Callable] = None,
         number_of_steps: Union[Tuple[int, ...], int] = 4,
+        mask: Optional[List[bool]] = None,
         number_of_cores: int = 2,
         limit_scale: int = 1,
     ):
@@ -94,6 +94,21 @@ class Sensitivity:
         self.job_cls = job_cls
 
         self.number_of_steps = number_of_steps
+        self.mask = mask
+
+        if mask is not None:
+            if self.shape != np.asarray(mask).shape:
+                raise ValueError(
+                    f"""
+                    The mask of the Sensitivity object must have the same shape as the sensitivity grid.
+                    
+                    For your inputs, the shape of each are as follows:
+                    
+                    Sensitivity Grid: {self.shape}
+                    Mask: {np.asarray(mask).shape}
+                    """
+                )
+
         self.number_of_cores = number_of_cores
 
         self.limit_scale = limit_scale

--- a/autofit/non_linear/grid/sensitivity/__init__.py
+++ b/autofit/non_linear/grid/sensitivity/__init__.py
@@ -169,7 +169,6 @@ class Sensitivity:
                 result.perturb_result.samples_summary for result in results
             ],
             shape=self.shape,
-            mask=self.mask,
         )
 
         self.paths.save_json("result", to_dict(sensitivity_result))

--- a/autofit/non_linear/grid/sensitivity/__init__.py
+++ b/autofit/non_linear/grid/sensitivity/__init__.py
@@ -350,27 +350,26 @@ class Sensitivity:
         perturb_model = self._perturb_models[number]
         label = self._labels[number]
 
-        if not self._should_bypass(number=number):
-            if self.perturb_model_prior_func is not None:
-                perturb_model = self.perturb_model_prior_func(
-                    perturb_instance=perturb_instance, perturb_model=perturb_model
-                )
-
-            simulate_instance = copy(self.instance)
-            simulate_instance.perturb = perturb_instance
-
-            paths = self.paths.for_sub_analysis(
-                label,
+        if self.perturb_model_prior_func is not None:
+            perturb_model = self.perturb_model_prior_func(
+                perturb_instance=perturb_instance, perturb_model=perturb_model
             )
 
-            return self.job_cls(
-                simulate_instance=simulate_instance,
-                model=self.model,
-                perturb_model=perturb_model,
-                base_instance=self.instance,
-                simulate_cls=self.simulate_cls,
-                base_fit_cls=self.base_fit_cls,
-                perturb_fit_cls=self.perturb_fit_cls,
-                paths=paths,
-                number=number,
-            )
+        simulate_instance = copy(self.instance)
+        simulate_instance.perturb = perturb_instance
+
+        paths = self.paths.for_sub_analysis(
+            label,
+        )
+
+        return self.job_cls(
+            simulate_instance=simulate_instance,
+            model=self.model,
+            perturb_model=perturb_model,
+            base_instance=self.instance,
+            simulate_cls=self.simulate_cls,
+            base_fit_cls=self.base_fit_cls,
+            perturb_fit_cls=self.perturb_fit_cls,
+            paths=paths,
+            number=number,
+        )

--- a/autofit/non_linear/grid/sensitivity/__init__.py
+++ b/autofit/non_linear/grid/sensitivity/__init__.py
@@ -98,9 +98,10 @@ class Sensitivity:
         self.job_cls = job_cls
 
         self.number_of_steps = number_of_steps
-        self.mask = np.array(mask)
+        self.mask = None
 
-        if self.mask is not None:
+        if mask is not None:
+            self.mask = np.asarray(mask)
             if self.shape != self.mask.shape:
                 raise ValueError(
                     f"""

--- a/autofit/non_linear/grid/sensitivity/__init__.py
+++ b/autofit/non_linear/grid/sensitivity/__init__.py
@@ -363,7 +363,7 @@ class Sensitivity:
                 label,
             )
 
-            yield self.job_cls(
+            return self.job_cls(
                 simulate_instance=simulate_instance,
                 model=self.model,
                 perturb_model=perturb_model,

--- a/autofit/non_linear/grid/sensitivity/job.py
+++ b/autofit/non_linear/grid/sensitivity/job.py
@@ -111,6 +111,7 @@ class Job(AbstractJob):
             model=self.model,
             dataset=dataset,
             paths=self.paths.for_sub_analysis("[base]"),
+            instance=self.simulate_instance,
         )
 
         perturb_model = copy(self.model)
@@ -120,6 +121,7 @@ class Job(AbstractJob):
             model=perturb_model,
             dataset=dataset,
             paths=self.paths.for_sub_analysis("[perturb]"),
+            instance=self.simulate_instance,
         )
 
         return JobResult(

--- a/autofit/non_linear/grid/sensitivity/job.py
+++ b/autofit/non_linear/grid/sensitivity/job.py
@@ -112,6 +112,24 @@ class Job(AbstractJob):
         self.perturb_fit_cls = perturb_fit_cls
         self.paths = paths
 
+    @property
+    def base_paths(self):
+        return self.paths.for_sub_analysis("[base]")
+
+    @property
+    def perturb_paths(self):
+        return self.paths.for_sub_analysis("[perturb]")
+
+    @property
+    def is_complete(self) -> bool:
+        """
+        Returns True if the job has been completed, False otherwise.
+        """
+        return (self.base_paths.is_complete and self.perturb_paths.is_complete) or (
+            (self.paths.output_path / "[base].zip").exists()
+            and (self.paths.output_path / "[perturb].zip").exists()
+        )
+
     def perform(self) -> JobResult:
         """
         - Create one model with a perturbation and another without
@@ -130,7 +148,7 @@ class Job(AbstractJob):
         result = self.base_fit_cls(
             model=self.model,
             dataset=dataset,
-            paths=self.paths.for_sub_analysis("[base]"),
+            paths=self.base_paths,
             instance=self.simulate_instance,
         )
 
@@ -140,7 +158,7 @@ class Job(AbstractJob):
         perturb_result = self.perturb_fit_cls(
             model=perturb_model,
             dataset=dataset,
-            paths=self.paths.for_sub_analysis("[perturb]"),
+            paths=self.perturb_paths,
             instance=self.simulate_instance,
         )
 

--- a/autofit/non_linear/grid/sensitivity/job.py
+++ b/autofit/non_linear/grid/sensitivity/job.py
@@ -140,10 +140,13 @@ class Job(AbstractJob):
         An object comprising the results of the two fits
         """
 
-        dataset = self.simulate_cls(
-            instance=self.simulate_instance,
-            simulate_path=self.paths.image_path.with_name("simulate"),
-        )
+        if self.is_complete:
+            dataset = None
+        else:
+            dataset = self.simulate_cls(
+                instance=self.simulate_instance,
+                simulate_path=self.paths.image_path.with_name("simulate"),
+            )
 
         result = self.base_fit_cls(
             model=self.model,
@@ -163,5 +166,7 @@ class Job(AbstractJob):
         )
 
         return JobResult(
-            number=self.number, result=result, perturb_result=perturb_result
+            number=self.number,
+            result=result,
+            perturb_result=perturb_result,
         )

--- a/autofit/non_linear/grid/sensitivity/job.py
+++ b/autofit/non_linear/grid/sensitivity/job.py
@@ -35,7 +35,10 @@ class JobResult(AbstractJobResult):
 
         if hasattr(self.result.samples, "log_evidence"):
             if self.result.samples.log_evidence is not None:
-                return float(self.perturb_result.samples.log_evidence - self.result.samples.log_evidence)
+                return float(
+                    self.perturb_result.samples.log_evidence
+                    - self.result.samples.log_evidence
+                )
 
     @property
     def log_likelihood_increase(self) -> Optional[float]:
@@ -46,6 +49,15 @@ class JobResult(AbstractJobResult):
         """
 
         return float(self.perturb_result.log_likelihood - self.result.log_likelihood)
+
+
+class MaskedJobResult(AbstractJobResult):
+    @property
+    def result(self):
+        return self
+
+    def __getattr__(self, item):
+        return None
 
 
 class Job(AbstractJob):

--- a/autofit/non_linear/grid/sensitivity/job.py
+++ b/autofit/non_linear/grid/sensitivity/job.py
@@ -56,6 +56,10 @@ class MaskedJobResult(AbstractJobResult):
     def result(self):
         return self
 
+    @property
+    def perturb_result(self):
+        return self
+
     def __getattr__(self, item):
         return None
 

--- a/autofit/non_linear/grid/sensitivity/job.py
+++ b/autofit/non_linear/grid/sensitivity/job.py
@@ -52,6 +52,10 @@ class JobResult(AbstractJobResult):
 
 
 class MaskedJobResult(AbstractJobResult):
+    """
+    A placeholder result for a job that has been masked out.
+    """
+
     @property
     def result(self):
         return self

--- a/autofit/non_linear/mock/mock_search.py
+++ b/autofit/non_linear/mock/mock_search.py
@@ -136,6 +136,7 @@ class MockSearch(NonLinearSearch):
         )
 
         self.paths.save_samples_summary(self.samples_summary)
+        self.paths.completed()
 
         return analysis.make_result(
             samples_summary=samples_summary,

--- a/autofit/non_linear/plot/nest_plotters.py
+++ b/autofit/non_linear/plot/nest_plotters.py
@@ -1,5 +1,3 @@
-from anesthetic.samples import NestedSamples
-from anesthetic import make_2d_axes
 from functools import wraps
 import numpy as np
 import warnings
@@ -59,6 +57,8 @@ class NestPlotter(SamplesPlotter):
 
         config_dict = conf.instance["visualize"]["plots_settings"]["corner_anesthetic"]
 
+        from anesthetic.samples import NestedSamples
+        from anesthetic import make_2d_axes
         import matplotlib.pylab as pylab
 
         params = {'font.size' : int(config_dict["fontsize"])}

--- a/docs/cookbooks/analysis.rst
+++ b/docs/cookbooks/analysis.rst
@@ -641,7 +641,7 @@ These files can then also be loaded via the database, as described in the databa
             Parameters
             ----------
             paths
-                The PyAutoFit paths object which manages all paths, e.g. where
+                The paths object which manages all paths, e.g. where
                 the non-linear search outputs are stored, visualization, and the
                 pickled objects used by the aggregator output by this function.
             """
@@ -674,7 +674,7 @@ These files can then also be loaded via the database, as described in the databa
             Parameters
             ----------
             paths
-                The PyAutoFit paths object which manages all paths, e.g. where the
+                The paths object which manages all paths, e.g. where the
                 non-linear search outputs are stored, visualization and the pickled
                 objects used by the aggregator output by this function.
             result

--- a/docs/cookbooks/result.rst
+++ b/docs/cookbooks/result.rst
@@ -553,7 +553,7 @@ as 1D numpy arrays, are converted to a suitable dictionary output format. This u
             Parameters
             ----------
             paths
-                The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+                The paths object which manages all paths, e.g. where the non-linear search outputs are stored,
                 visualization, and the pickled objects used by the aggregator output by this function.
             """
             from autoconf.dictable import to_dict
@@ -575,7 +575,7 @@ as 1D numpy arrays, are converted to a suitable dictionary output format. This u
             Parameters
             ----------
             paths
-                The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+                The paths object which manages all paths, e.g. where the non-linear search outputs are stored,
                 visualization and the pickled objects used by the aggregator output by this function.
             result
                 The result of a model fit, including the non-linear search, samples and maximum likelihood model.

--- a/test_autofit/non_linear/grid/test_sensitivity/conftest.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/conftest.py
@@ -38,7 +38,7 @@ class BaseFit:
     def __init__(self, analysis_cls):
         self.analysis_cls = analysis_cls
 
-    def __call__(self, dataset, model, paths):
+    def __call__(self, dataset, model, paths, instance):
         search = af.m.MockSearch(
             return_sensitivity_results=True,
             samples_summary=MockSamplesSummary(model=model),
@@ -53,7 +53,7 @@ class PerturbFit:
     def __init__(self, analysis_cls):
         self.analysis_cls = analysis_cls
 
-    def __call__(self, dataset, model, paths):
+    def __call__(self, dataset, model, paths, instance):
         search = af.m.MockSearch(
             return_sensitivity_results=True,
             samples_summary=MockSamplesSummary(model=model),

--- a/test_autofit/non_linear/grid/test_sensitivity/conftest.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/conftest.py
@@ -88,6 +88,37 @@ def make_sensitivity(
     )
 
 
+@pytest.fixture(name="masked_sensitivity")
+def make_masked_sensitivity(
+    perturb_model,
+):
+    # noinspection PyTypeChecker
+    instance = af.ModelInstance()
+    instance.gaussian = af.Gaussian()
+    return s.Sensitivity(
+        simulation_instance=instance,
+        base_model=af.Collection(gaussian=af.Model(af.Gaussian)),
+        perturb_model=perturb_model,
+        simulate_cls=Simulate(),
+        base_fit_cls=BaseFit(Analysis),
+        perturb_fit_cls=PerturbFit(Analysis),
+        paths=af.DirectoryPaths(),
+        number_of_steps=2,
+        mask=np.array(
+            [
+                [
+                    [True, True],
+                    [True, True],
+                ],
+                [
+                    [True, True],
+                    [True, True],
+                ],
+            ]
+        ),
+    )
+
+
 @pytest.fixture(name="job")
 def make_job(
     perturb_model,

--- a/test_autofit/non_linear/grid/test_sensitivity/conftest.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/conftest.py
@@ -42,6 +42,7 @@ class BaseFit:
         search = af.m.MockSearch(
             return_sensitivity_results=True,
             samples_summary=MockSamplesSummary(model=model),
+            paths=paths,
         )
 
         analysis = self.analysis_cls(dataset=dataset)
@@ -57,6 +58,7 @@ class PerturbFit:
         search = af.m.MockSearch(
             return_sensitivity_results=True,
             samples_summary=MockSamplesSummary(model=model),
+            paths=paths,
         )
 
         analysis = self.analysis_cls(dataset=dataset)

--- a/test_autofit/non_linear/grid/test_sensitivity/test_functionality.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/test_functionality.py
@@ -29,10 +29,14 @@ def test_labels(sensitivity):
 
 
 def test_perform_job(job):
+    assert not job.is_complete
+
     result = job.perform()
     assert isinstance(result, s.JobResult)
     assert isinstance(result.perturb_result, af.Result)
     assert isinstance(result.result, af.Result)
+
+    assert job.is_complete
 
 
 class TestPerturbationModels:

--- a/test_autofit/non_linear/grid/test_sensitivity/test_functionality.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/test_functionality.py
@@ -39,6 +39,18 @@ def test_perform_job(job):
     assert job.is_complete
 
 
+def test_perform_twice(job):
+    job.perform()
+    assert job.is_complete
+
+    result = job.perform()
+    assert isinstance(result, s.JobResult)
+    assert isinstance(result.perturb_result, af.Result)
+    assert isinstance(result.result, af.Result)
+
+    assert job.is_complete
+
+
 class TestPerturbationModels:
     @pytest.mark.parametrize(
         "limit_scale, fl, fu, sl, su",

--- a/test_autofit/non_linear/grid/test_sensitivity/test_masked_sensitivity.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/test_masked_sensitivity.py
@@ -1,0 +1,7 @@
+from math import prod
+
+
+def test_run(masked_sensitivity):
+    result = masked_sensitivity.run()
+    number_elements = prod(masked_sensitivity.shape)
+    assert len(result.samples) == number_elements


### PR DESCRIPTION
Partially resolves #1059

Essentially if a job has been performed we skip simulation and pass the data as None. It's a bit tricky to make the overall result as responsibility for creating base and peturb results is delegated to the base_fit_cls and peturb_fit_cls respectively. It is assumed that if these are called again with dataset = None that: 1) it won't crash. 2) they will just load the previously output results
