### PR TITLE
feature/jax_cpu_jit

### DIFF
--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -116,22 +116,22 @@ class Fitness:
         self.parameters_history_list = []
         self.log_likelihood_history_list = []
 
-        self.use_jax_vmap = use_jax_vmap
-
-        self._call = self.call
-
-        if self.use_jax_vmap:
-            self._call = self._vmap
-
         if analysis._use_jax:
 
             import jax
 
             if jax.default_backend() == "cpu":
 
-                logger.info("JAX using CPU backend, batch size set to 1 which will improve performance.")
+                logger.info("JAX using CPU backend, vmap disabled for faster performance.")
 
-                batch_size = 1
+                use_jax_vmap = False
+
+        self.use_jax_vmap = use_jax_vmap
+
+        self._call = self.call
+
+        if self.use_jax_vmap:
+            self._call = self._vmap
 
         self.batch_size = batch_size
         self.iterations_per_quick_update = iterations_per_quick_update

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -137,7 +137,7 @@ class Nautilus(abstract_nest.AbstractNest):
                 fom_is_log_likelihood=True,
                 resample_figure_of_merit=-1.0e99,
                 iterations_per_quick_update=self.iterations_per_quick_update,
-                use_jax_vmap=True,
+                use_jax_vmap=False,
                 batch_size=self.config_dict_search["n_batch"],
             )
 
@@ -225,13 +225,18 @@ class Nautilus(abstract_nest.AbstractNest):
         except KeyError:
             pass
 
+        if fitness.use_jax_vmap:
+            vectorized = True
+        else:
+            vectorized = False
+
         search_internal = self.sampler_cls(
             prior=PriorVectorized(model=model),
             likelihood=fitness.call_wrap,
             n_dim=model.prior_count,
             filepath=self.checkpoint_file,
             pool=None,
-            vectorized=True,
+            vectorized=vectorized,
             **config_dict,
         )
 

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -225,10 +225,7 @@ class Nautilus(abstract_nest.AbstractNest):
         except KeyError:
             pass
 
-        if fitness.use_jax_vmap:
-            vectorized = True
-        else:
-            vectorized = False
+        vectorized = fitness.use_jax_vmap
 
         search_internal = self.sampler_cls(
             prior=PriorVectorized(model=model),


### PR DESCRIPTION
This pull request primarily updates how JAX vectorization (`vmap`) is handled in the Nautilus search implementation, ensuring that vectorization is only enabled when appropriate for performance reasons. The changes disable `vmap` by default, especially when using the CPU backend, and ensure that the vectorization flag is consistently propagated throughout the codebase.

JAX vectorization handling:

* In `autofit/non_linear/fitness.py`, the initialization logic now disables `use_jax_vmap` when the JAX backend is set to CPU, improving performance by avoiding unnecessary vectorization. The log message has also been updated to reflect this change.
* In `autofit/non_linear/search/nest/nautilus/search.py`, the `_fit` method now explicitly sets `use_jax_vmap=False` when constructing the fitness object, ensuring vectorization is off by default.

Vectorization flag propagation:

* In the `fit_x1_cpu` method of `autofit/non_linear/search/nest/nautilus/search.py`, the `vectorized` argument for the sampler is now set based on the `fitness.use_jax_vmap` flag, ensuring consistency in how vectorization is applied throughout the search process.