### PR TITLE
feature/jax initial samples

### DIFF
--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -1,10 +1,12 @@
-import numpy as np
+
 import os
 from typing import Optional
 
 from autoconf import conf
 
 from autofit import exc
+
+from autofit.jax_wrapper import numpy as np
 
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.paths.abstract import AbstractPaths
@@ -155,7 +157,7 @@ class Fitness:
             instance = self.model.instance_from_vector(vector=parameters)
             log_likelihood = self.log_likelihood_function(instance=instance)
 
-            if np.isnan(log_likelihood):
+            if not jax_wrapper.use_jax and np.isnan(log_likelihood):
                 return self.resample_figure_of_merit
 
         except exc.FitException:

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -156,9 +156,7 @@ class Fitness:
         try:
             instance = self.model.instance_from_vector(vector=parameters)
             log_likelihood = self.log_likelihood_function(instance=instance)
-
-            if not jax_wrapper.use_jax and np.isnan(log_likelihood):
-                return self.resample_figure_of_merit
+            log_likelihood = np.where(np.isnan(log_likelihood), self.resample_figure_of_merit, log_likelihood)
 
         except exc.FitException:
             return self.resample_figure_of_merit


### PR DESCRIPTION
Fixes to make JAX sampling work:

- Samples  made via `Initializer` object do not use `multiprocessing` pool, the code for this will be cleaned up in the future but I need a better understanding of the JAX implementation as a whole.
- Fix how nan values are resampled.