### PR TITLE
Feature/enviroment warning

### DIFF
--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -272,8 +272,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             )
         ):
             if conf.instance["general"]["parallel"]["warn_environment_variables"]:
-                warnings.warn(
-                    exc.SearchWarning(
+                logger.info(
                         """
                         The non-linear search is using multiprocessing (number_of_cores>1). 
     
@@ -308,7 +307,6 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
                         `config -> general.yaml -> parallel: -> warn_environment_variables=False`
                         """
                     )
-                )
 
         self.optimisation_counter = Counter()
 

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -272,6 +272,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             )
         ):
             if conf.instance["general"]["parallel"]["warn_environment_variables"]:
+                warnings.warn(exc.SearchWarning(""))
                 logger.warning(
                         """
                         The non-linear search is using multiprocessing (number_of_cores>1). 

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -272,7 +272,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             )
         ):
             if conf.instance["general"]["parallel"]["warn_environment_variables"]:
-                logger.info(
+                logger.warning(
                         """
                         The non-linear search is using multiprocessing (number_of_cores>1). 
     


### PR DESCRIPTION
Use `logger.warning` instead of `warning` module as for some reason the warning module was not always warning people when it should have.