### PR TITLE
feature/jax_cpu_batch_size_1

### DIFF
--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -108,7 +108,8 @@ class Fitness:
         self.model = model
         self.paths = paths
         self.fom_is_log_likelihood = fom_is_log_likelihood
-        self.resample_figure_of_merit = resample_figure_of_merit or -xp.inf
+
+        self.resample_figure_of_merit = resample_figure_of_merit or -self._xp.inf
         self.convert_to_chi_squared = convert_to_chi_squared
         self.store_history = store_history
 
@@ -135,7 +136,7 @@ class Fitness:
         self.batch_size = batch_size
         self.iterations_per_quick_update = iterations_per_quick_update
         self.quick_update_max_lh_parameters = None
-        self.quick_update_max_lh = -xp.inf
+        self.quick_update_max_lh = -self._xp.inf
         self.quick_update_count = 0
 
         if self.paths is not None:

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -44,7 +44,6 @@ class Fitness:
         use_jax_vmap : bool = False,
         batch_size : Optional[int] = None,
         iterations_per_quick_update: Optional[int] = None,
-        xp=np,
     ):
         """
         Interfaces with any non-linear search to fit the model to the data and return a log likelihood via
@@ -122,6 +121,16 @@ class Fitness:
 
         if self.use_jax_vmap:
             self._call = self._vmap
+
+        if analysis._use_jax:
+
+            import jax
+
+            if jax.default_backend() == "cpu":
+
+                logger.info("JAX using CPU backend, batch size set to 1 which will improve performance.")
+
+                batch_size = 1
 
         self.batch_size = batch_size
         self.iterations_per_quick_update = iterations_per_quick_update


### PR DESCRIPTION
This pull request introduces a minor update to the initialization logic in `autofit/non_linear/fitness.py`, specifically to improve performance when using the JAX backend on CPUs. Now, when JAX is detected as the analysis backend and it is running on a CPU, the batch size is automatically set to 1, and a log message is generated to inform the user.

This is because CPU's do not get any speed up from using a vmap with a batch size above 1, but this can cause to issues with shared parallelism.

Performance optimization for JAX CPU backend:

* Automatically sets `batch_size` to 1 and logs an informational message when JAX is used with the CPU backend to improve performance. (`autofit/non_linear/fitness.py`)

Minor cleanup:

* Removes the unused `xp` parameter from the `__init__` method signature. (`autofit/non_linear/fitness.py`)