### PR TITLE
use masked results to ensure sensitivity result list always same lenght

### DIFF
--- a/autofit/non_linear/grid/sensitivity/__init__.py
+++ b/autofit/non_linear/grid/sensitivity/__init__.py
@@ -147,18 +147,16 @@ class Sensitivity:
         jobs = []
 
         for number in range(len(self._perturb_instances)):
-
-            if self._should_bypass(number=number):
-
-                model = self.model.copy()
-                model.perturb = self._perturb_models[number]
-                results.append(
-                    MaskedJobResult(
-                        number=number,
-                        model=model,
-                    )
+            model = self.model.copy()
+            model.perturb = self._perturb_models[number]
+            results.append(
+                MaskedJobResult(
+                    number=number,
+                    model=model,
                 )
-            else:
+            )
+
+            if not self._should_bypass(number=number):
                 jobs.append(self._make_job(number))
 
         for result in process_class.run_jobs(
@@ -167,8 +165,7 @@ class Sensitivity:
             if isinstance(result, Exception):
                 raise result
 
-            results.append(result)
-            results = sorted(results)
+            results[result.number] = result
 
             sensitivity_result = SensitivityResult(
                 samples=[result.result.samples_summary for result in results],
@@ -180,7 +177,9 @@ class Sensitivity:
             )
 
             if self.visualizer_cls is not None:
-                self.visualizer_cls(sensitivity_result=sensitivity_result, paths=self.paths)
+                self.visualizer_cls(
+                    sensitivity_result=sensitivity_result, paths=self.paths
+                )
 
             os.makedirs(self.paths.output_path, exist_ok=True)
 

--- a/test_autofit/non_linear/grid/test_sensitivity/test_masked_sensitivity.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/test_masked_sensitivity.py
@@ -69,3 +69,11 @@ def test_perturbed_physical_centres_list_from(masked_result):
         0.75,
         0.75,
     ]
+
+
+def test_visualise(sensitivity):
+    def visualiser(sensitivity_result, **_):
+        assert len(sensitivity_result.samples) == 8
+
+    sensitivity.visualizer_cls = visualiser
+    sensitivity.run()


### PR DESCRIPTION
Resolves #1069

Now incomplete sensitivity jobs are represented by MaskedJobResults until the job is completed
