### PR TITLE
feature/samples_summary_failsafe

### DIFF
--- a/autofit/aggregator/search_output.py
+++ b/autofit/aggregator/search_output.py
@@ -250,7 +250,7 @@ class SearchOutput(AbstractSearchOutput, fit_interface.Fit):
         try:
             return self.samples.max_log_likelihood()
         except (AttributeError, NotImplementedError):
-            return None
+            return self.samples_summary.instance
 
     @property
     def id(self) -> str:


### PR DESCRIPTION
This pull request updates the behavior of the `instance` method in `autofit/aggregator/search_output.py` to improve handling of cases where the `max_log_likelihood` method is unavailable. Instead of returning `None`, it now falls back to returning the instance from `samples_summary`.

Error handling improvement:

* Updated the `instance` method to return `self.samples_summary.instance` when `max_log_likelihood` is not implemented or accessible, rather than returning `None`.