### PR TITLE
Feature/jax latent

### DIFF
--- a/autofit/config/output.yaml
+++ b/autofit/config/output.yaml
@@ -86,7 +86,7 @@ start_point: true
 # manually after completing a successful model-fit. This will save computational run time by not computing latent
 # variables during a any model-fit which is unsuccessful.
 
-latent_during_fit: true # Whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files during the fit when it performs on-the-fly output.
+latent_during_fit: false # Whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files during the fit when it performs on-the-fly output.
 latent_after_fit: true # If `latent_during_fit` is False, whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files after the fit is complete.
 latent_csv: true # Whether to ouptut the `latent.csv` file.
 latent_results: true # Whether to output the `latent.results` file.

--- a/autofit/config/output.yaml
+++ b/autofit/config/output.yaml
@@ -88,6 +88,8 @@ start_point: true
 
 latent_during_fit: false # Whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files during the fit when it performs on-the-fly output.
 latent_after_fit: true # If `latent_during_fit` is False, whether to output the `latent.csv`, `latent.results` and `latent_summary.json` files after the fit is complete.
+latent_draw_via_pdf : true # Whether to draw latent variable values via the PDF of every sample, which uses fewer samples to estimate latent variable errors. If False, latent variable values are drawn from every sample.
+latent_draw_via_pdf_size : 100 # The number of samples drawn to estimate latent variable errors if `latent_draw_via_pdf` is True.
 latent_csv: true # Whether to ouptut the `latent.csv` file.
 latent_results: true # Whether to output the `latent.results` file.
 

--- a/autofit/example/analysis.py
+++ b/autofit/example/analysis.py
@@ -34,8 +34,9 @@ class Analysis(af.Analysis):
     It has been extended, based on the model that is input into the analysis, to include a 
     property `max_log_likelihood_model_data`, which is the model data of the best-fit model.
     """
-
     Result = ResultExample
+
+    LATENT_KEYS = ["fwhm"]
 
     def __init__(self, data: np.ndarray, noise_map: np.ndarray):
         """
@@ -231,9 +232,9 @@ class Analysis(af.Analysis):
 
         """
         try:
-            return {"fwhm": instance.fwhm}
+            return (instance.fwhm, )
         except AttributeError:
             try:
-                return {"gaussian.fwhm": instance[0].fwhm}
+                return (instance[0].fwhm,)
             except AttributeError:
-                return {"gaussian.fwhm": instance[0].gaussian.fwhm}
+                return (instance[0].gaussian.fwhm,)

--- a/autofit/example/analysis.py
+++ b/autofit/example/analysis.py
@@ -205,7 +205,7 @@ class Analysis(af.Analysis):
             analysis=self,
         )
 
-    def compute_latent_variables(self, instance) -> Dict[str, float]:
+    def compute_latent_variables(self, parameters, model) -> Dict[str, float]:
         """
         A latent variable is not a model parameter but can be derived from the model. Its value and errors may be
         of interest and aid in the interpretation of a model-fit.
@@ -219,8 +219,15 @@ class Analysis(af.Analysis):
         In the example below, the `latent.csv` file will contain one column with the FWHM of every Gausian model
         sampled by the non-linear search.
 
-        This function is called for every non-linear search sample, where the `instance` passed in corresponds to
-        each sample.
+        This function is called at the end of search, following one of two schemes depending on the settings in
+        `output.yaml`:
+
+        1) Call for every search sample, which produces a complete `latent/samples.csv` which mirrors the normal
+        `samples.csv` file but takes a long time to compute.
+
+        2) Call only for N random draws from the posterior inferred at the end of the search, which only produces a
+        `latent/latent_summary.json` file with the median and 1 and 3 sigma errors of the latent variables but is
+        fast to compute.
 
         Parameters
         ----------
@@ -231,6 +238,8 @@ class Analysis(af.Analysis):
         -------
 
         """
+        instance = model.instance_from_vector(vector=parameters)
+
         try:
             return (instance.fwhm, )
         except AttributeError:

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -63,21 +63,26 @@ class Analysis(ABC):
         The computed latent samples or None if compute_latent_variables is not implemented.
         """
         try:
+
             latent_samples = []
             model = samples.model
             for sample in samples.sample_list:
+
+                kwargs = self.compute_latent_variables(
+                    sample.instance_for_model(model, ignore_assertions=True)
+                )
+
+                # convert all values to Python floats to remove JAX arrays
+                kwargs = {k: float(v) if hasattr(v, "__array__") or isinstance(v, (np.generic,)) else v
+                          for k, v in kwargs.items()}
+
                 latent_samples.append(
                     Sample(
                         log_likelihood=sample.log_likelihood,
                         log_prior=sample.log_prior,
                         weight=sample.weight,
-                        kwargs=self.compute_latent_variables(
-                            sample.instance_for_model(
-                                model,
-                                ignore_assertions=True,
-                            )
-                        ),
-                    )
+                        kwargs=kwargs
+                        )
                 )
 
             return type(samples)(

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -95,7 +95,10 @@ class Analysis(ABC):
             compute_latent_for_model = functools.partial(self.compute_latent_variables, model=samples.model)
 
             if use_jax:
+                start = time.time()
+                logger.info("JAX: Applying vmap and jit to likelihood function for latent variables -- may take a few seconds.")
                 batched_compute_latent = jax.jit(jax.vmap(compute_latent_for_model))
+                logger.info(f"JAX: vmap and jit applied in {time.time() - start} seconds.")
             else:
                 def batched_compute_latent(x):
                     return np.array([compute_latent_for_model(xx) for xx in x])
@@ -113,11 +116,10 @@ class Analysis(ABC):
                 latent_values_batch = batched_compute_latent(batch)
 
                 if use_jax:
-               #     latent_values_batch = jnp.stack(latent_values_batch, axis=-1)  # (batch, n_latents)
+                    latent_values_batch = jnp.stack(latent_values_batch, axis=-1)  # (batch, n_latents)
                     mask = jnp.all(jnp.isfinite(latent_values_batch), axis=0)
                     latent_values_batch = latent_values_batch[:, mask]
                 else:
-               #     latent_values_batch = np.stack(latent_values_batch, axis=-1)  # (batch, n_latents)
                     mask = np.all(np.isfinite(latent_values_batch), axis=0)
                     latent_values_batch = latent_values_batch[:, mask]
 

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -187,26 +187,26 @@ class Fitness:
     @cached_property
     def _vmap(self):
         start = time.time()
-        print("JAX: Applying vmap and jit to likelihood function -- may take a few seconds.")
+        logger.info("JAX: Applying vmap and jit to likelihood function -- may take a few seconds.")
         func = jax.vmap(jax.jit(self.call))
-        print(f"JAX: vmap and jit applied in {time.time() - start} seconds.")
+        logger.info(f"JAX: vmap and jit applied in {time.time() - start} seconds.")
         return func
 
     @cached_property
     def _call(self):
         start = time.time()
-        print("JAX: Applying jit to likelihood function -- may take a few seconds.")
+        logger.info("JAX: Applying jit to likelihood function -- may take a few seconds.")
         func = jax_wrapper.jit(self.call)
-        print(f"JAX: jit applied in {time.time() - start} seconds.")
+        logger.info(f"JAX: jit applied in {time.time() - start} seconds.")
         return func
 
 
     @cached_property
     def _grad(self):
         start = time.time()
-        print("JAX: Applying grad to likelihood function -- may take a few seconds.")
+        logger.info("JAX: Applying grad to likelihood function -- may take a few seconds.")
         func = jax_wrapper.grad(self._call)
-        print(f"JAX: grad applied in {time.time() - start} seconds.")
+        logger.info(f"JAX: grad applied in {time.time() - start} seconds.")
         return func
 
     def grad(self, *args, **kwargs):

--- a/autofit/non_linear/samples/pdf.py
+++ b/autofit/non_linear/samples/pdf.py
@@ -328,6 +328,37 @@ class SamplesPDF(Samples):
 
         return self.parameter_lists[sample_index][:]
 
+    def samples_drawn_randomly_via_pdf_from(self, total_draws: int = 100) -> "SamplesPDF":
+        """
+        Draw one or more samples randomly from the PDF, weighted by the sample weights.
+
+        Parameters
+        ----------
+        total_draws : int, optional
+            The number of samples to draw. Defaults to 100.
+
+        Returns
+        -------
+        SamplesPDF
+            A new SamplesPDF object containing the drawn samples.
+        """
+        # Normalize weights to sum to 1
+        weights = np.asarray(self.weight_list, dtype=float)
+        weights /= weights.sum()
+
+        sample_indices = np.random.choice(
+            a=len(self.sample_list),
+            size=total_draws,
+            replace=True,
+            p=weights,
+        )
+
+        return SamplesPDF(
+            model=self.model,
+            sample_list=[self.sample_list[i] for i in sample_indices],
+            samples_info=self.samples_info,
+        )
+
     @to_instance
     def offset_values_via_input_values(
         self, input_vector: List

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -958,10 +958,26 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             if (during_analysis and conf.instance["output"]["latent_during_fit"]) or (
                 not during_analysis and conf.instance["output"]["latent_after_fit"]
             ):
+
+                if conf.instance["output"]["latent_draw_via_pdf"]:
+
+                    total_draws = conf.instance["output"]["latent_draw_via_pdf_size"]
+
+                    logger.info(f"Creating latent samples by drawing {total_draws} from the PDF.")
+
+                    latent_samples = samples.samples_drawn_randomly_via_pdf_from(total_draws=total_draws)
+
+                else:
+
+                    logger.info(f"Creating latent samples using all samples above the samples weight threshold.")
+
+                    latent_samples = samples_save
+
                 latent_samples = analysis.compute_latent_samples(samples_save)
 
                 if latent_samples:
-                    self.paths.save_latent_samples(latent_samples)
+                    if not conf.instance["output"]["latent_draw_via_pdf"]:
+                        self.paths.save_latent_samples(latent_samples)
                     self.paths.save_samples_summary(
                         latent_samples.summary(),
                         "latent/latent_summary",

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -250,7 +250,7 @@ class Nautilus(abstract_nest.AbstractNest):
         """
         search_internal = self.sampler_cls(
             prior=PriorVectorized(model=model),
-            likelihood=fitness.call_numpy_wrapper,
+            likelihood=fitness.__call__,
             n_dim=model.prior_count,
             prior_kwargs={"model": model},
             filepath=self.checkpoint_file,

--- a/test_autofit/analysis/test_latent_variables.py
+++ b/test_autofit/analysis/test_latent_variables.py
@@ -13,7 +13,10 @@ class Analysis(af.Analysis):
     def log_likelihood_function(self, instance):
         return 1.0
 
-    def compute_latent_variables(self, instance, model):
+    def compute_latent_variables(self, parameters, model):
+
+        instance = model.instance_from_vector(vector=parameters)
+
         return (instance.fwhm,)
 
 
@@ -109,7 +112,10 @@ class ComplexAnalysis(af.Analysis):
     def log_likelihood_function(self, instance):
         return 1.0
 
-    def compute_latent_variables(self, instance, model):
+    def compute_latent_variables(self, parameters, model):
+
+        instance = model.instance_from_vector(vector=parameters)
+
         return (1.0, 2.0, 3.0)
 
 
@@ -136,8 +142,6 @@ def test_complex_model():
     instance = latent_samples.model.instance_from_prior_medians()
 
     lens = instance.lens
-
-    print(lens)
 
     assert lens.mass == 1.0
     assert lens.brightness == 2.0

--- a/test_autofit/analysis/test_latent_variables.py
+++ b/test_autofit/analysis/test_latent_variables.py
@@ -7,11 +7,14 @@ from autofit.text.text_util import result_info_from
 
 
 class Analysis(af.Analysis):
+
+    LATENT_KEYS = ["fwhm"]
+
     def log_likelihood_function(self, instance):
         return 1.0
 
-    def compute_latent_variables(self, instance):
-        return {"fwhm": instance.fwhm}
+    def compute_latent_variables(self, instance, model):
+        return (instance.fwhm,)
 
 
 @with_config(
@@ -100,15 +103,14 @@ instances
 
 
 class ComplexAnalysis(af.Analysis):
+
+    LATENT_KEYS = ["lens.mass", "lens.brightness", "source.brightness"]
+
     def log_likelihood_function(self, instance):
         return 1.0
 
-    def compute_latent_variables(self, instance):
-        return {
-            "lens.mass": 1.0,
-            "lens.brightness": 2.0,
-            "source.brightness": 3.0,
-        }
+    def compute_latent_variables(self, instance, model):
+        return (1.0, 2.0, 3.0)
 
 
 def test_complex_model():
@@ -134,6 +136,9 @@ def test_complex_model():
     instance = latent_samples.model.instance_from_prior_medians()
 
     lens = instance.lens
+
+    print(lens)
+
     assert lens.mass == 1.0
     assert lens.brightness == 2.0
 

--- a/test_autofit/non_linear/samples/test_samples.py
+++ b/test_autofit/non_linear/samples/test_samples.py
@@ -164,6 +164,36 @@ def test__samples_above_weight_threshold_from():
     assert len(samples_above_weight_threshold) == 3
     assert samples_above_weight_threshold.sample_list[0].weight == 1.0
 
+def test__samples_drawn_randomly_via_pdf_from():
+
+    model = af.Collection(mock_class=af.m.MockClassx4)
+
+    parameters = [
+        [1.0, 2.0, 3.0, 4.0],
+        [5.0, 6.0, 7.0, 8.0],
+        [1.0, 2.0, 3.0, 4.0],
+        [1.0, 2.0, 3.0, 4.0],
+        [1.1, 2.1, 3.1, 4.1],
+    ]
+
+    samples_x5 = af.m.MockSamples(
+        model=model,
+        sample_list=af.Sample.from_lists(
+            model=model,
+            parameter_lists=parameters,
+            log_likelihood_list=[0.0, 0.0, 0.0, 0.0, 0.0],
+            log_prior_list=[0.0, 0.0, 0.0, 0.0, 0.0],
+            weight_list=[0.2, 0.2, 1.0, 1.0, 1.0],
+        ),
+    )
+
+    samples_drawn_randomly_via_pdf = samples_x5.samples_drawn_randomly_via_pdf_from(
+        total_draws=3
+    )
+
+    assert len(samples_drawn_randomly_via_pdf) == 3
+    assert samples_drawn_randomly_via_pdf.sample_list[0].weight == 1.0
+
 def test__addition_of_samples(samples_x5):
     samples = samples_x5 + samples_x5
 


### PR DESCRIPTION
Update the `compute_latent_variables` method to support:

- Jax `jit` and `vmap` inside of it, which required it to not return a `dict` and thus the keys of the latent variables became a class variables `LATENT_KEYS`.
- Make it so that just a `latent.summary` file can be created via PDF redraws to speed up latent variable time computation.