### PR TITLE
analysis_summed_latent

### DIFF
--- a/autofit/non_linear/analysis/combined.py
+++ b/autofit/non_linear/analysis/combined.py
@@ -413,3 +413,6 @@ class CombinedAnalysis(Analysis):
         from .free_parameter import FreeParameterAnalysis
 
         return FreeParameterAnalysis(*self.analyses, free_parameters=free_parameters)
+
+    def compute_latent_samples(self, samples):
+        return self.analyses[0].compute_latent_samples(samples=samples)


### PR DESCRIPTION
Hot fix to get latent variables working on summed `Analysis` objects.

Will implement properly in new year before merging.