### PR TITLE
Feature/build fixes

### DIFF
--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -94,7 +94,6 @@ from .non_linear.result import Result
 from .non_linear.result import ResultsCollection
 from .non_linear.settings import SettingsSearch
 from .non_linear.samples.pdf import marginalize
-from .example.model import Gaussian, Exponential
 from .text import formatter
 from .text import samples_text
 from .visualise import VisualiseGraph
@@ -129,6 +128,7 @@ for type_ in (
     "LogUniform",
     "Gaussian",
     "LogGaussian",
+    "TruncatedGaussian",
     "compound",
     "Constant",
 ):

--- a/autofit/fixtures.py
+++ b/autofit/fixtures.py
@@ -7,7 +7,7 @@ from autofit.non_linear.mock.mock_samples import MockSamples
 def make_model_gaussian_x1():
 
     return af.Model(
-        af.Gaussian
+        af.ex.Gaussian
     )
 
 

--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -233,6 +233,7 @@ class Prior(Variable, ABC, ArithmeticMixin):
         )
         if id_ is not None:
             loaded_ids[id_] = prior
+
         return prior
 
     def dict(self) -> dict:

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -406,11 +406,12 @@ class Model(AbstractPriorModel):
             logger.exception(key)
 
     def __getattr__(self, item):
-        if item in ("_is_frozen", "tuple_prior_tuples"):
-            return self.__getattribute__(item)
-
         try:
-            if "_" in item and not item.startswith("_"):
+            if (
+                "_" in item
+                and item not in ("_is_frozen", "tuple_prior_tuples")
+                and not item.startswith("_")
+            ):
                 return getattr(
                     [v for k, v in self.tuple_prior_tuples if item.split("_")[0] == k][
                         0
@@ -421,17 +422,35 @@ class Model(AbstractPriorModel):
         except IndexError:
             pass
 
-        try:
-            return getattr(
-                self.instance_for_arguments(
-                    {prior: prior for prior in self.priors},
-                ),
-                item,
-            )
-        except (AttributeError, TypeError):
-            pass
-
         self.__getattribute__(item)
+
+    # def __getattr__(self, item):
+    #     if item in ("_is_frozen", "tuple_prior_tuples"):
+    #         return self.__getattribute__(item)
+    #
+    #     try:
+    #         if "_" in item and not item.startswith("_"):
+    #             return getattr(
+    #                 [v for k, v in self.tuple_prior_tuples if item.split("_")[0] == k][
+    #                     0
+    #                 ],
+    #                 item,
+    #             )
+    #
+    #     except IndexError:
+    #         pass
+    #
+    #     try:
+    #         return getattr(
+    #             self.instance_for_arguments(
+    #                 {prior: prior for prior in self.priors},
+    #             ),
+    #             item,
+    #         )
+    #     except (AttributeError, TypeError):
+    #         pass
+    #
+    #     self.__getattribute__(item)
 
     @property
     def is_deferred_arguments(self):

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -74,14 +74,11 @@ class TruncatedNormalMessage(AbstractMessage):
         ----------
         mean
             The mean (μ) of the normal distribution.
-
         sigma
             The standard deviation (σ) of the distribution. Must be non-negative.
-
         log_norm
             An additive constant to the log probability of the message. Used internally for message-passing normalization.
             Default is 0.0.
-
         id_
             An optional unique identifier used to track the message in larger probabilistic graphs or models.
         """
@@ -96,6 +93,7 @@ class TruncatedNormalMessage(AbstractMessage):
             log_norm=log_norm,
             id_=id_,
         )
+
         self.mean, self.sigma, self.lower_limit, self.upper_limit = self.parameters
 
     def cdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:

--- a/autofit/non_linear/plot/__init__.py
+++ b/autofit/non_linear/plot/__init__.py
@@ -1,2 +1,5 @@
 from autofit.non_linear.plot.samples_plotters import SamplesPlotter
+from autofit.non_linear.plot.mcmc_plotters import MCMCPlotter
+from autofit.non_linear.plot.mle_plotters import MLEPlotter
+from autofit.non_linear.plot.nest_plotters import NestPlotter
 from autofit.non_linear.plot.output import Output

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -965,7 +965,14 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
 
                     logger.info(f"Creating latent samples by drawing {total_draws} from the PDF.")
 
-                    latent_samples = samples.samples_drawn_randomly_via_pdf_from(total_draws=total_draws)
+                    try:
+                        latent_samples = samples.samples_drawn_randomly_via_pdf_from(total_draws=total_draws)
+                    except AttributeError:
+                        latent_samples = samples_save
+                        logger.info(
+                            "Drawing via PDF not available for this search, "
+                            "using all samples above the samples weight threshold instead."
+                            "")
 
                 else:
 

--- a/autofit/plot/__init__.py
+++ b/autofit/plot/__init__.py
@@ -1,0 +1,2 @@
+from autofit.non_linear.plot.samples_plotters import SamplesPlotter
+from autofit.non_linear.plot.output import Output

--- a/autofit/plot/__init__.py
+++ b/autofit/plot/__init__.py
@@ -1,2 +1,5 @@
 from autofit.non_linear.plot.samples_plotters import SamplesPlotter
+from autofit.non_linear.plot.mcmc_plotters import MCMCPlotter
+from autofit.non_linear.plot.mle_plotters import MLEPlotter
+from autofit.non_linear.plot.nest_plotters import NestPlotter
 from autofit.non_linear.plot.output import Output

--- a/test_autofit/aggregator/test_reference.py
+++ b/test_autofit/aggregator/test_reference.py
@@ -26,11 +26,11 @@ def test_with():
 
     aggregator = Aggregator.from_directory(
         Path(__file__).parent,
-        reference={"": get_class_path(af.Exponential)},
+        reference={"": get_class_path(af.ex.Exponential)},
     )
     output_list = list(aggregator)
     model_list = [output.model for output in output_list]
-    assert any([getattr(model, "cls", False) is af.Exponential for model in model_list])
+    assert any([getattr(model, "cls", False) is af.ex.Exponential for model in model_list])
 
 @pytest.fixture(name="database_path")
 def database_path(output_directory):
@@ -49,7 +49,7 @@ def database_aggregator(
     )
     aggregator.add_directory(
         directory,
-        reference={"": get_class_path(af.Exponential)},
+        reference={"": get_class_path(af.ex.Exponential)},
         completed_only=True,
     )
 
@@ -59,7 +59,7 @@ def database_aggregator(
 def test_database(database_aggregator):
     fit = list(database_aggregator)[0]
     model = fit.model
-    assert model.cls is af.Exponential
+    assert model.cls is af.ex.Exponential
 
 
 @pytest.fixture(name="info")

--- a/test_autofit/aggregator/test_reference.py
+++ b/test_autofit/aggregator/test_reference.py
@@ -19,7 +19,7 @@ def test_without(directory):
     aggregator = Aggregator.from_directory(directory)
     model_list = [agg.model for agg in aggregator]
 
-    assert any([getattr(model, "cls", False) is af.Gaussian for model in model_list])
+    assert any([getattr(model, "cls", False) is af.ex.Gaussian for model in model_list])
 
 
 def test_with():

--- a/test_autofit/analysis/conftest.py
+++ b/test_autofit/analysis/conftest.py
@@ -9,7 +9,7 @@ class Result(af.mock.MockResult):
 
 class Analysis(af.Analysis):
     def log_likelihood_function(self, instance):
-        return 1.0 if isinstance(instance, af.Gaussian) else 0.0
+        return 1.0 if isinstance(instance, af.ex.Gaussian) else 0.0
 
     def make_result(self, samples):
         return Result(
@@ -29,4 +29,4 @@ def analysis_class():
 
 @pytest.fixture(name="model")
 def make_model():
-    return af.Model(af.Gaussian)
+    return af.Model(af.ex.Gaussian)

--- a/test_autofit/analysis/test_latent_variables.py
+++ b/test_autofit/analysis/test_latent_variables.py
@@ -55,7 +55,7 @@ def make_latent_samples():
     analysis = Analysis()
     return analysis.compute_latent_samples(
         SamplesPDF(
-            model=af.Model(af.Gaussian),
+            model=af.Model(af.ex.Gaussian),
             sample_list=[
                 af.Sample(
                     log_likelihood=1.0,
@@ -123,7 +123,7 @@ def test_complex_model():
     analysis = ComplexAnalysis()
     latent_samples = analysis.compute_latent_samples(
         SamplesPDF(
-            model=af.Model(af.Gaussian),
+            model=af.Model(af.ex.Gaussian),
             sample_list=[
                 af.Sample(
                     log_likelihood=1.0,

--- a/test_autofit/analysis/test_regression.py
+++ b/test_autofit/analysis/test_regression.py
@@ -33,7 +33,7 @@ class MyAnalysis(af.Analysis):
 
 
 def test_result_type():
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
 
     analysis = MyAnalysis().with_model(model)
 

--- a/test_autofit/database/identifier/test_identifiers.py
+++ b/test_autofit/database/identifier/test_identifiers.py
@@ -106,10 +106,10 @@ def test_missing_field():
 
 def test_change_class():
     gaussian_0 = af.Model(
-        af.Gaussian, normalization=af.UniformPrior(lower_limit=1e-6, upper_limit=1e6)
+        af.ex.Gaussian, normalization=af.UniformPrior(lower_limit=1e-6, upper_limit=1e6)
     )
     gaussian_1 = af.Model(
-        af.Gaussian, normalization=af.LogUniformPrior(lower_limit=1e-6, upper_limit=1e6)
+        af.ex.Gaussian, normalization=af.LogUniformPrior(lower_limit=1e-6, upper_limit=1e6)
     )
 
     assert Identifier(gaussian_0) != Identifier(gaussian_1)
@@ -143,14 +143,14 @@ def test_identifier_fields():
 def test_unique_tag():
     search = af.m.MockSearch()
 
-    search.fit(model=af.Model(af.Gaussian), analysis=af.m.MockAnalysis())
+    search.fit(model=af.Model(af.ex.Gaussian), analysis=af.m.MockAnalysis())
 
     identifier = search.paths.identifier
 
     search = af.m.MockSearch(unique_tag="dataset")
 
     search.fit(
-        model=af.Model(af.Gaussian),
+        model=af.Model(af.ex.Gaussian),
         analysis=af.m.MockAnalysis(),
     )
 
@@ -165,42 +165,42 @@ def test_prior():
 
 
 def test_model():
-    identifier = af.Model(af.Gaussian, centre=af.UniformPrior()).identifier
-    assert identifier == af.Model(af.Gaussian, centre=af.UniformPrior()).identifier
+    identifier = af.Model(af.ex.Gaussian, centre=af.UniformPrior()).identifier
+    assert identifier == af.Model(af.ex.Gaussian, centre=af.UniformPrior()).identifier
     assert (
         identifier
-        != af.Model(af.Gaussian, centre=af.UniformPrior(upper_limit=0.5)).identifier
+        != af.Model(af.ex.Gaussian, centre=af.UniformPrior(upper_limit=0.5)).identifier
     )
 
 
 def test_collection():
     identifier = af.Collection(
-        gaussian=af.Model(af.Gaussian, centre=af.UniformPrior())
+        gaussian=af.Model(af.ex.Gaussian, centre=af.UniformPrior())
     ).identifier
     assert (
         identifier
         == af.Collection(
-            gaussian=af.Model(af.Gaussian, centre=af.UniformPrior())
+            gaussian=af.Model(af.ex.Gaussian, centre=af.UniformPrior())
         ).identifier
     )
     assert (
         identifier
         != af.Collection(
-            gaussian=af.Model(af.Gaussian, centre=af.UniformPrior(upper_limit=0.5))
+            gaussian=af.Model(af.ex.Gaussian, centre=af.UniformPrior(upper_limit=0.5))
         ).identifier
     )
 
 
 def test_instance():
-    identifier = af.Collection(gaussian=af.Gaussian()).identifier
-    assert identifier == af.Collection(gaussian=af.Gaussian()).identifier
-    assert identifier != af.Collection(gaussian=af.Gaussian(centre=0.5)).identifier
+    identifier = af.Collection(gaussian=af.ex.Gaussian()).identifier
+    assert identifier == af.Collection(gaussian=af.ex.Gaussian()).identifier
+    assert identifier != af.Collection(gaussian=af.ex.Gaussian(centre=0.5)).identifier
 
 
 def test__identifier_description():
     model = af.Collection(
         gaussian=af.Model(
-            af.Gaussian,
+            af.ex.Gaussian,
             centre=af.UniformPrior(lower_limit=0.0, upper_limit=1.0),
             normalization=af.LogUniformPrior(lower_limit=0.001, upper_limit=0.01),
             sigma=af.GaussianPrior(
@@ -270,7 +270,7 @@ def test__identifier_description():
 def test__identifier_description__after_model_and_instance():
     model = af.Collection(
         gaussian=af.Model(
-            af.Gaussian,
+            af.ex.Gaussian,
             centre=af.UniformPrior(lower_limit=0.0, upper_limit=1.0),
             normalization=af.LogUniformPrior(lower_limit=0.001, upper_limit=0.01),
             sigma=af.GaussianPrior(
@@ -315,7 +315,7 @@ def test__identifier_description__after_model_and_instance():
 def test__identifier_description__after_take_attributes():
     model = af.Collection(
         gaussian=af.Model(
-            af.Gaussian,
+            af.ex.Gaussian,
             centre=af.UniformPrior(lower_limit=0.0, upper_limit=1.0),
             normalization=af.LogUniformPrior(lower_limit=0.001, upper_limit=0.01),
             sigma=af.GaussianPrior(

--- a/test_autofit/database/paths/conftest.py
+++ b/test_autofit/database/paths/conftest.py
@@ -11,7 +11,7 @@ def make_paths(session):
         session
     )
     paths.model = af.Model(
-        af.Gaussian
+        af.ex.Gaussian
     )
     assert paths.is_complete is False
     return paths

--- a/test_autofit/database/paths/test_paths.py
+++ b/test_autofit/database/paths/test_paths.py
@@ -80,7 +80,7 @@ def test_completion(
 
 
 def test_object(paths):
-    gaussian = af.Gaussian(
+    gaussian = af.ex.Gaussian(
         normalization=2.1
     )
 

--- a/test_autofit/database/paths/test_samples.py
+++ b/test_autofit/database/paths/test_samples.py
@@ -14,7 +14,7 @@ def save_samples(
 ):
     samples =af.m.MockSamples(
         model=af.Model(
-            af.Gaussian
+            af.ex.Gaussian
         ),
 
     )
@@ -57,7 +57,7 @@ def test_load_samples(
 ):
     samples = paths._load_samples()
 
-    assert samples.model.cls is af.Gaussian
+    assert samples.model.cls is af.ex.Gaussian
 
     sample, = samples.sample_list
     assert sample.weight == 0.5

--- a/test_autofit/database/paths/test_switch.py
+++ b/test_autofit/database/paths/test_switch.py
@@ -23,7 +23,7 @@ def make_search(session):
 )
 def make_model():
     return af.Model(
-        af.Gaussian
+        af.ex.Gaussian
     )
 
 

--- a/test_autofit/database/query/internal/test_construction.py
+++ b/test_autofit/database/query/internal/test_construction.py
@@ -7,11 +7,11 @@ def test_simple(aggregator):
 
 
 def test_and(aggregator):
-    construction = ((aggregator.model.centre == af.Gaussian) & (aggregator.model.centre.x == 0))
+    construction = ((aggregator.model.centre == af.ex.Gaussian) & (aggregator.model.centre.x == 0))
     assert construction.query == q.Q(
         "centre",
         q.And(
-            q.T(af.Gaussian),
+            q.T(af.ex.Gaussian),
             q.Q(
                 "x",
                 q.V(
@@ -23,11 +23,11 @@ def test_and(aggregator):
 
 
 def test_or(aggregator):
-    construction = ((aggregator.model.centre == af.Gaussian) | (aggregator.model.centre.x == 0))
+    construction = ((aggregator.model.centre == af.ex.Gaussian) | (aggregator.model.centre.x == 0))
     assert construction.query == q.Q(
         "centre",
         q.Or(
-            q.T(af.Gaussian),
+            q.T(af.ex.Gaussian),
             q.Q(
                 "x",
                 q.V(
@@ -51,7 +51,7 @@ def test_third_level(aggregator):
 
 
 def test_with_type(aggregator):
-    assert (aggregator.model.centre == af.Gaussian).query == q.Q("centre", q.T(af.Gaussian)).query
+    assert (aggregator.model.centre == af.ex.Gaussian).query == q.Q("centre", q.T(af.ex.Gaussian)).query
 
 
 def test_with_string(aggregator):

--- a/test_autofit/database/query/query/conftest.py
+++ b/test_autofit/database/query/query/conftest.py
@@ -11,7 +11,7 @@ from autofit import database as db
 def make_gaussian_1():
     return db.Fit(
         id="gaussian_1",
-        instance=af.Gaussian(
+        instance=af.ex.Gaussian(
             centre=1
         ),
         info={"info": 1},
@@ -26,7 +26,7 @@ def make_gaussian_1():
 def make_gaussian_2():
     return db.Fit(
         id="gaussian_2",
-        instance=af.Gaussian(
+        instance=af.ex.Gaussian(
             centre=2
         ),
         info={"info": 2},

--- a/test_autofit/database/query/query/test_model.py
+++ b/test_autofit/database/query/query/test_model.py
@@ -9,7 +9,7 @@ def test_embedded_query(
     model_1 = db.Fit(
         id="model_1",
         instance=af.Collection(
-            gaussian=af.Gaussian(
+            gaussian=af.ex.Gaussian(
                 centre=1
             )
         ),
@@ -18,7 +18,7 @@ def test_embedded_query(
     model_2 = db.Fit(
         id="model_2",
         instance=af.Collection(
-            gaussian=af.Gaussian(
+            gaussian=af.ex.Gaussian(
                 centre=2
             )
         ),

--- a/test_autofit/database/query/query/test_order_by.py
+++ b/test_autofit/database/query/query/test_order_by.py
@@ -12,7 +12,7 @@ def make_gaussian_0(
 ):
     gaussian_0 = db.Fit(
         id="gaussian_0",
-        instance=af.Gaussian(
+        instance=af.ex.Gaussian(
             centre=1
         ),
         info={"info": 1},

--- a/test_autofit/database/query/query/test_query_none.py
+++ b/test_autofit/database/query/query/test_query_none.py
@@ -12,7 +12,7 @@ def make_gaussian_none(
 ):
     gaussian_none = db.Fit(
         id="gaussian_none",
-        instance=af.Gaussian(
+        instance=af.ex.Gaussian(
             centre=None
         )
     )

--- a/test_autofit/database/query/test_grid_seach.py
+++ b/test_autofit/database/query/test_grid_seach.py
@@ -10,11 +10,11 @@ def _make_children(
     return [
         db.Fit(
             id=f"child_{grid_id}_{i}",
-            instance=af.Gaussian(
+            instance=af.ex.Gaussian(
                 centre=i
             ),
             model=af.Model(
-                af.Gaussian,
+                af.ex.Gaussian,
                 centre=float(-i)
             ),
             max_log_likelihood=grid_id + i
@@ -39,7 +39,7 @@ def make_grid_fit(children):
         unique_tag="grid_fit_1",
         is_grid_search=True,
         children=children,
-        instance=af.Gaussian(
+        instance=af.ex.Gaussian(
             centre=1
         )
     )
@@ -54,7 +54,7 @@ def make_grid_fit_2():
         unique_tag="grid_fit_2",
         is_grid_search=True,
         children=_make_children(2),
-        instance=af.Gaussian(
+        instance=af.ex.Gaussian(
             centre=2
         )
     )
@@ -96,11 +96,11 @@ def test_cell_aggregator(
 
 def test_model_order_no():
     model_1 = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=1.0
     )
     model_2 = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=2.0
     )
 
@@ -109,11 +109,11 @@ def test_model_order_no():
 
 def test_negative():
     model_1 = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=-3.0
     )
     model_2 = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=2.0
     )
     assert model_1.order_no < model_2.order_no
@@ -121,17 +121,17 @@ def test_negative():
 
 def test_model_order_no_complicated():
     model_1 = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=1.0,
         normalization=af.UniformPrior(0.0, 1.0)
     )
     model_2 = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=2.0,
         normalization=af.UniformPrior(0.0, 0.5)
     )
     model_3 = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=2.0,
         normalization=af.UniformPrior(0.0, 1.0)
     )

--- a/test_autofit/database/query/test_regression.py
+++ b/test_autofit/database/query/test_regression.py
@@ -16,7 +16,7 @@ def test_float_inequality(session):
             af.db.Fit(
                 id=str(uuid4()),
                 instance={
-                    "gaussian": af.Gaussian(
+                    "gaussian": af.ex.Gaussian(
                         sigma=sigma
                     )
                 }

--- a/test_autofit/database/test_named_instances.py
+++ b/test_autofit/database/test_named_instances.py
@@ -8,13 +8,13 @@ def test_set_and_retrieve(
     fit = db.Fit()
     fit.named_instances[
         "one"
-    ] = af.Gaussian()
+    ] = af.ex.Gaussian()
 
     assert isinstance(
         fit.named_instances[
             "one"
         ],
-        af.Gaussian
+        af.ex.Gaussian
     )
 
 
@@ -26,7 +26,7 @@ def test_query(
     )
     fit.named_instances[
         "one"
-    ] = af.Gaussian()
+    ] = af.ex.Gaussian()
 
     session.add(fit)
     session.commit()
@@ -39,5 +39,5 @@ def test_query(
         fit.named_instances[
             "one"
         ],
-        af.Gaussian
+        af.ex.Gaussian
     )

--- a/test_autofit/database/test_regression.py
+++ b/test_autofit/database/test_regression.py
@@ -8,12 +8,12 @@ from autofit.database import Fit
 
 @pytest.fixture(name="model")
 def make_model():
-    return af.Model(af.Gaussian)
+    return af.Model(af.ex.Gaussian)
 
 
 def test_instance_from_prior_medians(model):
     db.Object.from_object(model)()
-    db.Object.from_object(af.Gaussian())()
+    db.Object.from_object(af.ex.Gaussian())()
     instance = model.instance_from_prior_medians()
     db.Object.from_object(instance)()
 
@@ -21,35 +21,35 @@ def test_instance_from_prior_medians(model):
 def test_object_to_instance(model):
     assert isinstance(
         db.Object.from_object(model)().instance_from_prior_medians(),
-        af.Gaussian,
+        af.ex.Gaussian,
     )
 
 
 def test_model_with_parameterless_component():
-    child = af.Gaussian()
+    child = af.ex.Gaussian()
     model = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=child,
     )
     assert ("centre", child) in model.items()
 
     model = db.Object.from_object(model)()
     instance = model.instance_from_prior_medians()
-    assert isinstance(instance.centre, af.Gaussian)
+    assert isinstance(instance.centre, af.ex.Gaussian)
 
 
 def test_instance_in_collection():
-    collection = af.Collection(gaussian=af.Gaussian())
-    assert list(collection.items()) == [("gaussian", af.Gaussian())]
+    collection = af.Collection(gaussian=af.ex.Gaussian())
+    assert list(collection.items()) == [("gaussian", af.ex.Gaussian())]
 
 
 def test_samples_summary_model():
     fit = af.db.Fit()
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     fit["samples_summary"] = af.Samples(model=model, sample_list=[])
     fit.model = model
 
-    assert fit["samples_summary"].model.cls == af.Gaussian
+    assert fit["samples_summary"].model.cls == af.ex.Gaussian
 
 
 def test_dict_with_tuple_keys():

--- a/test_autofit/database/test_search.py
+++ b/test_autofit/database/test_search.py
@@ -19,7 +19,7 @@ def test_save_all_samples_boolean(session, save_all_samples):
 
 def test_unique_tag(session):
     analysis = af.m.MockAnalysis()
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
 
     unique_tag = "unique"
 

--- a/test_autofit/database/test_serialize.py
+++ b/test_autofit/database/test_serialize.py
@@ -7,7 +7,7 @@ from autofit.non_linear.samples import Samples
 
 @pytest.fixture(name="model")
 def make_model():
-    return af.Model(af.Gaussian)
+    return af.Model(af.ex.Gaussian)
 
 
 @pytest.fixture(name="serialized_model")
@@ -27,7 +27,7 @@ def make_serialized_collection(collection):
 
 class TestInstance:
     def test_serialize(self):
-        serialized_instance = db.Object.from_object(af.Gaussian())
+        serialized_instance = db.Object.from_object(af.ex.Gaussian())
         assert len(serialized_instance.children) == 3
 
     def test_tuple(self):
@@ -37,15 +37,15 @@ class TestInstance:
 class TestModel:
     def test_serialize(self, serialized_model):
         assert isinstance(serialized_model, db.Model)
-        assert serialized_model.cls is af.Gaussian
+        assert serialized_model.cls is af.ex.Gaussian
 
     def test_deserialize(self, serialized_model):
-        assert serialized_model().cls is af.Gaussian
+        assert serialized_model().cls is af.ex.Gaussian
 
 
 @pytest.fixture(name="collection_with_cache")
 def make_collection_with_cache():
-    model = af.Collection(gaussian=af.Gaussian)
+    model = af.Collection(gaussian=af.ex.Gaussian)
     model.freeze()
     _ = model.unique_prior_tuples
     return model
@@ -53,7 +53,7 @@ def make_collection_with_cache():
 
 class TestFrozenCache:
     def test_model_with_cache(self):
-        gaussian = af.Model(af.Gaussian)
+        gaussian = af.Model(af.ex.Gaussian)
         gaussian.freeze()
         _ = gaussian.unique_prior_tuples
         serialized = db.Object.from_object(gaussian)
@@ -140,7 +140,7 @@ def test_none():
 
 
 def test_commit(session):
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     serialized = db.Object.from_object(model)
     session.add(serialized)
     session.commit()

--- a/test_autofit/graphical/functionality/test_model_info.py
+++ b/test_autofit/graphical/functionality/test_model_info.py
@@ -9,7 +9,7 @@ from autofit import graphical as g
 @pytest.fixture(name="analysis_factor")
 def make_analysis_factor():
     return g.AnalysisFactor(
-        prior_model=af.Model(af.Gaussian),
+        prior_model=af.Model(af.ex.Gaussian),
         analysis=af.m.MockAnalysis(),
         name="AnalysisFactor0",
     )

--- a/test_autofit/graphical/functionality/test_visualize.py
+++ b/test_autofit/graphical/functionality/test_visualize.py
@@ -15,7 +15,7 @@ pass
 # def test_visualize():
 #     analysis = Analysis()
 #
-#     gaussian = af.Model(af.Gaussian)
+#     gaussian = af.Model(af.ex.Gaussian)
 #
 #     analysis_factor = g.AnalysisFactor(
 #         prior_model=gaussian,

--- a/test_autofit/graphical/hierarchical/test_embedded.py
+++ b/test_autofit/graphical/hierarchical/test_embedded.py
@@ -50,7 +50,7 @@ def make_centre(centre_model):
 def generate_data(centres):
     data = []
     for centre in centres:
-        gaussian = af.Gaussian(
+        gaussian = af.ex.Gaussian(
             centre=centre,
             normalization=20,
             sigma=5,
@@ -71,7 +71,7 @@ def _test_model_factor(data, centres):
     y = data[0]
     centre_argument = af.GaussianPrior(mean=50, sigma=20)
     prior_model = af.Model(
-        af.Gaussian, centre=centre_argument, normalization=20, sigma=5
+        af.ex.Gaussian, centre=centre_argument, normalization=20, sigma=5
     )
     factor = g.AnalysisFactor(prior_model, analysis=Analysis(x=x, y=y))
     laplace = g.LaplaceOptimiser()
@@ -84,7 +84,7 @@ def test_full_fit(centre_model, data, centres):
     graph = g.FactorGraphModel()
     for i, y in enumerate(data):
         prior_model = af.Model(
-            af.Gaussian,
+            af.ex.Gaussian,
             centre=af.GaussianPrior(mean=100, sigma=1),
             intensity=20,
             normalization=20,

--- a/test_autofit/graphical/info/conftest.py
+++ b/test_autofit/graphical/info/conftest.py
@@ -46,8 +46,8 @@ def make_factor_graph_model():
     name="non_trivial_model"
 )
 def make_non_trivial_model():
-    one = af.Model(af.Gaussian)
-    two = af.Model(af.Gaussian)
+    one = af.Model(af.ex.Gaussian)
+    two = af.Model(af.ex.Gaussian)
 
     one.centre = two.centre
 

--- a/test_autofit/graphical/info/test_hierarchical.py
+++ b/test_autofit/graphical/info/test_hierarchical.py
@@ -9,12 +9,12 @@ from autofit.graphical.declarative.graph import GraphInfoFormatter
 
 @pytest.fixture(name="model_factor_1")
 def make_model_factor_1():
-    return g.AnalysisFactor(af.Model(af.Gaussian), af.m.MockAnalysis())
+    return g.AnalysisFactor(af.Model(af.ex.Gaussian), af.m.MockAnalysis())
 
 
 @pytest.fixture(name="model_factor_2")
 def make_model_factor_2():
-    return g.AnalysisFactor(af.Model(af.Gaussian), af.m.MockAnalysis())
+    return g.AnalysisFactor(af.Model(af.ex.Gaussian), af.m.MockAnalysis())
 
 
 @pytest.fixture(name="hierarchical_factor")

--- a/test_autofit/graphical/regression/test_identifier.py
+++ b/test_autofit/graphical/regression/test_identifier.py
@@ -113,7 +113,7 @@ def test_logarithmic_prior(
 def make_model():
     return Identifier(
         af.Model(
-            af.Gaussian
+            af.ex.Gaussian
         )
     )
 

--- a/test_autofit/graphical/regression/test_static.py
+++ b/test_autofit/graphical/regression/test_static.py
@@ -54,7 +54,7 @@ def make_analysis_factor_factory(centre):
     def factory():
         return af.AnalysisFactor(
             prior_model=af.Model(
-                af.Gaussian,
+                af.ex.Gaussian,
                 centre=centre,
                 normalization=af.GaussianPrior(mean=1.0, sigma=2.0),
                 sigma=af.GaussianPrior(mean=1.0, sigma=2.0),

--- a/test_autofit/graphical/test_combined_analysis.py
+++ b/test_autofit/graphical/test_combined_analysis.py
@@ -7,7 +7,7 @@ from autofit.non_linear.paths.sub_directory_paths import SubDirectoryPaths
 
 
 def test_make_result():
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     factor_graph_model = af.FactorGraphModel(
         af.AnalysisFactor(
             model,
@@ -86,7 +86,7 @@ def analysis():
 
 @pytest.fixture
 def model():
-    return af.Model(af.Gaussian)
+    return af.Model(af.ex.Gaussian)
 
 
 @pytest.fixture

--- a/test_autofit/graphical/test_declarative_deterministic.py
+++ b/test_autofit/graphical/test_declarative_deterministic.py
@@ -6,13 +6,13 @@ def test():
 
     pass
 
-    # model_1 = af.Model(af.Gaussian)
+    # model_1 = af.Model(af.ex.Gaussian)
     # analysis_factor_1 = af.AnalysisFactor(
     #     prior_model=model_1,
     #     analysis=MockAnalysis(),
     # )
     #
-    # model_2 = af.Model(af.Gaussian)
+    # model_2 = af.Model(af.ex.Gaussian)
     # analysis_factor_2 = af.AnalysisFactor(
     #     prior_model=model_2,
     #     analysis=MockAnalysis(),

--- a/test_autofit/graphical/test_history.py
+++ b/test_autofit/graphical/test_history.py
@@ -16,7 +16,7 @@ class Analysis(af.Analysis):
 @pytest.fixture(name="model")
 def make_model():
     return af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=af.GaussianPrior(mean=50, sigma=20),
         normalization=af.GaussianPrior(mean=25, sigma=10),
         sigma=af.GaussianPrior(mean=10, sigma=10),

--- a/test_autofit/graphical/test_unification.py
+++ b/test_autofit/graphical/test_unification.py
@@ -35,7 +35,7 @@ def make_x():
 
 
 def test_projected_model():
-    model = af.Model(af.Gaussian, centre=af.UniformPrior())
+    model = af.Model(af.ex.Gaussian, centre=af.UniformPrior())
     samples = af.Samples(
         model,
         [

--- a/test_autofit/interpolator/conftest.py
+++ b/test_autofit/interpolator/conftest.py
@@ -9,7 +9,7 @@ def make_model_instance():
     return af.ModelInstance(
         dict(
             t=1.0,
-            gaussian=af.Gaussian(centre=0.0, normalization=1.0, sigma=-1.0),
+            gaussian=af.ex.Gaussian(centre=0.0, normalization=1.0, sigma=-1.0),
         )
     )
 
@@ -21,7 +21,7 @@ def make_instances(model_instance):
         af.ModelInstance(
             dict(
                 t=2.0,
-                gaussian=af.Gaussian(centre=1.0, normalization=2.0, sigma=-2.0),
+                gaussian=af.ex.Gaussian(centre=1.0, normalization=2.0, sigma=-2.0),
             )
         ),
     ]
@@ -34,7 +34,7 @@ def make_interpolator():
             model=af.Collection(
                 t=value,
                 gaussian=af.Model(
-                    af.Gaussian,
+                    af.ex.Gaussian,
                     centre=af.GaussianPrior(mean=1.0, sigma=1.0),
                     normalization=af.GaussianPrior(mean=1.0, sigma=1.0),
                     sigma=af.GaussianPrior(mean=1.0, sigma=1.0),

--- a/test_autofit/interpolator/test_interpolator.py
+++ b/test_autofit/interpolator/test_interpolator.py
@@ -42,7 +42,7 @@ def test_smooth_spline_interpolator(instances):
             af.ModelInstance(
                 dict(
                     t=3.0,
-                    gaussian=af.Gaussian(centre=4.0, normalization=3.0, sigma=-3.0),
+                    gaussian=af.ex.Gaussian(centre=4.0, normalization=3.0, sigma=-3.0),
                 )
             ),
         ]
@@ -78,7 +78,7 @@ def test_alternate_attribute(linear_interpolator, sigma):
 def test_deeper_attributes():
     collection = af.Collection(
         model=af.Model(
-            af.Gaussian,
+            af.ex.Gaussian,
             centre=0.0,
             normalization=1.0,
             sigma=-1.0,
@@ -203,7 +203,7 @@ def test_instance_from_dict(model_instance, instance_dict):
     assert instance.t == 1.0
 
     gaussian = instance.gaussian
-    assert isinstance(gaussian, af.Gaussian)
+    assert isinstance(gaussian, af.ex.Gaussian)
     assert gaussian.centre == 0.0
     assert gaussian.normalization == 1.0
     assert gaussian.sigma == -1.0

--- a/test_autofit/jax/test_pytrees.py
+++ b/test_autofit/jax/test_pytrees.py
@@ -9,7 +9,7 @@ jax = pytest.importorskip("jax")
 
 @pytest.fixture(name="gaussian")
 def make_gaussian():
-    return af.Gaussian(centre=1.0, sigma=1.0, normalization=1.0)
+    return af.ex.Gaussian(centre=1.0, sigma=1.0, normalization=1.0)
 
 
 @pytest.fixture(autouse=True)
@@ -42,7 +42,7 @@ def test_gaussian_prior(recreate):
 @pytest.fixture(name="model")
 def _model():
     return af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=af.GaussianPrior(mean=1.0, sigma=1.0),
         normalization=af.GaussianPrior(mean=1.0, sigma=1.0),
         sigma=af.GaussianPrior(mean=1.0, sigma=1.0),
@@ -51,7 +51,7 @@ def _model():
 
 def test_model(model, recreate):
     new = recreate(model)
-    assert new.cls == af.Gaussian
+    assert new.cls == af.ex.Gaussian
 
     centre = new.centre
     assert centre.mean == model.centre.mean
@@ -63,7 +63,7 @@ def test_instance(model, recreate):
     instance = model.instance_from_prior_medians()
     new = recreate(instance)
 
-    assert isinstance(new, af.Gaussian)
+    assert isinstance(new, af.ex.Gaussian)
 
     assert new.centre == instance.centre
     assert new.normalization == instance.normalization
@@ -86,7 +86,7 @@ def test_model_instance(model, recreate):
     new = recreate(instance)
 
     assert isinstance(new, af.ModelInstance)
-    assert isinstance(new.gaussian, af.Gaussian)
+    assert isinstance(new.gaussian, af.ex.Gaussian)
 
 
 def test_collection(model, recreate):
@@ -96,7 +96,7 @@ def test_collection(model, recreate):
     assert isinstance(new, af.Collection)
     assert isinstance(new.gaussian, af.Model)
 
-    assert new.gaussian.cls == af.Gaussian
+    assert new.gaussian.cls == af.ex.Gaussian
 
     centre = new.gaussian.centre
     assert centre.mean == model.centre.mean

--- a/test_autofit/mapper/functionality/test_by_path.py
+++ b/test_autofit/mapper/functionality/test_by_path.py
@@ -5,7 +5,7 @@ import autofit as af
 
 @pytest.fixture(name="model")
 def make_model():
-    return af.Collection(gaussian=af.Model(af.Gaussian))
+    return af.Collection(gaussian=af.Model(af.ex.Gaussian))
 
 
 class TestInstanceFromPathArguments:
@@ -58,7 +58,7 @@ class TestInstanceFromPathArguments:
 
 @pytest.fixture(name="underscore_model")
 def make_underscore_model():
-    return af.Collection(gaussian_component=af.Model(af.Gaussian))
+    return af.Collection(gaussian_component=af.Model(af.ex.Gaussian))
 
 
 class TestInstanceFromPriorNames:
@@ -112,7 +112,7 @@ class TestInstanceFromPriorNames:
 
 
 def test_component_names():
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     assert model.model_component_and_parameter_names == [
         "centre",
         "normalization",
@@ -127,14 +127,14 @@ def test_with_tuple():
 
 @pytest.fixture(name="linked_model")
 def make_linked_model():
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     model.sigma = model.centre
     return model
 
 
 class TestAllPaths:
     def test_independent(self):
-        model = af.Model(af.Gaussian)
+        model = af.Model(af.ex.Gaussian)
 
         assert model.all_paths_prior_tuples == [
             ((("centre",),), model.centre),
@@ -149,7 +149,7 @@ class TestAllPaths:
         ]
 
     def test_names_independent(self):
-        model = af.Model(af.Gaussian)
+        model = af.Model(af.ex.Gaussian)
 
         assert model.all_name_prior_tuples == [
             (("centre",), model.centre),

--- a/test_autofit/mapper/functionality/test_explicit_width_modifier.py
+++ b/test_autofit/mapper/functionality/test_explicit_width_modifier.py
@@ -10,7 +10,7 @@ def make_width_modifier():
 
 @pytest.fixture(name="updated_model")
 def make_updated_model(width_modifier):
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     model.centre.width_modifier = width_modifier
 
     return model.mapper_from_prior_means([1.0, 1.0, 1.0])

--- a/test_autofit/mapper/functionality/test_has.py
+++ b/test_autofit/mapper/functionality/test_has.py
@@ -4,78 +4,78 @@ import autofit as af
 from autofit.example import Exponential
 
 
-class GaussianChild(af.Gaussian):
+class GaussianChild(af.ex.Gaussian):
     pass
 
 
 def test_inheritance():
     collection = af.Collection(first=af.Model(GaussianChild), second=GaussianChild())
 
-    assert collection.has_instance(af.Gaussian)
-    assert collection.has_model(af.Gaussian)
+    assert collection.has_instance(af.ex.Gaussian)
+    assert collection.has_model(af.ex.Gaussian)
 
 
 def test_no_free_parameters():
     collection = af.Collection(
-        gaussian=af.Model(af.Gaussian, centre=1.0, normalization=1.0, sigma=1.0,)
+        gaussian=af.Model(af.ex.Gaussian, centre=1.0, normalization=1.0, sigma=1.0,)
     )
     assert collection.prior_count == 0
-    assert collection.has_model(af.Gaussian) is False
+    assert collection.has_model(af.ex.Gaussian) is False
 
 
 def test_instance():
-    collection = af.Collection(gaussian=af.Gaussian())
+    collection = af.Collection(gaussian=af.ex.Gaussian())
 
-    assert collection.has_instance(af.Gaussian) is True
-    assert collection.has_model(af.Gaussian) is False
+    assert collection.has_instance(af.ex.Gaussian) is True
+    assert collection.has_model(af.ex.Gaussian) is False
 
 
 def test_model():
-    collection = af.Collection(gaussian=af.Model(af.Gaussian))
+    collection = af.Collection(gaussian=af.Model(af.ex.Gaussian))
 
-    assert collection.has_model(af.Gaussian) is True
-    assert collection.has_instance(af.Gaussian) is False
+    assert collection.has_model(af.ex.Gaussian) is True
+    assert collection.has_instance(af.ex.Gaussian) is False
 
 
 def test_both():
-    collection = af.Collection(gaussian=af.Model(af.Gaussian), gaussian_2=af.Gaussian())
+    collection = af.Collection(gaussian=af.Model(af.ex.Gaussian), gaussian_2=af.ex.Gaussian())
 
-    assert collection.has_model(af.Gaussian) is True
-    assert collection.has_instance(af.Gaussian) is True
+    assert collection.has_model(af.ex.Gaussian) is True
+    assert collection.has_instance(af.ex.Gaussian) is True
 
 
 def test_embedded():
-    collection = af.Collection(gaussian=af.Model(af.Gaussian, centre=af.Gaussian()),)
+    collection = af.Collection(gaussian=af.Model(af.ex.Gaussian, centre=af.ex.Gaussian()),)
 
-    assert collection.has_model(af.Gaussian) is True
-    assert collection.has_instance(af.Gaussian) is True
+    assert collection.has_model(af.ex.Gaussian) is True
+    assert collection.has_instance(af.ex.Gaussian) is True
 
 
 def test_is_only_model():
     collection = af.Collection(
-        gaussian=af.Model(af.Gaussian), gaussian_2=af.Model(af.Gaussian)
+        gaussian=af.Model(af.ex.Gaussian), gaussian_2=af.Model(af.ex.Gaussian)
     )
 
-    assert collection.is_only_model(af.Gaussian) is True
+    assert collection.is_only_model(af.ex.Gaussian) is True
 
     collection.other = af.Model(af.m.MockClassx2)
 
-    assert collection.is_only_model(af.Gaussian) is False
+    assert collection.is_only_model(af.ex.Gaussian) is False
 
 
 @pytest.fixture(name="collection")
 def make_collection():
     return af.Collection(
-        gaussian=af.Model(af.Gaussian), exponential=af.Model(Exponential),
+        gaussian=af.Model(af.ex.Gaussian), exponential=af.Model(Exponential),
     )
 
 
 def test_models(collection):
-    assert collection.models_with_type(af.Gaussian) == [collection.gaussian]
+    assert collection.models_with_type(af.ex.Gaussian) == [collection.gaussian]
 
 
 def test_multiple_types(collection):
-    assert collection.models_with_type((af.Gaussian, Exponential)) == [
+    assert collection.models_with_type((af.ex.Gaussian, Exponential)) == [
         collection.gaussian,
         collection.exponential,
     ]
@@ -87,8 +87,8 @@ class Galaxy:
 
 
 def test_instances_with_type():
-    model = af.Collection(galaxy=Galaxy(child=af.Model(af.Gaussian)))
-    assert model.models_with_type(af.Gaussian) == [model.galaxy.child]
+    model = af.Collection(galaxy=Galaxy(child=af.Model(af.ex.Gaussian)))
+    assert model.models_with_type(af.ex.Gaussian) == [model.galaxy.child]
 
 
 class DelaunayBrightnessImage:
@@ -98,6 +98,6 @@ class DelaunayBrightnessImage:
 def test_model_attributes_with_type():
     mesh = af.Model(DelaunayBrightnessImage)
     mesh.pixels = af.UniformPrior(lower_limit=5.0, upper_limit=10.0)
-    pixelization = af.Model(af.Gaussian, mesh=mesh)
+    pixelization = af.Model(af.ex.Gaussian, mesh=mesh)
 
     assert pixelization.models_with_type(DelaunayBrightnessImage) == [mesh]

--- a/test_autofit/mapper/functionality/test_take_attributes.py
+++ b/test_autofit/mapper/functionality/test_take_attributes.py
@@ -8,7 +8,7 @@ import autofit as af
 )
 def make_target_gaussian():
     return af.Model(
-        af.Gaussian
+        af.ex.Gaussian
     )
 
 
@@ -24,7 +24,7 @@ def make_prior():
 )
 def make_source_gaussian(prior):
     return af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=prior
     )
 
@@ -126,7 +126,7 @@ def test_tuple_in_instance(
         prior
 ):
     # noinspection PyTypeChecker
-    source_gaussian = af.Gaussian(
+    source_gaussian = af.ex.Gaussian(
         centre=(prior, 1.0)
     )
     target_gaussian.take_attributes(
@@ -159,7 +159,7 @@ def test_tuple_in_instance_in_collection(
         prior
 ):
     # noinspection PyTypeChecker
-    source_gaussian = af.Gaussian(
+    source_gaussian = af.ex.Gaussian(
         centre=(prior, 1.0)
     )
 
@@ -280,11 +280,11 @@ def test_limits(
 def test_tuples():
     centre = (0.0, 1.0)
     source = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=centre
     )
     target = af.Model(
-        af.Gaussian
+        af.ex.Gaussian
     )
     target.take_attributes(source)
     assert target.centre == centre

--- a/test_autofit/mapper/model/serialise/test_json.py
+++ b/test_autofit/mapper/model/serialise/test_json.py
@@ -18,7 +18,7 @@ def make_collection_dict(model_dict):
 
 @pytest.fixture(name="model")
 def make_model():
-    return af.Model(af.Gaussian, centre=af.UniformPrior(upper_limit=2.0))
+    return af.Model(af.ex.Gaussian, centre=af.UniformPrior(upper_limit=2.0))
 
 
 @pytest.fixture(autouse=True)
@@ -48,13 +48,13 @@ class TestTuple:
 class TestFromDict:
     def test_model_from_dict(self, model_dict):
         model = af.Model.from_dict(model_dict)
-        assert model.cls == af.Gaussian
+        assert model.cls == af.ex.Gaussian
         assert model.prior_count == 3
         assert model.centre.upper_limit == 2.0
 
     def test_instance_from_dict(self, instance_dict):
         instance = from_dict(instance_dict)
-        assert isinstance(instance, af.Gaussian)
+        assert isinstance(instance, af.ex.Gaussian)
         assert instance.centre == 0.0
         assert instance.normalization == 0.1
         assert instance.sigma == 0.01
@@ -70,7 +70,7 @@ class TestToDict:
         assert remove_ids(model.dict()) == model_dict
 
     def test_model_floats(self, instance_dict):
-        model = af.Model(af.Gaussian, centre=0.0, normalization=0.1, sigma=0.01)
+        model = af.Model(af.ex.Gaussian, centre=0.0, normalization=0.1, sigma=0.01)
 
         assert model.dict() == instance_dict
 
@@ -79,7 +79,7 @@ class TestToDict:
         assert remove_ids(collection.dict()) == collection_dict
 
     def test_collection_instance(self, instance_dict):
-        collection = af.Collection(gaussian=af.Gaussian())
+        collection = af.Collection(gaussian=af.ex.Gaussian())
         assert collection.dict() == {
             "type": "collection",
             "arguments": {
@@ -122,7 +122,7 @@ class TestFromJson:
 
         model = af.Model.from_json(file=model_file)
 
-        assert model.cls == af.Gaussian
+        assert model.cls == af.ex.Gaussian
         assert model.prior_count == 3
         assert model.centre.upper_limit == 2.0
 

--- a/test_autofit/mapper/model/serialise/test_path_type.py
+++ b/test_autofit/mapper/model/serialise/test_path_type.py
@@ -26,7 +26,7 @@ def test_reference_model(model_dict, reference):
         reference=reference,
     )
 
-    assert model.gaussian.cls is af.Gaussian
+    assert model.gaussian.cls is af.ex.Gaussian
 
 
 def test_root_reference(model_dict, root_reference):
@@ -36,7 +36,7 @@ def test_root_reference(model_dict, root_reference):
         reference=root_reference,
     )
 
-    assert model.cls is af.Gaussian
+    assert model.cls is af.ex.Gaussian
 
 
 def test_instance(instance_dict, reference):
@@ -48,7 +48,7 @@ def test_instance(instance_dict, reference):
         reference=reference,
     )
 
-    assert isinstance(instance.gaussian, af.Gaussian)
+    assert isinstance(instance.gaussian, af.ex.Gaussian)
 
 
 def test_root_instance(instance_dict, root_reference):
@@ -59,7 +59,7 @@ def test_root_instance(instance_dict, root_reference):
         reference=root_reference,
     )
 
-    assert isinstance(instance, af.Gaussian)
+    assert isinstance(instance, af.ex.Gaussian)
 
 
 def test_deep_reference(instance_dict, reference):
@@ -79,4 +79,4 @@ def test_deep_reference(instance_dict, reference):
         reference=reference,
     )
 
-    assert isinstance(instance.collection.gaussian, af.Gaussian)
+    assert isinstance(instance.collection.gaussian, af.ex.Gaussian)

--- a/test_autofit/mapper/model/serialise/test_prior_duplication.py
+++ b/test_autofit/mapper/model/serialise/test_prior_duplication.py
@@ -31,7 +31,7 @@ def test_from_dict():
 
 
 def test_from_model():
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
 
     model.centre = model.sigma
 
@@ -47,8 +47,8 @@ def test_from_model():
 
 def test_collection():
     collection = af.Collection(
-        gaussian_1=af.Model(af.Gaussian),
-        gaussian_2=af.Model(af.Gaussian),
+        gaussian_1=af.Model(af.ex.Gaussian),
+        gaussian_2=af.Model(af.ex.Gaussian),
     )
     collection.gaussian_1.centre = collection.gaussian_2.centre
 

--- a/test_autofit/mapper/model/test_annotations.py
+++ b/test_autofit/mapper/model/test_annotations.py
@@ -4,7 +4,7 @@ import autofit as af
 
 
 class OptionalClass:
-    def __init__(self, optional: Optional[af.Gaussian]):
+    def __init__(self, optional: Optional[af.ex.Gaussian]):
         self.optional = optional
 
 

--- a/test_autofit/mapper/model/test_freeze.py
+++ b/test_autofit/mapper/model/test_freeze.py
@@ -8,7 +8,7 @@ import autofit as af
 )
 def make_frozen_model():
     model = af.Model(
-        af.Gaussian
+        af.ex.Gaussian
     )
 
     model.freeze()
@@ -21,7 +21,7 @@ def make_frozen_model():
 def make_frozen_collection():
     model = af.Collection(
         gaussian=af.Model(
-            af.Gaussian
+            af.ex.Gaussian
         )
     )
 
@@ -53,7 +53,7 @@ class TestFrozenCollection:
                 AssertionError
         ):
             frozen_collection.append(
-                af.Gaussian()
+                af.ex.Gaussian()
             )
 
     def test_set_item(

--- a/test_autofit/mapper/model/test_has.py
+++ b/test_autofit/mapper/model/test_has.py
@@ -5,7 +5,7 @@ import autofit as af
 
 @pytest.fixture(name="model")
 def make_prior_model():
-    return af.Model(af.Gaussian)
+    return af.Model(af.ex.Gaussian)
 
 
 @pytest.fixture(name="collection")
@@ -22,19 +22,19 @@ def test_collection_has(collection):
 
 
 def test_collection_has_model(collection):
-    assert collection.has_model(af.Gaussian)
+    assert collection.has_model(af.ex.Gaussian)
 
 
 def test_collection_of_collection(collection):
     collection = af.Collection(collection=collection)
     assert collection.has_instance(af.Prior)
-    assert collection.has_model(af.Gaussian)
+    assert collection.has_model(af.ex.Gaussian)
 
 
 def test_has_0_dimension():
     collection = af.Collection(
-        gaussian=af.Model(af.Gaussian, centre=0.0, normalization=0.1, sigma=0.01,)
+        gaussian=af.Model(af.ex.Gaussian, centre=0.0, normalization=0.1, sigma=0.01,)
     )
 
-    assert not collection.has_model(af.Gaussian)
-    assert collection.has(af.Gaussian)
+    assert not collection.has_model(af.ex.Gaussian)
+    assert collection.has(af.ex.Gaussian)

--- a/test_autofit/mapper/model/test_model_instance.py
+++ b/test_autofit/mapper/model/test_model_instance.py
@@ -166,23 +166,23 @@ class TestModelInstance:
         assert model_map.mock_profile.two == 0.0
 
 
-class Child(af.Gaussian):
+class Child(af.ex.Gaussian):
     pass
 
 
-class Child2(af.Gaussian):
+class Child2(af.ex.Gaussian):
     pass
 
 
 @pytest.fixture(name="exclude_instance")
 def make_excluded_instance():
     return af.ModelInstance(
-        {"child": Child(), "gaussian": af.Gaussian(), "child2": Child2(),}
+        {"child": Child(), "gaussian": af.ex.Gaussian(), "child2": Child2(),}
     )
 
 
 def test_single_argument(exclude_instance):
-    model = exclude_instance.as_model(af.Gaussian)
+    model = exclude_instance.as_model(af.ex.Gaussian)
 
     assert isinstance(model.gaussian, af.Model)
     assert isinstance(model.child, af.Model)
@@ -190,7 +190,7 @@ def test_single_argument(exclude_instance):
 
 
 def test_filter_child(exclude_instance):
-    model = exclude_instance.as_model(af.Gaussian, excluded_classes=Child)
+    model = exclude_instance.as_model(af.ex.Gaussian, excluded_classes=Child)
 
     assert isinstance(model.gaussian, af.Model)
     assert not isinstance(model.child, af.Model)
@@ -198,7 +198,7 @@ def test_filter_child(exclude_instance):
 
 
 def test_filter_multiple(exclude_instance):
-    model = exclude_instance.as_model(af.Gaussian, excluded_classes=(Child, Child2),)
+    model = exclude_instance.as_model(af.ex.Gaussian, excluded_classes=(Child, Child2),)
 
     assert isinstance(model.gaussian, af.Model)
     assert not isinstance(model.child, af.Model)

--- a/test_autofit/mapper/model/test_regression.py
+++ b/test_autofit/mapper/model/test_regression.py
@@ -32,7 +32,7 @@ def test_mapper_from_prior_arguments_simple_collection():
 
 def test_direct_instances_only():
     child = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=0.0,
         normalization=0.1,
         sigma=0.01,
@@ -40,7 +40,7 @@ def test_direct_instances_only():
     child.constant = 1.0
 
     model = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=child,
         normalization=0.1,
         sigma=0.01,
@@ -74,7 +74,7 @@ def test_as_model_tuples():
 
 
 def test_info_prints_number_of_parameters():
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     assert "Total Free Parameters" in model.info
 
 
@@ -118,7 +118,7 @@ def test_independent_ids():
 
 @pytest.fixture(name="gaussian")
 def make_gaussian():
-    return af.Gaussian()
+    return af.ex.Gaussian()
 
 
 @pytest.fixture(name="instance")
@@ -132,7 +132,7 @@ def make_path():
 
 
 def test_lists(instance, gaussian, path):
-    assert instance.path_instance_tuples_for_class(af.Gaussian) == [(path, gaussian)]
+    assert instance.path_instance_tuples_for_class(af.ex.Gaussian) == [(path, gaussian)]
 
 
 def test_replace_positional_path(instance, gaussian, path):
@@ -142,7 +142,7 @@ def test_replace_positional_path(instance, gaussian, path):
 
 @pytest.fixture(name="model_with_assertion")
 def make_model_with_assertion():
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     model.add_assertion(model.centre < -10)
     return model
 

--- a/test_autofit/mapper/prior/test_prior_parsing.py
+++ b/test_autofit/mapper/prior/test_prior_parsing.py
@@ -90,7 +90,7 @@ class TestWidth:
 
     def test_default(self):
         modifier = af.WidthModifier.for_class_and_attribute_name(
-            af.Gaussian, "not_real"
+            af.ex.Gaussian, "not_real"
         )
         assert modifier.value == 0.5
         assert isinstance(modifier, af.RelativeWidthModifier)

--- a/test_autofit/mapper/test_collection.py
+++ b/test_autofit/mapper/test_collection.py
@@ -3,6 +3,6 @@ import autofit as af
 
 def test_collection():
     collection = af.Collection(
-        af.Model(af.Gaussian) for _ in range(10)
+        af.Model(af.ex.Gaussian) for _ in range(10)
     )
     assert collection.prior_count == 30

--- a/test_autofit/mapper/test_constant.py
+++ b/test_autofit/mapper/test_constant.py
@@ -160,7 +160,7 @@ def test_float_id():
 
 def test_model_with_constants():
     instance = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=af.Constant(1.0),
     ).instance_from_prior_medians()
 

--- a/test_autofit/mapper/test_model_object.py
+++ b/test_autofit/mapper/test_model_object.py
@@ -3,9 +3,9 @@ import autofit as af
 
 def test_has():
     model_object = af.ModelObject()
-    assert not model_object.has(af.Gaussian)
+    assert not model_object.has(af.ex.Gaussian)
 
-    model_object.gaussian = af.Gaussian()
-    assert model_object.has(af.Gaussian)
+    model_object.gaussian = af.ex.Gaussian()
+    assert model_object.has(af.ex.Gaussian)
 
-    assert model_object.has((af.Gaussian, str))
+    assert model_object.has((af.ex.Gaussian, str))

--- a/test_autofit/mapper/test_parameterization.py
+++ b/test_autofit/mapper/test_parameterization.py
@@ -13,7 +13,7 @@ def reset_ids():
 
 
 def test_parameterization():
-    model = af.Collection(collection=af.Collection(gaussian=af.Model(af.Gaussian)))
+    model = af.Collection(collection=af.Collection(gaussian=af.Model(af.ex.Gaussian)))
 
     parameterization = model.parameterization
     assert parameterization == (
@@ -24,7 +24,7 @@ def test_parameterization():
 
 
 def test_root():
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     parameterization = model.parameterization
     assert parameterization == (
         "model                                                                           Gaussian (N=3)"
@@ -32,7 +32,7 @@ def test_root():
 
 
 def test_instance():
-    model = af.Collection(collection=af.Collection(gaussian=af.Gaussian()))
+    model = af.Collection(collection=af.Collection(gaussian=af.ex.Gaussian()))
 
     parameterization = model.parameterization
     assert parameterization == (
@@ -47,7 +47,7 @@ def test_tuple_prior():
     centre.centre_0 = af.UniformPrior()
     centre.centre_1 = af.UniformPrior()
 
-    model = af.Model(af.Gaussian, centre=centre)
+    model = af.Model(af.ex.Gaussian, centre=centre)
     parameterization = model.parameterization
     assert parameterization == (
         "model                                                                           Gaussian (N=4)"
@@ -142,7 +142,7 @@ tuple                                                                           
 
 
 def test_integer_attributes():
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
 
     model.centre = 2
 

--- a/test_autofit/mapper/with_paths/conftest.py
+++ b/test_autofit/mapper/with_paths/conftest.py
@@ -8,7 +8,7 @@ import autofit as af
 )
 def make_gaussian_1():
     return af.Model(
-        af.Gaussian
+        af.ex.Gaussian
     )
 
 
@@ -19,6 +19,6 @@ def make_model(gaussian_1):
     return af.Collection(
         gaussian_1=gaussian_1,
         gaussian_2=af.Model(
-            af.Gaussian
+            af.ex.Gaussian
         ),
     )

--- a/test_autofit/non_linear/grid/test_alphabetical.py
+++ b/test_autofit/non_linear/grid/test_alphabetical.py
@@ -8,7 +8,7 @@ import autofit as af
 )
 def make_model():
     model = af.Model(
-        af.Gaussian
+        af.ex.Gaussian
     )
     return model
 

--- a/test_autofit/non_linear/grid/test_optimizer_grid_search.py
+++ b/test_autofit/non_linear/grid/test_optimizer_grid_search.py
@@ -11,7 +11,7 @@ from autofit import exc
 def test_unpickle_result():
     # noinspection PyTypeChecker
     result = af.GridSearchResult(
-        samples=[af.Samples(model=af.Model(af.Gaussian), sample_list=[])],
+        samples=[af.Samples(model=af.Model(af.ex.Gaussian), sample_list=[])],
         lower_limits_lists=[[1]],
         grid_priors=[],
     )
@@ -296,7 +296,7 @@ class TestGridSearchResult:
 def test_higher_dimensions(n_dimensions, n_steps):
     shape = n_dimensions * (n_steps,)
     total = n_steps**n_dimensions
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     result = af.GridSearchResult(
         samples=total
         * [

--- a/test_autofit/non_linear/grid/test_quantities_for_path.py
+++ b/test_autofit/non_linear/grid/test_quantities_for_path.py
@@ -6,7 +6,7 @@ import autofit as af
 @pytest.fixture(name="result")
 def make_result():
     model = af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
     )
     grid_priors = [model.centre, model.normalization]
     lower_limits_lists = [
@@ -30,7 +30,7 @@ def make_result():
     def make_samples(centre, normalization):
         return af.Samples(
             model=af.Model(
-                af.Gaussian,
+                af.ex.Gaussian,
                 centre=af.UniformPrior(
                     lower_limit=centre,
                     upper_limit=centre + 2.0,

--- a/test_autofit/non_linear/grid/test_result.py
+++ b/test_autofit/non_linear/grid/test_result.py
@@ -7,7 +7,7 @@ from autofit.non_linear.samples.summary import SamplesSummary
 @pytest.fixture(name="model")
 def make_model():
     return af.Model(
-        af.Gaussian, centre=af.UniformPrior(lower_limit=0.0, upper_limit=1.0)
+        af.ex.Gaussian, centre=af.UniformPrior(lower_limit=0.0, upper_limit=1.0)
     )
 
 
@@ -71,7 +71,7 @@ def test_higher_dimension_instance_attributes(model, samples_1, samples_2):
 def make_deep_result(model, samples_1, samples_2):
     model = af.Collection(
         gaussian=af.Model(
-            af.Gaussian,
+            af.ex.Gaussian,
             centre=af.UniformPrior(lower_limit=0.0, upper_limit=1.0),
         )
     )
@@ -102,7 +102,7 @@ def test_paths(deep_result):
 def test_instances(deep_result):
     assert (
         deep_result.attribute_grid("gaussian").native
-        == [af.Gaussian(1.0, 2.0, 3.0), af.Gaussian(1.0, 2.0, 3.0)]
+        == [af.ex.Gaussian(1.0, 2.0, 3.0), af.ex.Gaussian(1.0, 2.0, 3.0)]
     ).all()
 
 

--- a/test_autofit/non_linear/grid/test_result_builder.py
+++ b/test_autofit/non_linear/grid/test_result_builder.py
@@ -17,7 +17,7 @@ def make_result_builder():
 def make_add_results(result_builder):
     def add_results(*numbers):
         for number in numbers:
-            model = af.Model(af.Gaussian)
+            model = af.Model(af.ex.Gaussian)
             samples_summary = MockSamplesSummary(model=model)
             result_builder.add(
                 JobResult(

--- a/test_autofit/non_linear/grid/test_result_json.py
+++ b/test_autofit/non_linear/grid/test_result_json.py
@@ -73,7 +73,7 @@ def test_embedded_sample_model_dict():
 
 
 def test_result_json(sample):
-    model = af.Model(af.Gaussian)
+    model = af.Model(af.ex.Gaussian)
     result = af.mock.MockResult(
         samples_summary=af.m.MockSamplesSummary(
             model=model,

--- a/test_autofit/non_linear/grid/test_sensitivity/conftest.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/conftest.py
@@ -68,7 +68,7 @@ class PerturbFit:
 
 @pytest.fixture(name="perturb_model")
 def make_perturb_model():
-    return af.Model(af.Gaussian)
+    return af.Model(af.ex.Gaussian)
 
 
 @pytest.fixture(name="sensitivity")
@@ -77,10 +77,10 @@ def make_sensitivity(
 ):
     # noinspection PyTypeChecker
     instance = af.ModelInstance()
-    instance.gaussian = af.Gaussian()
+    instance.gaussian = af.ex.Gaussian()
     return s.Sensitivity(
         simulation_instance=instance,
-        base_model=af.Collection(gaussian=af.Model(af.Gaussian)),
+        base_model=af.Collection(gaussian=af.Model(af.ex.Gaussian)),
         perturb_model=perturb_model,
         simulate_cls=Simulate(),
         base_fit_cls=BaseFit(Analysis),
@@ -96,10 +96,10 @@ def make_masked_sensitivity(
 ):
     # noinspection PyTypeChecker
     instance = af.ModelInstance()
-    instance.gaussian = af.Gaussian()
+    instance.gaussian = af.ex.Gaussian()
     return s.Sensitivity(
         simulation_instance=instance,
-        base_model=af.Collection(gaussian=af.Model(af.Gaussian)),
+        base_model=af.Collection(gaussian=af.Model(af.ex.Gaussian)),
         perturb_model=perturb_model,
         simulate_cls=Simulate(),
         base_fit_cls=BaseFit(Analysis),
@@ -126,13 +126,13 @@ def make_job(
     perturb_model,
 ):
     instance = af.ModelInstance()
-    instance.gaussian = af.Gaussian()
+    instance.gaussian = af.ex.Gaussian()
     base_instance = instance
-    instance.perturb = af.Gaussian()
+    instance.perturb = af.ex.Gaussian()
     # noinspection PyTypeChecker
     return s.Job(
-        model=af.Collection(gaussian=af.Model(af.Gaussian)),
-        perturb_model=af.Model(af.Gaussian),
+        model=af.Collection(gaussian=af.Model(af.ex.Gaussian)),
+        perturb_model=af.Model(af.ex.Gaussian),
         simulate_instance=instance,
         base_instance=base_instance,
         simulate_cls=Simulate(),

--- a/test_autofit/non_linear/grid/test_sensitivity/test_functionality.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/test_functionality.py
@@ -118,7 +118,7 @@ class TestPerturbationModels:
         assert model.sigma.upper_limit == 5
 
     def test_model_with_limits(self):
-        model = af.Model(af.Gaussian)
+        model = af.Model(af.ex.Gaussian)
 
         with_limits = model.with_limits(
             [

--- a/test_autofit/non_linear/grid/test_sensitivity/test_results.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/test_results.py
@@ -9,7 +9,7 @@ class Samples:
     def __init__(self, log_likelihood):
         self.log_likelihood = log_likelihood
         self.model = af.Model(
-            af.Gaussian,
+            af.ex.Gaussian,
             centre=af.UniformPrior(
                 0.0,
                 1.0,

--- a/test_autofit/non_linear/paths/test_paths.py
+++ b/test_autofit/non_linear/paths/test_paths.py
@@ -51,7 +51,7 @@ output_path = Path(__file__).parent / "path"
 
 @pytest.fixture(name="model")
 def make_model():
-    return af.Model(af.Gaussian)
+    return af.Model(af.ex.Gaussian)
 
 
 @output_path_for_test(output_path)

--- a/test_autofit/non_linear/paths/test_serialise_paths.py
+++ b/test_autofit/non_linear/paths/test_serialise_paths.py
@@ -23,7 +23,7 @@ def test_identifier():
 
 def test_identifier_with_model():
     paths = af.DirectoryPaths()
-    paths.model = af.Model(af.Gaussian)
+    paths.model = af.Model(af.ex.Gaussian)
     new_paths = from_dict(to_dict(paths))
 
     assert new_paths.identifier == paths.identifier

--- a/test_autofit/non_linear/samples/test_efficient.py
+++ b/test_autofit/non_linear/samples/test_efficient.py
@@ -9,7 +9,7 @@ import pytest
 @pytest.fixture(name="samples")
 def make_samples():
     return af.SamplesPDF(
-        model=af.Model(af.Gaussian),
+        model=af.Model(af.ex.Gaussian),
         sample_list=[
             af.Sample(
                 log_likelihood=1.0,
@@ -59,4 +59,4 @@ def test_database(efficient, session):
     recovered = Object.from_object(efficient)()
     samples = recovered.samples
 
-    assert samples.model.cls is af.Gaussian
+    assert samples.model.cls is af.ex.Gaussian

--- a/test_autofit/non_linear/samples/test_output_type.py
+++ b/test_autofit/non_linear/samples/test_output_type.py
@@ -9,7 +9,7 @@ from autofit.non_linear.samples.efficient import EfficientSamples
 @pytest.fixture(name="samples")
 def make_samples():
     return SamplesNest(
-        model=af.Model(af.Gaussian),
+        model=af.Model(af.ex.Gaussian),
         sample_list=[],
         samples_info=None,
     )

--- a/test_autofit/non_linear/search/test_logging.py
+++ b/test_autofit/non_linear/search/test_logging.py
@@ -19,7 +19,7 @@ def make_run_search():
         search = af.mock.MockSearch("name", fit_fast=False)
         search.paths.remove_files = False
         analysis = Analysis()
-        model = af.Model(af.Gaussian)
+        model = af.Model(af.ex.Gaussian)
         search.fit(model, analysis)
         return search
 

--- a/test_autofit/non_linear/search/test_sneaky_map.py
+++ b/test_autofit/non_linear/search/test_sneaky_map.py
@@ -23,7 +23,7 @@ def make_search():
 
 @pytest.fixture(name="model")
 def make_model():
-    return af.Model(af.Gaussian)
+    return af.Model(af.ex.Gaussian)
 
 
 @pytest.fixture(name="analysis")
@@ -51,7 +51,7 @@ def make_fitness(
 
 
 class Analysis(af.Analysis):
-    def log_likelihood_function(self, instance: af.Gaussian):
+    def log_likelihood_function(self, instance: af.ex.Gaussian):
         return -((10 - instance.centre) ** 2)
 
 
@@ -134,14 +134,14 @@ def test_sneaky_map(search, model, analysis):
 
     result = search.fit(model, analysis)
 
-    assert isinstance(result.instance, af.Gaussian)
+    assert isinstance(result.instance, af.ex.Gaussian)
 
 
 @pytest.mark.parametrize(
     "function",
     [
         _FunctionWrapper(lambda: 1, None, None),
-        Fitness(af.Model(af.Gaussian), MockAnalysis()),
+        Fitness(af.Model(af.ex.Gaussian), MockAnalysis()),
         _function_wrapper(lambda: 1, [], {}, "loglikelihood"),
     ],
 )

--- a/test_autofit/non_linear/test_initializer.py
+++ b/test_autofit/non_linear/test_initializer.py
@@ -236,7 +236,7 @@ def test_invert_gaussian(unit_value, physical_value):
 @pytest.fixture(name="model")
 def make_model():
     return af.Model(
-        af.Gaussian,
+        af.ex.Gaussian,
         centre=af.UniformPrior(1.0, 2.0),
         normalization=af.UniformPrior(2.0, 3.0),
         sigma=af.UniformPrior(-2.0, -1.0),

--- a/test_autofit/non_linear/test_regression.py
+++ b/test_autofit/non_linear/test_regression.py
@@ -36,8 +36,8 @@ def test_serialize_grid_search(search):
 
 @pytest.fixture(name="model")
 def make_model():
-    one = af.Model(af.Gaussian)
-    two = af.Model(af.Gaussian)
+    one = af.Model(af.ex.Gaussian)
+    two = af.Model(af.ex.Gaussian)
     model = af.Collection(
         one=one,
         two=two,

--- a/test_autofit/serialise/test_assertions.py
+++ b/test_autofit/serialise/test_assertions.py
@@ -52,7 +52,7 @@ def make_model_dict(assertion_dict):
 
 @pytest.fixture(name="model")
 def make_model():
-    return af.Model(af.Gaussian)
+    return af.Model(af.ex.Gaussian)
 
 
 def test_to_dict(model_dict, model):

--- a/test_autofit/serialise/test_samples.py
+++ b/test_autofit/serialise/test_samples.py
@@ -7,7 +7,7 @@ from autoconf.dictable import from_dict, to_dict
 
 @pytest.fixture(name="model")
 def make_model():
-    return af.Model(af.Gaussian)
+    return af.Model(af.ex.Gaussian)
 
 
 @pytest.fixture(name="sample")

--- a/test_autofit/test_visualise.py
+++ b/test_autofit/test_visualise.py
@@ -62,7 +62,7 @@ def graph_path(output_directory):
 
 def test_complex_object(graph_path):
     second = af.Model(af.ex.Gaussian)
-    exp = af.Model(af.Exponential)
+    exp = af.Model(af.ex.Exponential)
     third = af.Model(af.ex.Gaussian)
 
     collection = af.Collection(

--- a/test_autofit/test_visualise.py
+++ b/test_autofit/test_visualise.py
@@ -15,8 +15,8 @@ def reset_ids():
 @pytest.fixture
 def model():
     collection = af.Collection(
-        first=af.Model(af.Gaussian),
-        second=af.Model(af.Gaussian),
+        first=af.Model(af.ex.Gaussian),
+        second=af.Model(af.ex.Gaussian),
     )
     collection.first.centre = collection.second.centre
     return collection
@@ -61,9 +61,9 @@ def graph_path(output_directory):
 
 
 def test_complex_object(graph_path):
-    second = af.Model(af.Gaussian)
+    second = af.Model(af.ex.Gaussian)
     exp = af.Model(af.Exponential)
-    third = af.Model(af.Gaussian)
+    third = af.Model(af.ex.Gaussian)
 
     collection = af.Collection(
         first=af.Collection(

--- a/test_autofit/text/test_concise.py
+++ b/test_autofit/text/test_concise.py
@@ -20,7 +20,7 @@ def make_collection():
     return af.Collection(
         [
             af.Model(
-                af.Gaussian,
+                af.ex.Gaussian,
                 centre=centre,
                 normalization=normalization,
                 sigma=sigma,

--- a/test_autofit/tools/test_paths.py
+++ b/test_autofit/tools/test_paths.py
@@ -26,7 +26,7 @@ def make_paths():
 
 
 def test_restore(paths):
-    paths.model = af.Model(af.Gaussian)
+    paths.model = af.Model(af.ex.Gaussian)
     paths.save_all({}, {})
 
     paths.zip_remove()


### PR DESCRIPTION
Fixes to autofit as integration testing on build server raises issues:

- `TruncatedGaussian` added to registered prior type in `__init__`.
- Reinstate import of plot module at `autofit` level.
- Prevent samples without PDF from breaking latent variable sampler.
- Remove `af.Gaussian` as it is confusing with `af.GausssianPrior`, just use` af.ex.Gaussian`

Lots more integration tests still to go...