### PR TITLE
Feature/checkpoint deleting

### DIFF
--- a/autofit/non_linear/grid/grid_search/__init__.py
+++ b/autofit/non_linear/grid/grid_search/__init__.py
@@ -273,7 +273,6 @@ class GridSearch:
 
     def save_metadata(self):
         self.paths.save_unique_tag(is_grid_search=True)
-        self.paths.zip_remove_nuclear()
 
     def make_jobs(self, model, analysis, grid_priors, info: Optional[Dict] = None):
         grid_priors = model.sort_priors_alphabetically(set(grid_priors))

--- a/autofit/non_linear/grid/grid_search/job.py
+++ b/autofit/non_linear/grid/grid_search/job.py
@@ -55,7 +55,6 @@ class Job(AbstractJob):
             model=self.model,
             analysis=self.analysis,
             info=self.info,
-            bypass_nuclear_if_on=True,
         )
         result_list_row = [
             self.index,

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -291,58 +291,6 @@ class AbstractPaths(ABC):
         except FileNotFoundError:
             pass
 
-    def zip_remove_nuclear(self):
-        """
-        When multiple model-fits are performed using the same `path_prefix` and `name`,
-        the results are populated in the same folder with different unique identifiers.
-
-        By accident, one may perform runs where additional results are placed
-        in these folders which are not wanted for the subsequent analysis.
-
-        Removing these results from the directory can be cumbersome, as determining
-        the unwanted results based on their unique identifier requires visually inspecting
-        them.
-
-        These unwanted results can also make manipulating the results via the database
-        problematic, as one may need to again filter based on unique identifier.
-
-        When a run is performed in nuclear mode, all results in every folder are
-        deleted except the results corresponding to the unique identifier of that run.
-
-        Therefore, provided the user is 100% certain that the run corresponds to the
-        results they want to keep, nuclear mode can be used to remove all unwanted results.
-
-        For example, suppose a folder has 5 results, 4 of which are unwanted and 1 which is
-        wanted. If nuclear mode runs, and the model-fit is set up correctly such that the
-        identifier created corresponds to the wanted result, all 4 unwanted results
-        will be deleted.
-
-        To enable nuclear mode, set the environment variable ``PYAUTOFIT_NUCLEAR_MODE=1``.
-
-        Nuclear mode is dangerous, and must be used with CAUTION AND CARE!
-        """
-
-        if os.environ.get("PYAUTOFIT_NUCLEAR_MODE") == "1":
-            file_path = Path(os.path.split(self.output_path)[0])
-
-            file_list = os.listdir(file_path)
-            file_list = [file for file in file_list if self.identifier not in file]
-
-            for file in file_list:
-                file_to_remove = file_path / file
-
-                try:
-                    os.remove(file_to_remove)
-                    logger.info(f"NUCLEAR MODE -- Removed {file_to_remove}")
-                except (IsADirectoryError, FileNotFoundError):
-                    pass
-
-                try:
-                    shutil.rmtree(file_to_remove)
-                    logger.info(f"NUCLEAR MODE -- Removed {file_to_remove}")
-                except (NotADirectoryError, FileNotFoundError):
-                    pass
-
     def restore(self):
         """
         Copy files from the ``.zip`` file to the samples folder.

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -534,7 +534,6 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         model: AbstractPriorModel,
         analysis: Analysis,
         info: Optional[Dict] = None,
-        bypass_nuclear_if_on: bool = False,
     ) -> Union[Result, List[Result]]:
         """
         Fit a model, M with some function f that takes instances of the
@@ -557,9 +556,6 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         info
             Optional dictionary containing information about the fit that can be saved in the `files` folder
             (e.g. as `files/info.json`) and can be loaded via the database.
-        bypass_nuclear_if_on
-            If nuclear mode is on (environment variable "PYAUTOFIT_NUCLEAR_MODE=1") passing this as True will
-            bypass it.
 
         Returns
         -------
@@ -612,7 +608,6 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             )
 
             self.post_fit_output(
-                bypass_nuclear_if_on=bypass_nuclear_if_on,
                 search_internal=result.search_internal,
             )
 
@@ -847,7 +842,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
         return result
 
-    def post_fit_output(self, search_internal, bypass_nuclear_if_on: bool):
+    def post_fit_output(self, search_internal):
         """
         Cleans up the output folderds after a completed non-linear search.
 
@@ -860,8 +855,8 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
         Parameters
         ----------
-        bypass_nuclear_if_on
-            Whether to use nuclear mode to delete a lot of files (see nuclear mode description).
+        search_internal
+            The internal search.
         """
         if not conf.instance["output"]["search_internal"]:
             self.logger.info("Removing search internal folder.")
@@ -873,9 +868,6 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             self.logger.info("Removing all files except for .zip file")
 
         self.paths.zip_remove()
-
-        if not bypass_nuclear_if_on:
-            self.paths.zip_remove_nuclear()
 
     @abstractmethod
     def _fit(self, model: AbstractPriorModel, analysis: Analysis):

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -481,6 +481,11 @@ class AbstractDynesty(AbstractNest, ABC):
         raise NotImplementedError()
 
     def output_search_internal(self, search_internal):
+
+        self.paths.save_search_internal(
+            obj=search_internal,
+        )
+
         try:
             os.remove(self.checkpoint_file)
         except (TypeError, FileNotFoundError):

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -201,11 +201,6 @@ class AbstractDynesty(AbstractNest, ABC):
                     during_analysis=True,
                 )
 
-        try:
-            os.remove(self.checkpoint_file)
-        except TypeError:
-            pass
-
         return search_internal
 
     def samples_info_from(self, search_internal=None):

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -480,6 +480,12 @@ class AbstractDynesty(AbstractNest, ABC):
     ):
         raise NotImplementedError()
 
+    def output_search_internal(self, search_internal):
+        try:
+            os.remove(self.checkpoint_file)
+        except TypeError:
+            pass
+
     def check_pool(self, uses_pool: bool, pool):
         if (uses_pool and pool is None) or (not uses_pool and pool is not None):
             raise exc.SearchException(

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -483,7 +483,7 @@ class AbstractDynesty(AbstractNest, ABC):
     def output_search_internal(self, search_internal):
         try:
             os.remove(self.checkpoint_file)
-        except TypeError:
+        except (TypeError, FileNotFoundError):
             pass
 
     def check_pool(self, uses_pool: bool, pool):

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -464,6 +464,10 @@ class Nautilus(abstract_nest.AbstractNest):
         search_internal.pool_l = pool_l
         search_internal.pool_s = pool_s
 
+        if self.checkpoint_file is not None:
+
+            os.remove(self.checkpoint_file)
+
     def samples_info_from(self, search_internal=None):
         return {
             "log_evidence": search_internal.evidence(),

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -159,10 +159,6 @@ class Nautilus(abstract_nest.AbstractNest):
                     checkpoint_exists=checkpoint_exists,
                 )
 
-        if self.checkpoint_file is not None:
-
-            os.remove(self.checkpoint_file)
-
         return search_internal
 
     @property

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -464,9 +464,10 @@ class Nautilus(abstract_nest.AbstractNest):
         search_internal.pool_l = pool_l
         search_internal.pool_s = pool_s
 
-        if self.checkpoint_file is not None:
-
+        try:
             os.remove(self.checkpoint_file)
+        except (TypeError, FileNotFoundError):
+            pass
 
     def samples_info_from(self, search_internal=None):
         return {


### PR DESCRIPTION
This PR removes legacy code that manually deletes checkpoint files for Nautilus and Dynesty searches and completely eliminates the nuclear mode functionality that is no longer used.

- Removed checkpoint file deletion if statements from Nautilus and Dynesty search modules
- Eliminated nuclear mode logic from abstract search, paths, and grid search modules