### PR TITLE
Add intermediate-level mapper internals cookbook

### DIFF
--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -141,4 +141,4 @@ def save_abc(pickler, obj):
     pickle._Pickler.save_type(pickler, obj)
 
 
-__version__ = "2025.11.5.1"
+__version__ = "2025.12.15.1"

--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -141,4 +141,4 @@ def save_abc(pickler, obj):
     pickle._Pickler.save_type(pickler, obj)
 
 
-__version__ = "2025.12.15.1"
+__version__ = "2025.12.15.2"

--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -141,4 +141,4 @@ def save_abc(pickler, obj):
     pickle._Pickler.save_type(pickler, obj)
 
 
-__version__ = "2025.12.15.2"
+__version__ = "2025.12.21.1"

--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -141,4 +141,4 @@ def save_abc(pickler, obj):
     pickle._Pickler.save_type(pickler, obj)
 
 
-__version__ = "2025.12.21.1"
+__version__ = "2026.1.21.3"

--- a/autofit/aggregator/search_output.py
+++ b/autofit/aggregator/search_output.py
@@ -250,7 +250,7 @@ class SearchOutput(AbstractSearchOutput, fit_interface.Fit):
         try:
             return self.samples.max_log_likelihood()
         except (AttributeError, NotImplementedError):
-            return None
+            return self.samples_summary.instance
 
     @property
     def id(self) -> str:

--- a/autofit/aggregator/summary/aggregate_csv/column.py
+++ b/autofit/aggregator/summary/aggregate_csv/column.py
@@ -64,20 +64,34 @@ class Column(AbstractColumn):
         result = {}
 
         if ValueType.Median in self.value_types:
-            result[""] = row.median_pdf_sample_kwargs[self.path]
+            try:
+                result[""] = row.median_pdf_sample_kwargs[self.path]
+            except KeyError:
+                result[""] = None
 
         if ValueType.MaxLogLikelihood in self.value_types:
-            result["max_lh"] = row.max_likelihood_kwargs[self.path]
+            try:
+                result["max_lh"] = row.max_likelihood_kwargs[self.path]
+            except KeyError:
+                result["max_lh"] = None
 
         if ValueType.ValuesAt1Sigma in self.value_types:
-            lower, upper = row.values_at_sigma_1_kwargs[self.path]
-            result["lower_1_sigma"] = lower
-            result["upper_1_sigma"] = upper
+            try:
+                lower, upper = row.values_at_sigma_1_kwargs[self.path]
+                result["lower_1_sigma"] = lower
+                result["upper_1_sigma"] = upper
+            except KeyError:
+                result["lower_1_sigma"] = None
+                result["upper_1_sigma"] = None
 
         if ValueType.ValuesAt3Sigma in self.value_types:
-            lower, upper = row.values_at_sigma_3_kwargs[self.path]
-            result["lower_3_sigma"] = lower
-            result["upper_3_sigma"] = upper
+            try:
+                lower, upper = row.values_at_sigma_3_kwargs[self.path]
+                result["lower_3_sigma"] = lower
+                result["upper_3_sigma"] = upper
+            except KeyError:
+                result["lower_3_sigma"] = None
+                result["upper_3_sigma"] = None
 
         return result
 

--- a/autofit/aggregator/summary/aggregate_images.py
+++ b/autofit/aggregator/summary/aggregate_images.py
@@ -24,32 +24,11 @@ def subplot_filename(subplot: Enum) -> str:
     )
 
 
-class SubplotFit(Enum):
-    """
-    The subplots that can be extracted from the subplot_fit image.
-
-    The values correspond to the position of the subplot in the 4x3 grid.
-    """
-
-    Data = (0, 0)
-    DataSourceScaled = (1, 0)
-    SignalToNoiseMap = (2, 0)
-    ModelData = (3, 0)
-    LensLightModelData = (0, 1)
-    LensLightSubtractedImage = (1, 1)
-    SourceModelData = (2, 1)
-    SourcePlaneZoomed = (3, 1)
-    NormalizedResidualMap = (0, 2)
-    NormalizedResidualMapOneSigma = (1, 2)
-    ChiSquaredMap = (2, 2)
-    SourcePlaneNoZoom = (3, 2)
-
-
 class SubplotFitImage:
     def __init__(
         self,
         image: Image.Image,
-        suplot_type: Type[SubplotFit] = SubplotFit,
+        suplot_type,
     ):
         """
         The subplot_fit image associated with one fit.
@@ -173,7 +152,7 @@ class AggregateImages:
         self,
         folder: Path,
         name: Union[str, List[str]],
-        subplots: List[Union[SubplotFit, List[Image.Image], Callable]],
+        subplots: List[Union[List[Image.Image], Callable]],
         subplot_width: Optional[int] = sys.maxsize,
     ):
         """
@@ -226,7 +205,7 @@ class AggregateImages:
     def _matrix_for_result(
         i: int,
         result: SearchOutput,
-        subplots: List[Union[SubplotFit, List[Image.Image], Callable]],
+        subplots: List[Union[List[Image.Image], Callable]],
         subplot_width: int = sys.maxsize,
     ) -> List[List[Image.Image]]:
         """
@@ -272,7 +251,8 @@ class AggregateImages:
                 _images[subplot_type] = SubplotFitImage(
                     result.image(
                         subplot_filename(subplot_),
-                    )
+                    ),
+                    subplot_type
                 )
             return _images[subplot_type]
 

--- a/autofit/graphical/declarative/abstract.py
+++ b/autofit/graphical/declarative/abstract.py
@@ -20,7 +20,7 @@ class AbstractDeclarativeFactor(Analysis, ABC):
     _plates: Tuple[Plate, ...] = ()
 
     def __init__(self, include_prior_factors=False, use_jax : bool = False):
-        self.include_prior_factors = include_prior_factors
+        self._include_prior_factors = include_prior_factors
 
         super().__init__(use_jax=use_jax)
 
@@ -63,7 +63,7 @@ class AbstractDeclarativeFactor(Analysis, ABC):
             for prior in factor.prior_model.priors:
                 counter[prior] += 1
         return [
-            (prior, count + 1 if self.include_prior_factors else count)
+            (prior, count + 1 if self._include_prior_factors else count)
             for prior, count in counter.items()
         ]
 
@@ -96,7 +96,7 @@ class AbstractDeclarativeFactor(Analysis, ABC):
         The complete graph made by combining all factors and priors
         """
         factors = [model for model in self.model_factors]
-        if self.include_prior_factors:
+        if self._include_prior_factors:
             factors += self.prior_factors
         # noinspection PyTypeChecker
         return DeclarativeFactorGraph(factors)

--- a/autofit/graphical/declarative/collection.py
+++ b/autofit/graphical/declarative/collection.py
@@ -42,7 +42,7 @@ class FactorGraphModel(AbstractDeclarativeFactor):
     def tree_flatten(self):
         return (
             (self._model_factors,),
-            (self._name, self.include_prior_factors),
+            (self._name, self._include_prior_factors),
         )
 
     @classmethod

--- a/autofit/graphical/declarative/factor/abstract.py
+++ b/autofit/graphical/declarative/factor/abstract.py
@@ -42,7 +42,7 @@ class AbstractModelFactor(FactorKW, AbstractDeclarativeFactor, ABC):
             factor, **prior_variable_dict,
             name=name or namer(self.__class__.__name__),
         )
-        self.include_prior_factors = include_prior_factors
+        self._include_prior_factors = include_prior_factors
 
     @property
     def info(self) -> str:

--- a/autofit/graphical/declarative/factor/hierarchical.py
+++ b/autofit/graphical/declarative/factor/hierarchical.py
@@ -72,7 +72,7 @@ class HierarchicalFactor(Model):
         self._name = name or namer(self.__class__.__name__)
         self._factors = list()
         self.optimiser = optimiser
-        self.use_jax = use_jax
+        self._use_jax = use_jax
 
     @property
     def name(self):
@@ -147,7 +147,7 @@ class Factor:
 
 class _HierarchicalFactor(AbstractModelFactor):
     def __init__(
-        self, distribution_model: HierarchicalFactor, drawn_prior: Prior, use_jax : bool = False
+        self, distribution_model: HierarchicalFactor, drawn_prior: Prior,
     ):
         """
         A factor that links a variable to a parameterised distribution.
@@ -162,7 +162,7 @@ class _HierarchicalFactor(AbstractModelFactor):
         """
         self.distribution_model = distribution_model
         self.drawn_prior = drawn_prior
-        self.use_jax = distribution_model.use_jax
+        self._use_jax = distribution_model._use_jax
 
         prior_variable_dict = {prior.name: prior for prior in distribution_model.priors}
 

--- a/autofit/graphical/declarative/factor/hierarchical.py
+++ b/autofit/graphical/declarative/factor/hierarchical.py
@@ -8,6 +8,7 @@ from autofit.mapper.variable import Plate
 from autofit.messages import NormalMessage
 from autofit.non_linear.paths.abstract import AbstractPaths
 from autofit.tools.namer import namer
+
 from .abstract import AbstractModelFactor
 
 
@@ -19,6 +20,7 @@ class HierarchicalFactor(Model):
         distribution: Type[Prior],
         optimiser=None,
         name: Optional[str] = None,
+        use_jax : bool = False,
         **kwargs,
     ):
         """
@@ -70,6 +72,7 @@ class HierarchicalFactor(Model):
         self._name = name or namer(self.__class__.__name__)
         self._factors = list()
         self.optimiser = optimiser
+        self.use_jax = use_jax
 
     @property
     def name(self):
@@ -159,7 +162,7 @@ class _HierarchicalFactor(AbstractModelFactor):
         """
         self.distribution_model = distribution_model
         self.drawn_prior = drawn_prior
-        self.use_jax = use_jax
+        self.use_jax = distribution_model.use_jax
 
         prior_variable_dict = {prior.name: prior for prior in distribution_model.priors}
 
@@ -188,7 +191,7 @@ class _HierarchicalFactor(AbstractModelFactor):
         return self.drawn_prior
 
     def log_likelihood_function(self, instance):
-        return instance.distribution_model.message(instance.drawn_prior)
+        return instance.distribution_model.message(instance.drawn_prior, xp=self._xp)
 
     @property
     def priors(self) -> Set[Prior]:

--- a/autofit/mapper/prior/arithmetic/assertion.py
+++ b/autofit/mapper/prior/arithmetic/assertion.py
@@ -1,4 +1,5 @@
 from abc import ABC
+import numpy as np
 from typing import Optional, Dict
 
 from autofit.mapper.prior.arithmetic.compound import CompoundPrior, Compound

--- a/autofit/mapper/prior/arithmetic/assertion.py
+++ b/autofit/mapper/prior/arithmetic/assertion.py
@@ -24,7 +24,7 @@ class ComparisonAssertion(CompoundPrior, Compound, ABC):
 
 
 class GreaterThanLessThanAssertion(ComparisonAssertion):
-    def _instance_for_arguments(self, arguments, ignore_assertions=False):
+    def _instance_for_arguments(self, arguments, ignore_assertions=False, xp=np):
         """
         Assert that the value in the dictionary associated with the lower
         prior is lower than the value associated with the greater prior.
@@ -55,6 +55,7 @@ class GreaterThanLessThanEqualAssertion(ComparisonAssertion):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         """
         Assert that the value in the dictionary associated with the lower
@@ -90,6 +91,7 @@ class CompoundAssertion(AbstractPriorModel, Compound):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.assertion_1.instance_for_arguments(
             arguments,

--- a/autofit/mapper/prior/arithmetic/compound.py
+++ b/autofit/mapper/prior/arithmetic/compound.py
@@ -212,6 +212,7 @@ class SumPrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -237,6 +238,7 @@ class MultiplePrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -256,6 +258,7 @@ class DivisionPrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -275,6 +278,7 @@ class FloorDivPrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -294,6 +298,7 @@ class ModPrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -313,6 +318,7 @@ class PowerPrior(CompoundPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return self.left_for_arguments(
             arguments,
@@ -396,6 +402,7 @@ class NegativePrior(ModifiedPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return -self.prior.instance_for_arguments(
             arguments,
@@ -412,6 +419,7 @@ class AbsolutePrior(ModifiedPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return abs(
             self.prior.instance_for_arguments(
@@ -430,6 +438,7 @@ class Log(ModifiedPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return np.log(
             self.prior.instance_for_arguments(
@@ -448,6 +457,7 @@ class Log10(ModifiedPrior):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         return np.log10(
             self.prior.instance_for_arguments(

--- a/autofit/mapper/prior/gaussian.py
+++ b/autofit/mapper/prior/gaussian.py
@@ -1,3 +1,4 @@
+import numpy as np
 from typing import Optional
 
 from autofit.messages.normal import NormalMessage
@@ -13,6 +14,7 @@ class GaussianPrior(Prior):
         mean: float,
         sigma: float,
         id_: Optional[int] = None,
+        _xp=np
     ):
         """
         A Gaussian prior defined by a normal distribution.
@@ -50,6 +52,7 @@ class GaussianPrior(Prior):
             message=NormalMessage(
                 mean=mean,
                 sigma=sigma,
+                xp=_xp
             ),
             id_=id_,
         )

--- a/autofit/mapper/prior/gaussian.py
+++ b/autofit/mapper/prior/gaussian.py
@@ -14,7 +14,6 @@ class GaussianPrior(Prior):
         mean: float,
         sigma: float,
         id_: Optional[int] = None,
-        _xp=np
     ):
         """
         A Gaussian prior defined by a normal distribution.
@@ -48,11 +47,11 @@ class GaussianPrior(Prior):
         >>> prior = GaussianPrior(mean=1.0, sigma=2.0)
         >>> physical_value = prior.value_for(unit=0.5)  # Returns ~1.0 (mean)
         """
+
         super().__init__(
             message=NormalMessage(
                 mean=mean,
                 sigma=sigma,
-                xp=_xp
             ),
             id_=id_,
         )

--- a/autofit/mapper/prior/log_gaussian.py
+++ b/autofit/mapper/prior/log_gaussian.py
@@ -133,7 +133,7 @@ class LogGaussianPrior(Prior):
     def parameter_string(self) -> str:
         return f"mean = {self.mean}, sigma = {self.sigma}"
 
-    def log_prior_from_value(self, value):
+    def log_prior_from_value(self, value, xp=np):
         if value <= 0:
             return float("-inf")
 

--- a/autofit/mapper/prior/log_uniform.py
+++ b/autofit/mapper/prior/log_uniform.py
@@ -110,7 +110,7 @@ class LogUniformPrior(Prior):
 
     __identifier_fields__ = ("lower_limit", "upper_limit")
 
-    def log_prior_from_value(self, value) -> float:
+    def log_prior_from_value(self, value, xp=np) -> float:
         """
         Returns the log prior of a physical value, so the log likelihood of a model evaluation can be converted to a
         posterior as log_prior + log_likelihood.

--- a/autofit/mapper/prior/uniform.py
+++ b/autofit/mapper/prior/uniform.py
@@ -1,3 +1,4 @@
+import numpy as np
 from typing import Optional, Tuple
 
 from autofit.messages.normal import UniformNormalMessage
@@ -128,7 +129,7 @@ class UniformPrior(Prior):
             round(super().value_for(unit), 14)
         )
 
-    def log_prior_from_value(self, value):
+    def log_prior_from_value(self, value, xp=np):
         """
         Returns the log prior of a physical value, so the log likelihood of a model evaluation can be converted to a
         posterior as log_prior + log_likelihood.

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1095,7 +1095,7 @@ class AbstractPriorModel(AbstractModel):
         return list(
             map(
                 lambda prior_tuple, value: prior_tuple.prior.log_prior_from_value(
-                    value=value, xp=np
+                    value=value, xp=xp
                 ),
                 self.prior_tuples_ordered_by_id,
                 vector,

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1078,6 +1078,7 @@ class AbstractPriorModel(AbstractModel):
     def log_prior_list_from_vector(
         self,
         vector: [float],
+        xp=np,
     ):
         """
         Compute the log priors of every parameter in a vector, using the Prior of every parameter.
@@ -1094,7 +1095,7 @@ class AbstractPriorModel(AbstractModel):
         return list(
             map(
                 lambda prior_tuple, value: prior_tuple.prior.log_prior_from_value(
-                    value=value
+                    value=value, xp=np
                 ),
                 self.prior_tuples_ordered_by_id,
                 vector,

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -745,7 +745,7 @@ class AbstractPriorModel(AbstractModel):
         """
         return self.vector_from_unit_vector([0.5] * len(self.unique_prior_tuples))
 
-    def instance_from_vector(self, vector, ignore_assertions: bool = False):
+    def instance_from_vector(self, vector, ignore_assertions: bool = False, xp=np):
         """
         Returns a ModelInstance, which has an attribute and class instance corresponding
         to every `Model` attributed to this instance.
@@ -778,6 +778,7 @@ class AbstractPriorModel(AbstractModel):
         return self.instance_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xp=xp
         )
 
     def has(self, cls: Union[Type, Tuple[Type, ...]]) -> bool:
@@ -1309,6 +1310,7 @@ class AbstractPriorModel(AbstractModel):
         self,
         arguments: Dict[Prior, float],
         ignore_assertions: bool = False,
+        xp=np,
     ):
         raise NotImplementedError()
 
@@ -1316,6 +1318,7 @@ class AbstractPriorModel(AbstractModel):
         self,
         arguments: Dict[Prior, float],
         ignore_assertions: bool = False,
+        xp=np,
     ):
         """
         Returns an instance of the model for a set of arguments
@@ -1339,6 +1342,7 @@ class AbstractPriorModel(AbstractModel):
         return self._instance_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
+            xpx=p
         )
 
     def path_for_name(self, name: str) -> Tuple[str, ...]:

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1342,7 +1342,7 @@ class AbstractPriorModel(AbstractModel):
         return self._instance_for_arguments(
             arguments,
             ignore_assertions=ignore_assertions,
-            xpx=p
+            xp=xp
         )
 
     def path_for_name(self, name: str) -> Tuple[str, ...]:

--- a/autofit/mapper/prior_model/array.py
+++ b/autofit/mapper/prior_model/array.py
@@ -57,6 +57,7 @@ class Array(AbstractPriorModel):
         self,
         arguments: Dict[Prior, float],
         ignore_assertions: bool = False,
+        xp=np,
     ) -> np.ndarray:
         """
         Create an array where the prior at each index is replaced with the

--- a/autofit/mapper/prior_model/collection.py
+++ b/autofit/mapper/prior_model/collection.py
@@ -208,6 +208,7 @@ class Collection(AbstractPriorModel):
         self,
         arguments,
         ignore_assertions=False,
+        xp=np,
     ):
         """
         Parameters

--- a/autofit/mapper/prior_model/collection.py
+++ b/autofit/mapper/prior_model/collection.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from collections.abc import Iterable
 
 from autofit.mapper.model import ModelInstance, assert_not_frozen
@@ -229,6 +231,7 @@ class Collection(AbstractPriorModel):
                 value = value.instance_for_arguments(
                     arguments,
                     ignore_assertions=ignore_assertions,
+                    xp=xp
                 )
             elif isinstance(value, Prior):
                 value = arguments[value]

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -459,6 +459,7 @@ class Model(AbstractPriorModel):
         self,
         arguments: {ModelObject: object},
         ignore_assertions=False,
+        xp=np,
     ):
         """
         Returns an instance of the associated class for a set of arguments

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -2,6 +2,7 @@ import collections.abc
 import copy
 import inspect
 import logging
+import numpy as np
 import typing
 from typing import *
 
@@ -420,36 +421,6 @@ class Model(AbstractPriorModel):
 
         self.__getattribute__(item)
 
-    # def __getattr__(self, item):
-    #
-    #     try:
-    #         if (
-    #             "_" in item
-    #             and item not in ("_is_frozen", "tuple_prior_tuples")
-    #             and not item.startswith("_")
-    #         ):
-    #             return getattr(
-    #                 [v for k, v in self.tuple_prior_tuples if item.split("_")[0] == k][
-    #                     0
-    #                 ],
-    #                 item,
-    #             )
-    #
-    #     except IndexError:
-    #         pass
-    #
-    #     try:
-    #         return getattr(
-    #             self.instance_for_arguments(
-    #                 {prior: prior for prior in self.priors},
-    #             ),
-    #             item,
-    #         )
-    #     except (AttributeError, TypeError):
-    #         pass
-    #
-    #     self.__getattribute__(item)
-
     @property
     def is_deferred_arguments(self):
         return len(self.direct_deferred_tuples) > 0
@@ -491,6 +462,7 @@ class Model(AbstractPriorModel):
             ] = prior_model.instance_for_arguments(
                 arguments,
                 ignore_assertions=ignore_assertions,
+                xp=xp
             )
 
         prior_arguments = dict()
@@ -533,6 +505,7 @@ class Model(AbstractPriorModel):
                     value = value.instance_for_arguments(
                         arguments,
                         ignore_assertions=ignore_assertions,
+                        xp=xp
                     )
                 elif isinstance(value, Constant):
                     value = value.value

--- a/autofit/messages/abstract.py
+++ b/autofit/messages/abstract.py
@@ -62,7 +62,7 @@ class AbstractMessage(MessageInterface, ABC):
             self._broadcast = _xp.broadcast_arrays(*parameters)
 
         if self.shape:
-            self.parameters = tuple(xp.aarray(p) for p in parameters)
+            self.parameters = tuple(xp.asarray(p) for p in parameters)
         else:
             self.parameters = tuple(parameters)
 

--- a/autofit/messages/abstract.py
+++ b/autofit/messages/abstract.py
@@ -45,17 +45,24 @@ class AbstractMessage(MessageInterface, ABC):
         lower_limit=-math.inf,
         upper_limit=math.inf,
         id_=None,
+        _xp=np
     ):
+
+        xp=_xp
 
         self.lower_limit = float(lower_limit)
         self.upper_limit = float(upper_limit)
 
         self.id = next(self.ids) if id_ is None else id_
         self.log_norm = log_norm
-        self._broadcast = np.broadcast(*parameters)
+
+        if xp is np:
+            self._broadcast = np.broadcast(*parameters)
+        else:
+            self._broadcast = _xp.broadcast_arrays(*parameters)
 
         if self.shape:
-            self.parameters = tuple(np.asanyarray(p) for p in parameters)
+            self.parameters = tuple(xp.aarray(p) for p in parameters)
         else:
             self.parameters = tuple(parameters)
 

--- a/autofit/messages/abstract.py
+++ b/autofit/messages/abstract.py
@@ -366,8 +366,8 @@ class AbstractMessage(MessageInterface, ABC):
             )
         return mean, variance
 
-    def __call__(self, x):
-        return np.sum(self.logpdf(x))
+    def __call__(self, x, xp=np):
+        return xp.sum(self.logpdf(x, xp=xp))
 
     def factor_jacobian(
         self, x: np.ndarray, _variables: Optional[Tuple[str]] = ("x",)

--- a/autofit/messages/abstract.py
+++ b/autofit/messages/abstract.py
@@ -56,6 +56,7 @@ class AbstractMessage(MessageInterface, ABC):
         self.id = next(self.ids) if id_ is None else id_
         self.log_norm = log_norm
 
+
         if xp is np:
             self._broadcast = np.broadcast(*parameters)
         else:
@@ -222,7 +223,7 @@ class AbstractMessage(MessageInterface, ABC):
             )
 
     def __pow__(self, other: Real) -> "AbstractMessage":
-        natural = self.natural_parameters
+        natural = self.natural_parameters()
         new_params = other * natural
         log_norm = other * self.log_norm
         new = self.from_natural_parameters(
@@ -313,12 +314,12 @@ class AbstractMessage(MessageInterface, ABC):
         ]
 
         # Calculate log product of message normalisation
-        log_norm = self.log_base_measure - self.log_partition
-        log_norm += sum(dist.log_base_measure - dist.log_partition for dist in dists)
+        log_norm = self.log_base_measure - self.log_partition()
+        log_norm += sum(dist.log_base_measure - dist.log_partition() for dist in dists)
 
         # Calculate log normalisation of product of messages
         prod_dist = self.sum_natural_parameters(*dists)
-        log_norm -= prod_dist.log_base_measure - prod_dist.log_partition
+        log_norm -= prod_dist.log_base_measure - prod_dist.log_partition()
 
         return log_norm
 

--- a/autofit/messages/beta.py
+++ b/autofit/messages/beta.py
@@ -201,7 +201,8 @@ class BetaMessage(AbstractMessage):
     @staticmethod
     def calc_natural_parameters(
             alpha: Union[float, np.ndarray],
-            beta: Union[float, np.ndarray]
+            beta: Union[float, np.ndarray],
+            xp=np
     ) -> np.ndarray:
         """
         Calculate the natural parameters of a Beta distribution from alpha and beta.
@@ -217,7 +218,7 @@ class BetaMessage(AbstractMessage):
         -------
         Natural parameters [alpha - 1, beta - 1].
         """
-        return np.array([alpha - 1, beta - 1])
+        return xp.array([alpha - 1, beta - 1])
 
     @staticmethod
     def invert_natural_parameters(

--- a/autofit/messages/beta.py
+++ b/autofit/messages/beta.py
@@ -171,8 +171,7 @@ class BetaMessage(AbstractMessage):
         """
         raise NotImplemented()
 
-    @cached_property
-    def log_partition(self) -> np.ndarray:
+    def log_partition(self, xp=np) -> np.ndarray:
         """
         Compute the log partition function (log normalization constant) of the Beta distribution.
 

--- a/autofit/messages/beta.py
+++ b/autofit/messages/beta.py
@@ -184,8 +184,7 @@ class BetaMessage(AbstractMessage):
 
         return betaln(*self.parameters)
 
-    @cached_property
-    def natural_parameters(self) -> np.ndarray:
+    def natural_parameters(self, xp=np) -> np.ndarray:
         """
         Compute the natural parameters of the Beta distribution.
 
@@ -196,7 +195,8 @@ class BetaMessage(AbstractMessage):
         """
         return self.calc_natural_parameters(
             self.alpha,
-            self.beta
+            self.beta,
+            xp=xp
         )
 
     @staticmethod
@@ -258,7 +258,7 @@ class BetaMessage(AbstractMessage):
         return cls.calc_natural_parameters(a, b)
 
     @classmethod
-    def to_canonical_form(cls, x: np.ndarray) -> np.ndarray:
+    def to_canonical_form(cls, x: np.ndarray, xp=np) -> np.ndarray:
         """
         Convert a value x in (0,1) to the canonical sufficient statistics for Beta.
 
@@ -271,7 +271,7 @@ class BetaMessage(AbstractMessage):
         -------
         Canonical sufficient statistics [log(x), log(1 - x)].
         """
-        return np.array([np.log(x), np.log1p(-x)])
+        return xp.array([xp.log(x), xp.log1p(-x)])
 
     @cached_property
     def mean(self) -> Union[np.ndarray, float]:

--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -158,7 +158,7 @@ class TransformedMessage(MessageInterface):
         return self.base_message.kl(dist.base_message)
 
     def natural_parameters(self, xp=np) -> np.ndarray:
-        return self.base_message.natural_parameters
+        return self.base_message.natural_parameters(xp=xp)
 
     @inverse_transform
     def sample(self, n_samples: Optional[int] = None):
@@ -229,7 +229,7 @@ class TransformedMessage(MessageInterface):
         return self.base_message.cdf(x)
 
     def log_partition(self, xp=np) -> np.ndarray:
-        return self.base_message.log_partition
+        return self.base_message.log_partition(xp=xp)
 
     def invert_sufficient_statistics(self, sufficient_statistics):
         return self.base_message.invert_sufficient_statistics(sufficient_statistics)

--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -34,7 +34,7 @@ def transform(func):
     """
 
     @functools.wraps(func)
-    def wrapper(self, x, xp):
+    def wrapper(self, x, xp=np):
         x = self._transform(x)
         return func(self, x, xp)
 
@@ -225,8 +225,8 @@ class TransformedMessage(MessageInterface):
         return self.base_message.invert_natural_parameters(natural_parameters)
 
     @transform
-    def cdf(self, x):
-        return self.base_message.cdf(x)
+    def cdf(self, x, xp=np):
+        return self.base_message.cdf(x, xp=xp)
 
     def log_partition(self, xp=np) -> np.ndarray:
         return self.base_message.log_partition(xp=xp)

--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -34,9 +34,9 @@ def transform(func):
     """
 
     @functools.wraps(func)
-    def wrapper(self, x):
+    def wrapper(self, x, xp):
         x = self._transform(x)
-        return func(self, x)
+        return func(self, x, xp)
 
     return wrapper
 
@@ -239,8 +239,8 @@ class TransformedMessage(MessageInterface):
         return self.base_message.value_for(unit)
 
     @transform
-    def calc_log_base_measure(self, x) -> np.ndarray:
-        return self.base_message.calc_log_base_measure(x)
+    def calc_log_base_measure(self, x, xp=np) -> np.ndarray:
+        return self.base_message.calc_log_base_measure(x, xp=xp)
 
     @transform
     def to_canonical_form(self, x, xp=np) -> np.ndarray:

--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -228,8 +228,7 @@ class TransformedMessage(MessageInterface):
     def cdf(self, x):
         return self.base_message.cdf(x)
 
-    @property
-    def log_partition(self) -> np.ndarray:
+    def log_partition(self, xp=np) -> np.ndarray:
         return self.base_message.log_partition
 
     def invert_sufficient_statistics(self, sufficient_statistics):

--- a/autofit/messages/composed_transform.py
+++ b/autofit/messages/composed_transform.py
@@ -157,8 +157,7 @@ class TransformedMessage(MessageInterface):
     def kl(self, dist):
         return self.base_message.kl(dist.base_message)
 
-    @property
-    def natural_parameters(self):
+    def natural_parameters(self, xp=np) -> np.ndarray:
         return self.base_message.natural_parameters
 
     @inverse_transform
@@ -245,8 +244,8 @@ class TransformedMessage(MessageInterface):
         return self.base_message.calc_log_base_measure(x)
 
     @transform
-    def to_canonical_form(self, x) -> np.ndarray:
-        return self.base_message.to_canonical_form(x)
+    def to_canonical_form(self, x, xp=np) -> np.ndarray:
+        return self.base_message.to_canonical_form(x, xp=xp)
 
     @property
     @inverse_transform

--- a/autofit/messages/fixed.py
+++ b/autofit/messages/fixed.py
@@ -25,8 +25,7 @@ class FixedMessage(AbstractMessage):
     def value_for(self, unit: float) -> float:
         raise NotImplemented()
 
-    @cached_property
-    def natural_parameters(self) -> Tuple[np.ndarray, ...]:
+    def natural_parameters(self, xp=np) -> Tuple[np.ndarray, ...]:
         return self.parameters
 
     @staticmethod
@@ -35,7 +34,7 @@ class FixedMessage(AbstractMessage):
         return natural_parameters,
 
     @staticmethod
-    def to_canonical_form(x: np.ndarray) -> np.ndarray:
+    def to_canonical_form(x: np.ndarray, xp=np) -> np.ndarray:
         return x
 
     @cached_property

--- a/autofit/messages/fixed.py
+++ b/autofit/messages/fixed.py
@@ -37,8 +37,7 @@ class FixedMessage(AbstractMessage):
     def to_canonical_form(x: np.ndarray, xp=np) -> np.ndarray:
         return x
 
-    @cached_property
-    def log_partition(self) -> np.ndarray:
+    def log_partition(self, xp=np) -> np.ndarray:
         return 0.
 
     @classmethod

--- a/autofit/messages/gamma.py
+++ b/autofit/messages/gamma.py
@@ -36,9 +36,8 @@ class GammaMessage(AbstractMessage):
     def value_for(self, unit: float) -> float:
         raise NotImplemented()
 
-    @cached_property
-    def natural_parameters(self):
-        return self.calc_natural_parameters(self.alpha, self.beta)
+    def natural_parameters(self, xp=np) -> np.ndarray:
+        return self.calc_natural_parameters(self.alpha, self.beta, xp=xp)
 
     @staticmethod
     def calc_natural_parameters(alpha, beta):
@@ -50,8 +49,8 @@ class GammaMessage(AbstractMessage):
         return eta1 + 1, -eta2
 
     @staticmethod
-    def to_canonical_form(x):
-        return np.array([np.log(x), x])
+    def to_canonical_form(x, xp=np):
+        return xp.array([np.log(x), x])
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats):

--- a/autofit/messages/gamma.py
+++ b/autofit/messages/gamma.py
@@ -6,11 +6,11 @@ from autofit.messages.utils import invpsilog
 
 
 class GammaMessage(AbstractMessage):
-    @property
-    def log_partition(self):
+
+    def log_partition(self, xp=np):
         from scipy import special
 
-        alpha, beta = GammaMessage.invert_natural_parameters(self.natural_parameters)
+        alpha, beta = GammaMessage.invert_natural_parameters(self.natural_parameters(xp=xp))
         return special.gammaln(alpha) - alpha * np.log(beta)
 
     log_base_measure = 0.0

--- a/autofit/messages/gamma.py
+++ b/autofit/messages/gamma.py
@@ -40,8 +40,8 @@ class GammaMessage(AbstractMessage):
         return self.calc_natural_parameters(self.alpha, self.beta, xp=xp)
 
     @staticmethod
-    def calc_natural_parameters(alpha, beta):
-        return np.array([alpha - 1, -beta])
+    def calc_natural_parameters(alpha, beta, xp=np):
+        return xp.array([alpha - 1, -beta])
 
     @staticmethod
     def invert_natural_parameters(natural_parameters):
@@ -97,13 +97,13 @@ class GammaMessage(AbstractMessage):
 
     def logpdf_gradient(self, x):
         logl = self.logpdf(x)
-        eta1 = self.natural_parameters[0]
+        eta1 = self.natural_parameters()[0]
         gradl = eta1 / x - self.beta
         return logl, gradl
 
     def logpdf_gradient_hessian(self, x):
         logl = self.logpdf(x)
-        eta1 = self.natural_parameters[0]
+        eta1 = self.natural_parameters()[0]
         gradl = eta1 / x
         hessl = -gradl / x
         gradl -= self.beta

--- a/autofit/messages/interface.py
+++ b/autofit/messages/interface.py
@@ -83,19 +83,8 @@ class MessageInterface(ABC):
 
     @classmethod
     def natural_logpdf(cls, eta, t, log_base, log_partition, xp=np):
-
-        try:
-            eta = eta()
-        except TypeError:
-            pass
-
-        try:
-            log_partition_in = log_partition(xp=xp)
-        except TypeError:
-            log_partition_in = log_partition
-
         eta_t = xp.multiply(eta, t).sum(0)
-        return xp.nan_to_num(log_base + eta_t - log_partition_in, nan=-xp.inf)
+        return xp.nan_to_num(log_base + eta_t - log_partition, nan=-xp.inf)
 
     def numerical_logpdf_gradient(
         self, x: np.ndarray, eps: float = 1e-6

--- a/autofit/messages/interface.py
+++ b/autofit/messages/interface.py
@@ -48,7 +48,7 @@ class MessageInterface(ABC):
         eta = self._broadcast_natural_parameters(x, xp=xp)
         t = self.to_canonical_form(x, xp=xp)
         log_base = self.calc_log_base_measure(x)
-        return self.natural_logpdf(eta, t, log_base, self.log_partition)
+        return self.natural_logpdf(eta, t, log_base, self.log_partition(xp=xp), xp=xp)
 
     def _broadcast_natural_parameters(self, x, xp=np):
         shape = xp.shape(x)
@@ -75,15 +75,14 @@ class MessageInterface(ABC):
     def calc_log_base_measure(cls, x):
         return cls.log_base_measure
 
-    @cached_property
     @abstractmethod
-    def log_partition(self) -> np.ndarray:
+    def log_partition(self, xp=np) -> np.ndarray:
         pass
 
     @classmethod
-    def natural_logpdf(cls, eta, t, log_base, log_partition):
-        eta_t = np.multiply(eta, t).sum(0)
-        return np.nan_to_num(log_base + eta_t - log_partition, nan=-np.inf)
+    def natural_logpdf(cls, eta, t, log_base, log_partition, xp=np):
+        eta_t = xp.multiply(eta, t).sum(0)
+        return xp.nan_to_num(log_base + eta_t - log_partition, nan=-xp.inf)
 
     def numerical_logpdf_gradient(
         self, x: np.ndarray, eps: float = 1e-6

--- a/autofit/messages/interface.py
+++ b/autofit/messages/interface.py
@@ -44,32 +44,31 @@ class MessageInterface(ABC):
     def pdf(self, x: np.ndarray) -> np.ndarray:
         return np.exp(self.logpdf(x))
 
-    def logpdf(self, x: Union[np.ndarray, float]) -> np.ndarray:
-        eta = self._broadcast_natural_parameters(x)
-        t = self.to_canonical_form(x)
+    def logpdf(self, x: Union[np.ndarray, float], xp=np) -> np.ndarray:
+        eta = self._broadcast_natural_parameters(x, xp=xp)
+        t = self.to_canonical_form(x, xp=xp)
         log_base = self.calc_log_base_measure(x)
         return self.natural_logpdf(eta, t, log_base, self.log_partition)
 
-    def _broadcast_natural_parameters(self, x):
-        shape = np.shape(x)
+    def _broadcast_natural_parameters(self, x, xp=np):
+        shape = xp.shape(x)
         if shape == self.shape:
-            return self.natural_parameters
+            return self.natural_parameters(xp=xp)
         elif shape[1:] == self.shape:
-            return self.natural_parameters[:, None, ...]
+            return self.natural_parameters(xp=xp)[:, None, ...]
         else:
             raise ValueError(
                 f"shape of passed value {shape} does not "
                 f"match message shape {self.shape}"
             )
 
-    @cached_property
     @abstractmethod
-    def natural_parameters(self):
+    def natural_parameters(self, xp=np) -> np.ndarray:
         pass
 
     @staticmethod
     @abstractmethod
-    def to_canonical_form(x: Union[np.ndarray, float]) -> np.ndarray:
+    def to_canonical_form(x: Union[np.ndarray, float], xp=np) -> np.ndarray:
         pass
 
     @classmethod

--- a/autofit/messages/interface.py
+++ b/autofit/messages/interface.py
@@ -23,6 +23,11 @@ class MessageInterface(ABC):
 
     @property
     def shape(self) -> Tuple[int, ...]:
+
+        # JAX behaviour
+        if isinstance(self.broadcast, list):
+            return ()
+
         return self.broadcast.shape
 
     @property

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -93,7 +93,8 @@ class NormalMessage(AbstractMessage):
         id_
             An optional unique identifier used to track the message in larger probabilistic graphs or models.
         """
-        if isinstance(mean, (np.ndarray, float, int)):
+
+        if isinstance(mean, (np.ndarray, float, int, list)):
             xp = np
         else:
             import jax.numpy as jnp
@@ -470,7 +471,7 @@ class NormalMessage(AbstractMessage):
         A natural form Gaussian with zeroed parameters but same configuration.
         """
         return NaturalNormal.from_natural_parameters(
-            self.natural_parameters * 0.0, **self._init_kwargs
+            self.natural_parameters() * 0.0, **self._init_kwargs
         )
 
     def zeros_like(self) -> "AbstractMessage":
@@ -556,7 +557,7 @@ class NaturalNormal(NormalMessage):
         return np.nan_to_num(-self.parameters[0] / self.parameters[1] / 2)
 
     @staticmethod
-    def calc_natural_parameters(eta1: float, eta2: float) -> np.ndarray:
+    def calc_natural_parameters(eta1: float, eta2: float, xp=np) -> np.ndarray:
         """
         Return the natural parameters in array form (identity function for this class).
 
@@ -567,7 +568,7 @@ class NaturalNormal(NormalMessage):
         eta2
             The second natural parameter.
         """
-        return np.array([eta1, eta2])
+        return xp.array([eta1, eta2])
 
     def natural_parameters(self, xp=np) -> np.ndarray:
         """

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -148,8 +148,7 @@ class NormalMessage(AbstractMessage):
 
         return norm.ppf(x, loc=self.mean, scale=self.sigma)
 
-    @cached_property
-    def natural_parameters(self) -> np.ndarray:
+    def natural_parameters(self, xp=np) -> np.ndarray:
         """
         The natural (canonical) parameters of the Gaussian distribution in exponential-family form.
 
@@ -162,10 +161,10 @@ class NormalMessage(AbstractMessage):
         -------
         A NumPy array containing the two natural parameters [η₁, η₂].
         """
-        return self.calc_natural_parameters(self.mean, self.sigma)
+        return self.calc_natural_parameters(self.mean, self.sigma, xp=xp)
 
     @staticmethod
-    def calc_natural_parameters(mu : Union[float, np.ndarray], sigma : Union[float, np.ndarray]) -> np.ndarray:
+    def calc_natural_parameters(mu : Union[float, np.ndarray], sigma : Union[float, np.ndarray], xp=np) -> np.ndarray:
         """
         Convert standard parameters of a Gaussian distribution (mean and standard deviation)
         into natural parameters used in its exponential family representation.
@@ -184,7 +183,7 @@ class NormalMessage(AbstractMessage):
             η₂ = -1 / (2σ²)
         """
         precision = 1 / sigma**2
-        return np.array([mu * precision, -precision / 2])
+        return xp.array([mu * precision, -precision / 2])
 
     @staticmethod
     def invert_natural_parameters(natural_parameters : np.ndarray) -> Tuple[float, float]:
@@ -207,7 +206,7 @@ class NormalMessage(AbstractMessage):
         return mu, sigma
 
     @staticmethod
-    def to_canonical_form(x : Union[float, np.ndarray]) -> np.ndarray:
+    def to_canonical_form(x : Union[float, np.ndarray], xp=np) -> np.ndarray:
         """
         Convert a scalar input `x` to its sufficient statistics for the Gaussian exponential family.
 
@@ -223,7 +222,7 @@ class NormalMessage(AbstractMessage):
         -------
         The sufficient statistics [x, x²].
         """
-        return np.array([x, x**2])
+        return xp.array([x, x**2])
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats: Tuple[float, float]) -> np.ndarray:
@@ -570,12 +569,11 @@ class NaturalNormal(NormalMessage):
         """
         return np.array([eta1, eta2])
 
-    @cached_property
-    def natural_parameters(self) -> np.ndarray:
+    def natural_parameters(self, xp=np) -> np.ndarray:
         """
         Return the natural parameters of this distribution.
         """
-        return self.calc_natural_parameters(*self.parameters)
+        return self.calc_natural_parameters(*self.parameters, xp=xp)
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats: Tuple[float, float]) -> np.ndarray:

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -401,7 +401,7 @@ class NormalMessage(AbstractMessage):
 
         return self.mean + (self.sigma * np.sqrt(2) * inv)
 
-    def log_prior_from_value(self, value: float) -> float:
+    def log_prior_from_value(self, value: float, xp=np) -> float:
         """
         Compute the log prior probability of a given physical value under this Gaussian prior.
 

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -24,6 +24,7 @@ def is_nan(value):
     return is_nan_
 
 def assert_sigma_non_negative(sigma, xp=np):
+
     sigma_arr = xp.asarray(sigma)
     is_negative = xp.any(sigma_arr < 0)
 
@@ -65,7 +66,6 @@ class NormalMessage(AbstractMessage):
         sigma : Union[float, np.ndarray],
         log_norm : Optional[float] = 0.0,
         id_ : Optional[Hashable] = None,
-        xp=np
     ):
         """
         A Gaussian (Normal) message representing a probability distribution over a continuous variable.
@@ -87,6 +87,20 @@ class NormalMessage(AbstractMessage):
         id_
             An optional unique identifier used to track the message in larger probabilistic graphs or models.
         """
+        if isinstance(mean, (np.ndarray, float, int)):
+            xp = np
+        else:
+            import jax.numpy as jnp
+            xp = jnp
+
+
+        print(type(mean))
+        print(type(mean))
+        print(xp)
+        print(xp)
+        print(xp)
+        print(xp)
+
         assert_sigma_non_negative(sigma, xp=xp)
 
         super().__init__(

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -111,7 +111,7 @@ class NormalMessage(AbstractMessage):
         )
         self.mean, self.sigma = self.parameters
 
-    def cdf(self, x : Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+    def cdf(self, x : Union[float, np.ndarray], xp=np) -> Union[float, np.ndarray]:
         """
         Compute the cumulative distribution function (CDF) of the Gaussian distribution
         at a given value or array of values `x`.

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -45,8 +45,8 @@ def assert_sigma_non_negative(sigma, xp=np):
             raise ValueError("Sigma cannot be negative")
 
 class NormalMessage(AbstractMessage):
-    @cached_property
-    def log_partition(self):
+
+    def log_partition(self, xp=np):
         """
         Compute the log-partition function (also called log-normalizer or cumulant function)
         for the normal distribution in its natural (canonical) parameterization.
@@ -59,8 +59,8 @@ class NormalMessage(AbstractMessage):
            A(η) = η₁² / (-4η₂) - 0.5 * log(-2η₂)
         This ensures normalization of the exponential-family distribution.
         """
-        eta1, eta2 = self.natural_parameters
-        return -(eta1**2) / 4 / eta2 - np.log(-2 * eta2) / 2
+        eta1, eta2 = self.natural_parameters(xp=xp)
+        return -(eta1**2) / 4 / eta2 - xp.log(-2 * eta2) / 2
 
     log_base_measure = -0.5 * np.log(2 * np.pi)
     _support = ((-np.inf, np.inf),)

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -161,7 +161,7 @@ class TruncatedNormalMessage(AbstractMessage):
         return self.calc_natural_parameters(self.mean, self.sigma, xp=xp)
 
     @staticmethod
-    def calc_natural_parameters(mu : Union[float, np.ndarray], sigma : Union[float, np.ndarray]) -> np.ndarray:
+    def calc_natural_parameters(mu : Union[float, np.ndarray], sigma : Union[float, np.ndarray], xp=np) -> np.ndarray:
         """
         Convert standard parameters of a Gaussian distribution (mean and standard deviation)
         into natural parameters used in its exponential family representation.
@@ -189,7 +189,7 @@ class TruncatedNormalMessage(AbstractMessage):
             η₂ = -1 / (2σ²)
         """
         precision = 1 / sigma**2
-        return np.array([mu * precision, -precision / 2])
+        return xp.array([mu * precision, -precision / 2])
 
     @staticmethod
     def invert_natural_parameters(natural_parameters : np.ndarray) -> Tuple[float, float]:
@@ -493,7 +493,7 @@ class TruncatedNormalMessage(AbstractMessage):
         A natural form Gaussian with zeroed parameters but same configuration.
         """
         return TruncatedNaturalNormal.from_natural_parameters(
-            self.natural_parameters * 0.0, **self._init_kwargs
+            self.natural_parameters() * 0.0, **self._init_kwargs
         )
 
     def zeros_like(self) -> "AbstractMessage":
@@ -617,10 +617,11 @@ class TruncatedNaturalNormal(TruncatedNormalMessage):
 
     @staticmethod
     def calc_natural_parameters(
-            eta1: float,
-            eta2: float,
-            lower_limit: float = -np.inf,
-            upper_limit: float = np.inf
+        eta1: float,
+        eta2: float,
+        lower_limit: float = -np.inf,
+        upper_limit: float = np.inf,
+        xp=np
     ) -> np.ndarray:
         """
         Return the natural parameters in array form (identity function for this class).
@@ -635,7 +636,7 @@ class TruncatedNaturalNormal(TruncatedNormalMessage):
         eta2
             The second natural parameter.
         """
-        return np.array([eta1, eta2])
+        return xp.array([eta1, eta2])
 
     def natural_parameters(self, xp=np) -> np.ndarray:
         """

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -96,7 +96,7 @@ class TruncatedNormalMessage(AbstractMessage):
 
         self.mean, self.sigma, self.lower_limit, self.upper_limit = self.parameters
 
-    def cdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+    def cdf(self, x: Union[float, np.ndarray], xp=np) -> Union[float, np.ndarray]:
         """
         Compute the cumulative distribution function (CDF) of the truncated Gaussian distribution
         at a given value or array of values `x`.

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -141,8 +141,7 @@ class TruncatedNormalMessage(AbstractMessage):
         b = (self.upper_limit - self.mean) / self.sigma
         return truncnorm.ppf(x, a=a, b=b, loc=self.mean, scale=self.sigma)
 
-    @cached_property
-    def natural_parameters(self) -> np.ndarray:
+    def natural_parameters(self, xp=np) -> np.ndarray:
         """
         The pseudo-natural (canonical) parameters of a truncated Gaussian distribution.
 
@@ -159,7 +158,7 @@ class TruncatedNormalMessage(AbstractMessage):
         -------
         A NumPy array containing the pseudo-natural parameters [η₁, η₂].
         """
-        return self.calc_natural_parameters(self.mean, self.sigma)
+        return self.calc_natural_parameters(self.mean, self.sigma, xp=xp)
 
     @staticmethod
     def calc_natural_parameters(mu : Union[float, np.ndarray], sigma : Union[float, np.ndarray]) -> np.ndarray:
@@ -217,7 +216,7 @@ class TruncatedNormalMessage(AbstractMessage):
         return mu, sigma
 
     @staticmethod
-    def to_canonical_form(x : Union[float, np.ndarray]) -> np.ndarray:
+    def to_canonical_form(x : Union[float, np.ndarray], xp=np) -> np.ndarray:
         """
         Convert a scalar input `x` to its sufficient statistics for the Gaussian exponential family.
 
@@ -234,7 +233,7 @@ class TruncatedNormalMessage(AbstractMessage):
         -------
         The sufficient statistics [x, x²].
         """
-        return np.array([x, x**2])
+        return xp.array([x, x**2])
 
     @classmethod
     def invert_sufficient_statistics(cls, suff_stats: Tuple[float, float]) -> np.ndarray:
@@ -638,12 +637,11 @@ class TruncatedNaturalNormal(TruncatedNormalMessage):
         """
         return np.array([eta1, eta2])
 
-    @cached_property
-    def natural_parameters(self) -> np.ndarray:
+    def natural_parameters(self, xp=np) -> np.ndarray:
         """
         Return the natural parameters of this distribution.
         """
-        return self.calc_natural_parameters(*self.parameters, self.lower_limit, self.upper_limit)
+        return self.calc_natural_parameters(*self.parameters, self.lower_limit, self.upper_limit, xp=xp)
 
     @classmethod
     def invert_sufficient_statistics(

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -422,7 +422,7 @@ class TruncatedNormalMessage(AbstractMessage):
         x_standard = norm.ppf(truncated_cdf)
         return self.mean + self.sigma * x_standard
 
-    def log_prior_from_value(self, value: float) -> float:
+    def log_prior_from_value(self, value: float, xp=np) -> float:
         """
         Compute the log prior probability of a given physical value under this truncated Gaussian prior.
 
@@ -446,11 +446,11 @@ class TruncatedNormalMessage(AbstractMessage):
         Z = norm.cdf(b) - norm.cdf(a)
 
         z = (value -self.mean) / self.sigma
-        log_pdf = -0.5 * z ** 2 - np.log(self.sigma) - 0.5 * np.log(2 * np.pi)
-        log_trunc_pdf = log_pdf - np.log(Z)
+        log_pdf = -0.5 * z ** 2 - xp.log(self.sigma) - 0.5 * xp.log(2 * xp.pi)
+        log_trunc_pdf = log_pdf - xp.log(Z)
 
         in_bounds = (self.lower_limit <= value) & (value <= self.upper_limit)
-        return np.where(in_bounds, log_trunc_pdf, -np.inf)
+        return xp.where(in_bounds, log_trunc_pdf, -xp.inf)
 
     def __str__(self):
         """

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -25,8 +25,8 @@ def is_nan(value):
 
 
 class TruncatedNormalMessage(AbstractMessage):
-    @cached_property
-    def log_partition(self) -> float:
+
+    def log_partition(self, xp=np) -> float:
         """
         Compute the log-partition function (normalizer) of the truncated Gaussian.
 
@@ -46,7 +46,7 @@ class TruncatedNormalMessage(AbstractMessage):
         a = (self.lower_limit - self.mean) / self.sigma
         b = (self.upper_limit - self.mean) / self.sigma
         Z = norm.cdf(b) - norm.cdf(a)
-        return np.log(Z) if Z > 0 else -np.inf
+        return xp.log(Z) if Z > 0 else -xp.inf
 
     log_base_measure = -0.5 * np.log(2 * np.pi)
 

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -109,7 +109,7 @@ class Analysis(ABC):
 
             compute_latent_for_model = functools.partial(self.compute_latent_variables, model=samples.model)
 
-            if self.use_jax:
+            if self._use_jax:
                 import jax
                 start = time.time()
                 logger.info("JAX: Applying vmap and jit to likelihood function for latent variables -- may take a few seconds.")
@@ -130,7 +130,7 @@ class Analysis(ABC):
                 # batched JAX call on this chunk
                 latent_values_batch = batched_compute_latent(batch)
 
-                if self.use_jax:
+                if self._use_jax:
                     import jax.numpy as jnp
                     latent_values_batch = jnp.stack(latent_values_batch, axis=-1)  # (batch, n_latents)
                     mask = jnp.all(jnp.isfinite(latent_values_batch), axis=0)

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -36,7 +36,7 @@ class Analysis(ABC):
         self, use_jax : bool = False, **kwargs
     ):
 
-        self.use_jax = use_jax
+        self._use_jax = use_jax
         self.kwargs = kwargs
 
     def __getattr__(self, item: str):
@@ -63,7 +63,7 @@ class Analysis(ABC):
 
     @property
     def _xp(self):
-        if self.use_jax:
+        if self._use_jax:
             import jax.numpy as jnp
             return jnp
         return np

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -315,3 +315,41 @@ class Analysis(ABC):
 
     def perform_quick_update(self, paths, instance):
         raise NotImplementedError
+
+    def print_vram_use(self, model, batch_size : int) -> str:
+        """
+        Print JAX VRAM use for a given batch size.
+
+        Parameters
+        ----------
+        batch_size
+            The batch size to profile, which is the number of model evaluations JAX will perform simultaneously.
+        """
+        import jax
+        import jax.numpy as jnp
+
+        from autofit.non_linear.fitness import Fitness
+
+        fitness = Fitness(
+            model=model,
+            analysis=self,
+            fom_is_log_likelihood=True,
+            use_jax_vmap=True,
+            batch_size=batch_size,
+        )
+
+        parameters = np.zeros((batch_size, model.total_free_parameters))
+
+        for i in range(batch_size):
+            parameters[i, :] = model.physical_values_from_prior_medians
+
+        parameters = jnp.array(parameters)
+
+        batched_call = jax.jit(jax.vmap(fitness.call))
+        lowered = batched_call.lower(parameters)
+        compiled = lowered.compile()
+        memory_analysis = compiled.memory_analysis()
+
+        print(
+            f"VRAM USE = {(memory_analysis.output_size_in_bytes + memory_analysis.temp_size_in_bytes) / 1024 ** 3:.3f} GB"
+        )

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -350,6 +350,17 @@ class Analysis(ABC):
         compiled = lowered.compile()
         memory_analysis = compiled.memory_analysis()
 
-        print(
-            f"VRAM USE = {(memory_analysis.output_size_in_bytes + memory_analysis.temp_size_in_bytes) / 1024 ** 3:.3f} GB"
+        vram_bytes = (
+                memory_analysis.output_size_in_bytes
+                + memory_analysis.temp_size_in_bytes
         )
+
+        if vram_bytes == 0:
+            print(
+                "VRAM USE = 0.000 GB "
+                "(this likely means JAX is running in CPU-only mode)"
+            )
+        else:
+            print(
+                f"VRAM USE = {vram_bytes / 1024 ** 3:.3f} GB"
+            )

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -325,6 +325,10 @@ class Analysis(ABC):
         batch_size
             The batch size to profile, which is the number of model evaluations JAX will perform simultaneously.
         """
+        if not self._use_jax:
+            print("use_jax=False for this analysis, therefore does not use GPU and VRAM use cannot be profiled.")
+            return
+
         import jax
         import jax.numpy as jnp
 

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -157,7 +157,7 @@ class Fitness:
         The figure of merit returned to the non-linear search, which is either the log likelihood or log posterior.
         """
         # Get instance from model
-        instance = self.model.instance_from_vector(vector=parameters)
+        instance = self.model.instance_from_vector(vector=parameters, xp=self._xp)
 
         if self._xp.__name__.startswith("jax"):
 
@@ -227,7 +227,7 @@ class Fitness:
         if self.fom_is_log_likelihood:
             log_likelihood = figure_of_merit
         else:
-            log_prior_list = self._xp.array(self.model.log_prior_list_from_vector(vector=parameters))
+            log_prior_list = self._xp.array(self.model.log_prior_list_from_vector(vector=parameters, xp=self._xp))
             log_likelihood = figure_of_merit - self._xp.sum(log_prior_list)
 
         self.manage_quick_update(parameters=parameters, log_likelihood=log_likelihood)
@@ -237,8 +237,8 @@ class Fitness:
 
         if self.store_history:
 
-            self.parameters_history_list.append(parameters)
-            self.log_likelihood_history_list.append(log_likelihood)
+            self.parameters_history_list.append(np.array(parameters))
+            self.log_likelihood_history_list.append(np.array(log_likelihood))
 
         return figure_of_merit
 

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -134,7 +134,7 @@ class Fitness:
 
     @property
     def _xp(self):
-        if self.analysis.use_jax:
+        if self.analysis._use_jax:
             import jax.numpy as jnp
             return jnp
         return np

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -179,7 +179,7 @@ class Fitness:
             figure_of_merit = log_likelihood
         else:
             # Ensure prior list is compatible with JAX (must return a JAX array, not list)
-            log_prior_array = self._xp.array(self.model.log_prior_list_from_vector(vector=parameters))
+            log_prior_array = self._xp.array(self.model.log_prior_list_from_vector(vector=parameters, xp=self._xp))
             figure_of_merit = log_likelihood + self._xp.sum(log_prior_array)
 
         # Convert to chi-squared scale if requested

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -173,6 +173,7 @@ class Fitness:
 
         # Penalize NaNs in the log-likelihood
         log_likelihood = self._xp.where(self._xp.isnan(log_likelihood), self.resample_figure_of_merit, log_likelihood)
+        log_likelihood = self._xp.where(self._xp.isinf(log_likelihood), self.resample_figure_of_merit, log_likelihood)
 
         # Determine final figure of merit
         if self.fom_is_log_likelihood:
@@ -222,18 +223,15 @@ class Fitness:
         figure_of_merit = self._call(parameters)
 
         if self.convert_to_chi_squared:
-            figure_of_merit *= -0.5
-
-        if self.fom_is_log_likelihood:
-            log_likelihood = figure_of_merit
+            log_likelihood = -0.5 * figure_of_merit
         else:
+            log_likelihood = figure_of_merit
+
+        if not self.fom_is_log_likelihood:
             log_prior_list = self._xp.array(self.model.log_prior_list_from_vector(vector=parameters, xp=self._xp))
-            log_likelihood = figure_of_merit - self._xp.sum(log_prior_list)
+            log_likelihood -= self._xp.sum(log_prior_list)
 
         self.manage_quick_update(parameters=parameters, log_likelihood=log_likelihood)
-
-        if self.convert_to_chi_squared:
-            log_likelihood *= -2.0
 
         if self.store_history:
 

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -317,7 +317,7 @@ class Fitness:
 
             logger.info("Performing quick update of maximum log likelihood fit image and model.results")
 
-            instance = self.model.instance_from_vector(vector=self.quick_update_max_lh_parameters)
+            instance = self.model.instance_from_vector(vector=self.quick_update_max_lh_parameters, xp=self._xp)
 
             try:
                 self.analysis.perform_quick_update(self.paths, instance)

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -228,8 +228,8 @@ class Fitness:
             log_likelihood = figure_of_merit
 
         if not self.fom_is_log_likelihood:
-            log_prior_list = self._xp.array(self.model.log_prior_list_from_vector(vector=parameters, xp=self._xp))
-            log_likelihood -= self._xp.sum(log_prior_list)
+            log_prior_list = np.array(self.model.log_prior_list_from_vector(vector=parameters, xp=np))
+            log_likelihood -= np.sum(log_prior_list)
 
         self.manage_quick_update(parameters=parameters, log_likelihood=log_likelihood)
 

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -116,16 +116,6 @@ class Fitness:
         self.parameters_history_list = []
         self.log_likelihood_history_list = []
 
-        if analysis._use_jax:
-
-            import jax
-
-            if jax.default_backend() == "cpu":
-
-                logger.info("JAX using CPU backend, vmap disabled for faster performance.")
-
-                use_jax_vmap = False
-
         self.use_jax_vmap = use_jax_vmap
 
         self._call = self.call

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -108,7 +108,8 @@ class Fitness:
         self.model = model
         self.paths = paths
         self.fom_is_log_likelihood = fom_is_log_likelihood
-        self.resample_figure_of_merit = resample_figure_of_merit or -xp.inf
+
+        self.resample_figure_of_merit = resample_figure_of_merit or -self._xp.inf
         self.convert_to_chi_squared = convert_to_chi_squared
         self.store_history = store_history
 
@@ -135,7 +136,7 @@ class Fitness:
         self.batch_size = batch_size
         self.iterations_per_quick_update = iterations_per_quick_update
         self.quick_update_max_lh_parameters = None
-        self.quick_update_max_lh = -xp.inf
+        self.quick_update_max_lh = -self._xp.inf
         self.quick_update_count = 0
 
         if self.paths is not None:

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -44,7 +44,6 @@ class Fitness:
         use_jax_vmap : bool = False,
         batch_size : Optional[int] = None,
         iterations_per_quick_update: Optional[int] = None,
-        xp=np,
     ):
         """
         Interfaces with any non-linear search to fit the model to the data and return a log likelihood via
@@ -122,6 +121,16 @@ class Fitness:
 
         if self.use_jax_vmap:
             self._call = self._vmap
+
+        if analysis._use_jax:
+
+            import jax
+
+            if jax.default_backend() == "cpu":
+
+                logger.info("JAX using CPU backend, batch size set to 1 which will improve performance.")
+
+                batch_size = 1
 
         self.batch_size = batch_size
         self.iterations_per_quick_update = iterations_per_quick_update

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -134,10 +134,7 @@ class Fitness:
 
     @property
     def _xp(self):
-        if self.analysis._use_jax:
-            import jax.numpy as jnp
-            return jnp
-        return np
+        return self.analysis._xp
 
     def call(self, parameters):
         """

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -116,22 +116,22 @@ class Fitness:
         self.parameters_history_list = []
         self.log_likelihood_history_list = []
 
-        self.use_jax_vmap = use_jax_vmap
-
-        self._call = self.call
-
-        if self.use_jax_vmap:
-            self._call = self._vmap
-
         if analysis._use_jax:
 
             import jax
 
             if jax.default_backend() == "cpu":
 
-                logger.info("JAX using CPU backend, batch size set to 1 which will improve performance.")
+                logger.info("JAX using CPU backend, vmap disabled for faster performance.")
 
-                batch_size = 1
+                use_jax_vmap = False
+
+        self.use_jax_vmap = use_jax_vmap
+
+        self._call = self.call
+
+        if self.use_jax_vmap:
+            self._call = self._vmap
 
         self.batch_size = batch_size
         self.iterations_per_quick_update = iterations_per_quick_update

--- a/autofit/non_linear/grid/grid_search/__init__.py
+++ b/autofit/non_linear/grid/grid_search/__init__.py
@@ -219,8 +219,6 @@ class GridSearch:
         result: GridSearchResult
             The result of the grid search
         """
-        self.logger.info("...in parallel")
-
         grid_priors = model.sort_priors_alphabetically(set(grid_priors))
         lists = self.make_lists(grid_priors)
 

--- a/autofit/non_linear/grid/grid_search/job.py
+++ b/autofit/non_linear/grid/grid_search/job.py
@@ -51,6 +51,7 @@ class Job(AbstractJob):
         self.info = info
 
     def perform(self):
+
         result = self.search_instance.fit(
             model=self.model,
             analysis=self.analysis,

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -145,7 +145,7 @@ class AbstractBFGS(AbstractMLE):
                 config_dict_options["maxiter"] = iterations
 
                 search_internal = optimize.minimize(
-                    fun=fitness.call_wrap,
+                    fun=fitness._jit,
                     x0=x0,
                     method=self.method,
                     options=config_dict_options,

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -227,6 +227,9 @@ class AbstractBFGS(AbstractMLE):
 
         weight_list = len(log_likelihood_list) * [1.0]
 
+        print(log_likelihood_list)
+        print(parameter_lists)
+
         sample_list = Sample.from_lists(
             model=model,
             parameter_lists=parameter_lists,

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -136,21 +136,32 @@ class AbstractBFGS(AbstractMLE):
         maxiter = self.config_dict_options.get("maxiter", 1e8)
 
         while total_iterations < maxiter:
-            iterations_remaining = maxiter - total_iterations
 
+            iterations_remaining = maxiter - total_iterations
             iterations = min(self.iterations_per_full_update, iterations_remaining)
 
             if iterations > 0:
                 config_dict_options = self.config_dict_options
                 config_dict_options["maxiter"] = iterations
 
-                search_internal = optimize.minimize(
-                    fun=fitness._jit,
-                    x0=x0,
-                    method=self.method,
-                    options=config_dict_options,
-                    **self.config_dict_search
-                )
+                if analysis._use_jax:
+
+                    search_internal = optimize.minimize(
+                        fun=fitness._jit,
+                        x0=x0,
+                        method=self.method,
+                        options=config_dict_options,
+                        **self.config_dict_search
+                    )
+                else:
+
+                    search_internal = optimize.minimize(
+                        fun=fitness.__call__,
+                        x0=x0,
+                        method=self.method,
+                        options=config_dict_options,
+                        **self.config_dict_search
+                    )
 
                 total_iterations += search_internal.nit
 

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -92,7 +92,6 @@ class AbstractBFGS(AbstractMLE):
             fom_is_log_likelihood=False,
             resample_figure_of_merit=-np.inf,
             convert_to_chi_squared=True,
-            use_jax_vmap=True,
             store_history=self.should_plot_start_point
         )
 
@@ -146,7 +145,7 @@ class AbstractBFGS(AbstractMLE):
                 config_dict_options["maxiter"] = iterations
 
                 search_internal = optimize.minimize(
-                    fun=fitness.call_wrap,
+                    fun=fitness._jit,
                     x0=x0,
                     method=self.method,
                     options=config_dict_options,
@@ -209,7 +208,6 @@ class AbstractBFGS(AbstractMLE):
         x0 = search_internal.x
         total_iterations = search_internal.nit
 
-
         if self.should_plot_start_point:
 
             parameter_lists = search_internal.parameters_history_list
@@ -227,8 +225,9 @@ class AbstractBFGS(AbstractMLE):
 
         weight_list = len(log_likelihood_list) * [1.0]
 
-        print(log_likelihood_list)
         print(parameter_lists)
+        print(log_likelihood_list)
+        print(log_prior_list)
 
         sample_list = Sample.from_lists(
             model=model,

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -92,6 +92,7 @@ class AbstractBFGS(AbstractMLE):
             fom_is_log_likelihood=False,
             resample_figure_of_merit=-np.inf,
             convert_to_chi_squared=True,
+            use_jax_vmap=True,
             store_history=self.should_plot_start_point
         )
 
@@ -145,7 +146,7 @@ class AbstractBFGS(AbstractMLE):
                 config_dict_options["maxiter"] = iterations
 
                 search_internal = optimize.minimize(
-                    fun=fitness._jit,
+                    fun=fitness.call_wrap,
                     x0=x0,
                     method=self.method,
                     options=config_dict_options,

--- a/autofit/non_linear/search/mle/bfgs/search.py
+++ b/autofit/non_linear/search/mle/bfgs/search.py
@@ -225,10 +225,6 @@ class AbstractBFGS(AbstractMLE):
 
         weight_list = len(log_likelihood_list) * [1.0]
 
-        print(parameter_lists)
-        print(log_likelihood_list)
-        print(log_prior_list)
-
         sample_list = Sample.from_lists(
             model=model,
             parameter_lists=parameter_lists,

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -146,7 +146,7 @@ class AbstractDynesty(AbstractNest, ABC):
                         "parallel"
                     ].get("force_x1_cpu")
                     or self.kwargs.get("force_x1_cpu")
-                    or analysis.use_jax
+                    or analysis._use_jax
                 ):
                     raise RuntimeError
 

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -127,7 +127,7 @@ class Nautilus(abstract_nest.AbstractNest):
         if (
             self.config_dict.get("force_x1_cpu")
             or self.kwargs.get("force_x1_cpu")
-            or analysis.use_jax
+            or analysis._use_jax
         ):
 
             fitness = Fitness(

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -137,7 +137,7 @@ class Nautilus(abstract_nest.AbstractNest):
                 fom_is_log_likelihood=True,
                 resample_figure_of_merit=-1.0e99,
                 iterations_per_quick_update=self.iterations_per_quick_update,
-                use_jax_vmap=True,
+                use_jax_vmap=False,
                 batch_size=self.config_dict_search["n_batch"],
             )
 
@@ -225,13 +225,18 @@ class Nautilus(abstract_nest.AbstractNest):
         except KeyError:
             pass
 
+        if fitness.use_jax_vmap:
+            vectorized = True
+        else:
+            vectorized = False
+
         search_internal = self.sampler_cls(
             prior=PriorVectorized(model=model),
             likelihood=fitness.call_wrap,
             n_dim=model.prior_count,
             filepath=self.checkpoint_file,
             pool=None,
-            vectorized=True,
+            vectorized=vectorized,
             **config_dict,
         )
 

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -225,10 +225,7 @@ class Nautilus(abstract_nest.AbstractNest):
         except KeyError:
             pass
 
-        if fitness.use_jax_vmap:
-            vectorized = True
-        else:
-            vectorized = False
+        vectorized = fitness.use_jax_vmap
 
         search_internal = self.sampler_cls(
             prior=PriorVectorized(model=model),

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -486,6 +486,10 @@ class Nautilus(abstract_nest.AbstractNest):
         )
 
     @property
+    def batch_size(self):
+        return self.config_dict_search.get("n_batch")
+
+    @property
     def config_dict(self):
         return conf.instance["non_linear"]["nest"][self.__class__.__name__]
 

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -41,6 +41,7 @@ class Nautilus(abstract_nest.AbstractNest):
         iterations_per_full_update: int = None,
         number_of_cores: int = None,
         session: Optional[sa.orm.Session] = None,
+        use_jax_vmap : bool = True,
         **kwargs
     ):
         """
@@ -90,6 +91,8 @@ class Nautilus(abstract_nest.AbstractNest):
 
         self.logger.debug("Creating Nautilus Search")
 
+        self.use_jax_vmap = use_jax_vmap
+
     def _fit(self, model: AbstractPriorModel, analysis):
         """
         Fit a model using the search and the Analysis class which contains the data and returns the log likelihood from
@@ -137,7 +140,7 @@ class Nautilus(abstract_nest.AbstractNest):
                 fom_is_log_likelihood=True,
                 resample_figure_of_merit=-1.0e99,
                 iterations_per_quick_update=self.iterations_per_quick_update,
-                use_jax_vmap=False,
+                use_jax_vmap=self.use_jax_vmap,
                 batch_size=self.config_dict_search["n_batch"],
             )
 

--- a/autofit/non_linear/settings.py
+++ b/autofit/non_linear/settings.py
@@ -11,6 +11,7 @@ class SettingsSearch:
         number_of_cores: Optional[int] = 1,
         session: Optional[sa.orm.Session] = None,
         info: Optional[dict] = None,
+        use_jax_vmap: bool = True,
     ):
         """
         Stores all the input settings that are used in search's and their `fit functions.
@@ -40,6 +41,7 @@ class SettingsSearch:
         self.unique_tag = unique_tag
         self.number_of_cores = number_of_cores
         self.session = session
+        self.use_jax_vmap = use_jax_vmap
 
         self.info = info
 
@@ -50,6 +52,7 @@ class SettingsSearch:
             "unique_tag": self.unique_tag,
             "number_of_cores": self.number_of_cores,
             "session": self.session,
+            "use_jax_vmap": self.use_jax_vmap,
         }
 
     @property

--- a/test_autofit/aggregator/summary_files/test_aggregate_images.py
+++ b/test_autofit/aggregator/summary_files/test_aggregate_images.py
@@ -6,8 +6,27 @@ from pathlib import Path
 from PIL import Image
 
 from autofit.aggregator import Aggregator
-from autofit.aggregator.summary.aggregate_images import AggregateImages, SubplotFit
+from autofit.aggregator.summary.aggregate_images import AggregateImages
 
+class SubplotFit(Enum):
+    """
+    The subplots that can be extracted from the subplot_fit image.
+
+    The values correspond to the position of the subplot in the 4x3 grid.
+    """
+
+    Data = (0, 0)
+    DataSourceScaled = (1, 0)
+    SignalToNoiseMap = (2, 0)
+    ModelData = (3, 0)
+    LensLightModelData = (0, 1)
+    LensLightSubtractedImage = (1, 1)
+    SourceModelData = (2, 1)
+    SourcePlaneZoomed = (3, 1)
+    NormalizedResidualMap = (0, 2)
+    NormalizedResidualMapOneSigma = (1, 2)
+    ChiSquaredMap = (2, 2)
+    SourcePlaneNoZoom = (3, 2)
 
 @pytest.fixture
 def aggregate(aggregator):
@@ -167,7 +186,7 @@ def test_custom_subplot_fit(aggregate):
             SubplotFit.Data,
         ]
     )
-    assert result.size == (61, 120)
+    assert result.size == (244, 362)
 
 
 def test_bad_aggregator():

--- a/test_autofit/graphical/global/test_hierarchical.py
+++ b/test_autofit/graphical/global/test_hierarchical.py
@@ -55,8 +55,7 @@ model                                                                           
 2 - 3
     one                                                                         UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
 factor
-    include_prior_factors                                                       True
-    use_jax                                                                     False"""
+    include_prior_factors                                                       True"""
     )
 
 

--- a/test_autofit/graphical/global/test_hierarchical.py
+++ b/test_autofit/graphical/global/test_hierarchical.py
@@ -53,9 +53,7 @@ model                                                                           
 1
     drawn_prior                                                                 UniformPrior [1], lower_limit = 0.0, upper_limit = 1.0
 2 - 3
-    one                                                                         UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0
-factor
-    include_prior_factors                                                       True"""
+    one                                                                         UniformPrior [0], lower_limit = 0.0, upper_limit = 1.0"""
     )
 
 

--- a/test_autofit/graphical/hierarchical/test_optimise.py
+++ b/test_autofit/graphical/hierarchical/test_optimise.py
@@ -11,13 +11,6 @@ def make_factor(hierarchical_factor):
 def test_optimise(factor):
     search = af.DynestyStatic(maxcall=100, dynamic_delta=False, delta=0.1,)
 
-    print(type(factor.analysis))
-    print(type(factor.analysis))
-    print(type(factor.analysis))
-    print(type(factor.analysis))
-    print(type(factor.analysis))
-
-
     _, status = search.optimise(
         factor.mean_field_approximation().factor_approximation(factor)
     )

--- a/test_autofit/mapper/test_model_mapping_expanded.py
+++ b/test_autofit/mapper/test_model_mapping_expanded.py
@@ -1,0 +1,631 @@
+"""
+Expanded tests for the model mapping API, covering gaps identified in:
+- Collection composition and instance creation
+- Shared (linked) priors across model types
+- Direct use of instance_for_arguments with argument dicts
+- Model tree navigation (object_for_path, path_for_prior, name_for_prior)
+- Edge cases (empty models, deeply nested models, single-parameter models)
+- Model subsetting (with_paths, without_paths)
+- Freezing behavior
+- Assertion checking
+- from_instance round-trips
+- mapper_from_prior_arguments and mapper_from_partial_prior_arguments
+"""
+import copy
+
+import numpy as np
+import pytest
+
+import autofit as af
+from autofit import exc
+from autofit.mapper.prior.abstract import Prior
+
+
+# ---------------------------------------------------------------------------
+# Collection: composition, nesting, instance creation, iteration
+# ---------------------------------------------------------------------------
+class TestCollectionComposition:
+    def test_collection_from_dict(self):
+        model = af.Collection(
+            one=af.Model(af.m.MockClassx2),
+            two=af.Model(af.m.MockClassx2),
+        )
+        assert model.prior_count == 4
+
+    def test_collection_from_list(self):
+        model = af.Collection([af.m.MockClassx2, af.m.MockClassx2])
+        assert model.prior_count == 4
+
+    def test_collection_from_generator(self):
+        model = af.Collection(af.Model(af.m.MockClassx2) for _ in range(3))
+        assert model.prior_count == 6
+
+    def test_nested_collection(self):
+        inner = af.Collection(a=af.m.MockClassx2)
+        outer = af.Collection(inner=inner, extra=af.m.MockClassx2)
+        assert outer.prior_count == 4
+
+    def test_deeply_nested_collection(self):
+        model = af.Collection(
+            level1=af.Collection(
+                level2=af.Collection(
+                    leaf=af.m.MockClassx2,
+                )
+            )
+        )
+        assert model.prior_count == 2
+
+    def test_collection_instance_attribute_access(self):
+        model = af.Collection(gaussian=af.m.MockClassx2, exp=af.m.MockClassx2)
+        instance = model.instance_from_vector([1.0, 2.0, 3.0, 4.0])
+        assert instance.gaussian.one == 1.0
+        assert instance.gaussian.two == 2.0
+        assert instance.exp.one == 3.0
+        assert instance.exp.two == 4.0
+
+    def test_collection_instance_index_access(self):
+        model = af.Collection([af.m.MockClassx2, af.m.MockClassx2])
+        instance = model.instance_from_vector([1.0, 2.0, 3.0, 4.0])
+        assert instance[0].one == 1.0
+        assert instance[1].one == 3.0
+
+    def test_collection_len(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        assert len(model) == 2
+
+    def test_collection_contains(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        assert "a" in model
+        assert "c" not in model
+
+    def test_collection_items(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        keys = [k for k, v in model.items()]
+        assert "a" in keys
+        assert "b" in keys
+
+    def test_collection_getitem_string(self):
+        model = af.Collection(a=af.m.MockClassx2)
+        assert isinstance(model["a"], af.Model)
+
+    def test_collection_append(self):
+        model = af.Collection()
+        model.append(af.m.MockClassx2)
+        model.append(af.m.MockClassx2)
+        assert model.prior_count == 4
+
+    def test_collection_mixed_model_and_fixed(self):
+        """Collection with one free model and one fixed instance."""
+        model = af.Collection(
+            free=af.Model(af.m.MockClassx2),
+        )
+        assert model.prior_count == 2
+
+    def test_empty_collection(self):
+        model = af.Collection()
+        assert model.prior_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Shared (linked) priors
+# ---------------------------------------------------------------------------
+class TestSharedPriors:
+    def test_link_within_model(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = model.two
+        assert model.prior_count == 1
+        instance = model.instance_from_vector([5.0])
+        assert instance.one == instance.two == 5.0
+
+    def test_link_across_collection_children(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        model.a.one = model.b.one  # Link a.one to b.one
+        assert model.prior_count == 3  # 4 - 1 shared
+
+    def test_linked_priors_same_value(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        model.a.one = model.b.one
+        instance = model.instance_from_vector([10.0, 20.0, 30.0])
+        assert instance.a.one == instance.b.one
+
+    def test_link_reduces_unique_prior_count(self):
+        model = af.Model(af.m.MockClassx2)
+        original_count = len(model.unique_prior_tuples)
+        model.one = model.two
+        assert len(model.unique_prior_tuples) == original_count - 1
+
+    def test_linked_prior_identity(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = model.two
+        assert model.one is model.two
+
+
+# ---------------------------------------------------------------------------
+# instance_for_arguments (direct argument dict usage)
+# ---------------------------------------------------------------------------
+class TestInstanceForArguments:
+    def test_model_instance_for_arguments(self):
+        model = af.Model(af.m.MockClassx2)
+        args = {model.one: 10.0, model.two: 20.0}
+        instance = model.instance_for_arguments(args)
+        assert instance.one == 10.0
+        assert instance.two == 20.0
+
+    def test_collection_instance_for_arguments(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        args = {}
+        for name, prior in model.prior_tuples_ordered_by_id:
+            args[prior] = 1.0
+        instance = model.instance_for_arguments(args)
+        assert instance.a.one == 1.0
+        assert instance.b.two == 1.0
+
+    def test_shared_prior_in_arguments(self):
+        """When priors are linked, only one entry is needed in the arguments dict."""
+        model = af.Model(af.m.MockClassx2)
+        model.one = model.two
+        shared_prior = model.one
+        args = {shared_prior: 42.0}
+        instance = model.instance_for_arguments(args)
+        assert instance.one == 42.0
+        assert instance.two == 42.0
+
+    def test_missing_prior_raises(self):
+        model = af.Model(af.m.MockClassx2)
+        args = {model.one: 10.0}  # missing model.two
+        with pytest.raises(KeyError):
+            model.instance_for_arguments(args)
+
+
+# ---------------------------------------------------------------------------
+# Vector and unit vector mapping
+# ---------------------------------------------------------------------------
+class TestVectorMapping:
+    def test_instance_from_vector_basic(self):
+        model = af.Model(af.m.MockClassx2)
+        instance = model.instance_from_vector([3.0, 4.0])
+        assert instance.one == 3.0
+        assert instance.two == 4.0
+
+    def test_vector_length_mismatch_raises(self):
+        model = af.Model(af.m.MockClassx2)
+        with pytest.raises(AssertionError):
+            model.instance_from_vector([1.0])
+
+    def test_unit_vector_length_mismatch_raises(self):
+        model = af.Model(af.m.MockClassx2)
+        with pytest.raises(AssertionError):
+            model.instance_from_unit_vector([0.5])
+
+    def test_vector_from_unit_vector(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = af.UniformPrior(lower_limit=0.0, upper_limit=10.0)
+        model.two = af.UniformPrior(lower_limit=0.0, upper_limit=10.0)
+        physical = model.vector_from_unit_vector([0.0, 1.0])
+        assert physical[0] == pytest.approx(0.0, abs=1e-6)
+        assert physical[1] == pytest.approx(10.0, abs=1e-6)
+
+    def test_instance_from_prior_medians(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = af.UniformPrior(lower_limit=0.0, upper_limit=100.0)
+        model.two = af.UniformPrior(lower_limit=0.0, upper_limit=100.0)
+        instance = model.instance_from_prior_medians()
+        assert instance.one == pytest.approx(50.0)
+        assert instance.two == pytest.approx(50.0)
+
+    def test_random_instance(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = af.UniformPrior(lower_limit=0.0, upper_limit=1.0)
+        model.two = af.UniformPrior(lower_limit=0.0, upper_limit=1.0)
+        instance = model.random_instance()
+        assert 0.0 <= instance.one <= 1.0
+        assert 0.0 <= instance.two <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Model tree navigation
+# ---------------------------------------------------------------------------
+class TestModelTreeNavigation:
+    def test_object_for_path_child_model(self):
+        model = af.Collection(g=af.Model(af.m.MockClassx2))
+        child = model.object_for_path(("g",))
+        assert isinstance(child, af.Model)
+
+    def test_object_for_path_prior(self):
+        model = af.Collection(g=af.Model(af.m.MockClassx2))
+        prior = model.object_for_path(("g", "one"))
+        assert isinstance(prior, Prior)
+
+    def test_paths_matches_prior_count(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        assert len(model.paths) == model.prior_count
+
+    def test_path_for_prior(self):
+        model = af.Collection(g=af.Model(af.m.MockClassx2))
+        prior = model.g.one
+        path = model.path_for_prior(prior)
+        assert path == ("g", "one")
+
+    def test_name_for_prior(self):
+        model = af.Collection(g=af.Model(af.m.MockClassx2))
+        prior = model.g.one
+        name = model.name_for_prior(prior)
+        assert name == "g_one"
+
+    def test_path_instance_tuples_for_class(self):
+        model = af.Collection(g=af.Model(af.m.MockClassx2))
+        tuples = model.path_instance_tuples_for_class(Prior)
+        paths = [t[0] for t in tuples]
+        assert ("g", "one") in paths
+        assert ("g", "two") in paths
+
+    def test_deeply_nested_path(self):
+        inner_model = af.Model(af.m.MockClassx2)
+        inner_collection = af.Collection(leaf=inner_model)
+        outer = af.Collection(branch=inner_collection)
+
+        prior = outer.branch.leaf.one
+        path = outer.path_for_prior(prior)
+        assert path == ("branch", "leaf", "one")
+
+    def test_direct_vs_recursive_prior_tuples(self):
+        model = af.Collection(a=af.m.MockClassx2)
+        assert len(model.direct_prior_tuples) == 0  # Collection has no direct priors
+        assert len(model.prior_tuples) == 2  # But has 2 recursive priors
+
+    def test_direct_prior_model_tuples(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        assert len(model.direct_prior_model_tuples) == 2
+
+
+# ---------------------------------------------------------------------------
+# instance_from_path_arguments and instance_from_prior_name_arguments
+# ---------------------------------------------------------------------------
+class TestPathAndNameArguments:
+    def test_instance_from_path_arguments(self):
+        model = af.Collection(g=af.m.MockClassx2)
+        instance = model.instance_from_path_arguments(
+            {("g", "one"): 10.0, ("g", "two"): 20.0}
+        )
+        assert instance.g.one == 10.0
+        assert instance.g.two == 20.0
+
+    def test_instance_from_prior_name_arguments(self):
+        model = af.Collection(g=af.m.MockClassx2)
+        instance = model.instance_from_prior_name_arguments(
+            {"g_one": 10.0, "g_two": 20.0}
+        )
+        assert instance.g.one == 10.0
+        assert instance.g.two == 20.0
+
+
+# ---------------------------------------------------------------------------
+# Assertions
+# ---------------------------------------------------------------------------
+class TestAssertions:
+    def test_assertion_passes(self):
+        model = af.Model(af.m.MockClassx2)
+        model.add_assertion(model.one > model.two)
+        # one=10 > two=5 should pass
+        instance = model.instance_from_vector([10.0, 5.0])
+        assert instance.one == 10.0
+
+    def test_assertion_fails(self):
+        model = af.Model(af.m.MockClassx2)
+        model.add_assertion(model.one > model.two)
+        with pytest.raises(exc.FitException):
+            model.instance_from_vector([1.0, 10.0])
+
+    def test_ignore_assertions(self):
+        model = af.Model(af.m.MockClassx2)
+        model.add_assertion(model.one > model.two)
+        # Should not raise even though assertion fails
+        instance = model.instance_from_vector([1.0, 10.0], ignore_assertions=True)
+        assert instance.one == 1.0
+
+    def test_multiple_assertions(self):
+        model = af.Model(af.m.MockClassx4)
+        model.add_assertion(model.one > model.two)
+        model.add_assertion(model.three > model.four)
+        # Both pass
+        instance = model.instance_from_vector([10.0, 5.0, 10.0, 5.0])
+        assert instance.one == 10.0
+        # First fails
+        with pytest.raises(exc.FitException):
+            model.instance_from_vector([1.0, 10.0, 10.0, 5.0])
+
+    def test_true_assertion_ignored(self):
+        """Adding True as an assertion should be a no-op."""
+        model = af.Model(af.m.MockClassx2)
+        model.add_assertion(True)
+        assert len(model.assertions) == 0
+
+
+# ---------------------------------------------------------------------------
+# Model subsetting (with_paths, without_paths)
+# ---------------------------------------------------------------------------
+class TestModelSubsetting:
+    def test_with_paths_single_child(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        subset = model.with_paths([("a",)])
+        assert subset.prior_count == 2
+
+    def test_without_paths_single_child(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        subset = model.without_paths([("a",)])
+        assert subset.prior_count == 2
+
+    def test_with_paths_specific_prior(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        subset = model.with_paths([("a", "one")])
+        assert subset.prior_count == 1
+
+    def test_with_prefix(self):
+        model = af.Collection(ab_one=af.m.MockClassx2, cd_two=af.m.MockClassx2)
+        subset = model.with_prefix("ab")
+        assert subset.prior_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Freezing behavior
+# ---------------------------------------------------------------------------
+class TestFreezing:
+    def test_freeze_prevents_modification(self):
+        model = af.Model(af.m.MockClassx2)
+        model.freeze()
+        with pytest.raises(AssertionError):
+            model.one = af.UniformPrior(lower_limit=0.0, upper_limit=1.0)
+
+    def test_unfreeze_allows_modification(self):
+        model = af.Model(af.m.MockClassx2)
+        model.freeze()
+        model.unfreeze()
+        model.one = af.UniformPrior(lower_limit=0.0, upper_limit=1.0)
+        assert isinstance(model.one, af.UniformPrior)
+
+    def test_frozen_model_still_creates_instances(self):
+        model = af.Model(af.m.MockClassx2)
+        model.freeze()
+        instance = model.instance_from_vector([1.0, 2.0])
+        assert instance.one == 1.0
+
+    def test_freeze_propagates_to_children(self):
+        model = af.Collection(a=af.m.MockClassx2)
+        model.freeze()
+        with pytest.raises(AssertionError):
+            model.a.one = 1.0
+
+    def test_cached_results_consistent(self):
+        model = af.Model(af.m.MockClassx2)
+        model.freeze()
+        result1 = model.prior_tuples_ordered_by_id
+        result2 = model.prior_tuples_ordered_by_id
+        assert result1 == result2
+
+
+# ---------------------------------------------------------------------------
+# mapper_from_prior_arguments and related
+# ---------------------------------------------------------------------------
+class TestMapperFromPriorArguments:
+    def test_replace_all_priors(self):
+        model = af.Model(af.m.MockClassx2)
+        new_one = af.GaussianPrior(mean=0.0, sigma=1.0)
+        new_two = af.GaussianPrior(mean=5.0, sigma=2.0)
+        new_model = model.mapper_from_prior_arguments(
+            {model.one: new_one, model.two: new_two}
+        )
+        assert new_model.prior_count == 2
+        assert isinstance(new_model.one, af.GaussianPrior)
+
+    def test_partial_replacement(self):
+        model = af.Model(af.m.MockClassx2)
+        new_one = af.GaussianPrior(mean=0.0, sigma=1.0)
+        new_model = model.mapper_from_partial_prior_arguments(
+            {model.one: new_one}
+        )
+        assert new_model.prior_count == 2
+        assert isinstance(new_model.one, af.GaussianPrior)
+        # two should retain its original prior type
+        assert new_model.two is not None
+
+    def test_fix_via_mapper_from_prior_arguments(self):
+        """Replacing a prior with a float effectively fixes that parameter."""
+        model = af.Model(af.m.MockClassx2)
+        new_model = model.mapper_from_prior_arguments(
+            {model.one: 5.0, model.two: model.two}
+        )
+        assert new_model.prior_count == 1
+
+    def test_with_limits(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = af.UniformPrior(lower_limit=0.0, upper_limit=100.0)
+        model.two = af.UniformPrior(lower_limit=0.0, upper_limit=100.0)
+        new_model = model.with_limits([(10.0, 20.0), (30.0, 40.0)])
+        assert new_model.prior_count == 2
+
+
+# ---------------------------------------------------------------------------
+# from_instance round trips
+# ---------------------------------------------------------------------------
+class TestFromInstance:
+    def test_from_simple_instance(self):
+        instance = af.m.MockClassx2(1.0, 2.0)
+        model = af.AbstractPriorModel.from_instance(instance)
+        assert model.prior_count == 0
+
+    def test_from_instance_as_model(self):
+        instance = af.m.MockClassx2(1.0, 2.0)
+        model = af.AbstractPriorModel.from_instance(instance)
+        free_model = model.as_model()
+        assert free_model.prior_count == 2
+
+    def test_from_instance_with_model_classes(self):
+        instance = af.m.MockClassx2(1.0, 2.0)
+        model = af.AbstractPriorModel.from_instance(
+            instance, model_classes=(af.m.MockClassx2,)
+        )
+        assert model.prior_count == 2
+
+    def test_from_list_instance(self):
+        instance_list = [af.m.MockClassx2(1.0, 2.0), af.m.MockClassx2(3.0, 4.0)]
+        model = af.AbstractPriorModel.from_instance(instance_list)
+        assert model.prior_count == 0
+
+    def test_from_dict_instance(self):
+        instance_dict = {
+            "one": af.m.MockClassx2(1.0, 2.0),
+            "two": af.m.MockClassx2(3.0, 4.0),
+        }
+        model = af.AbstractPriorModel.from_instance(instance_dict)
+        assert model.prior_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Fixing parameters and Constant values
+# ---------------------------------------------------------------------------
+class TestFixedParameters:
+    def test_fix_reduces_prior_count(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = 5.0
+        assert model.prior_count == 1
+
+    def test_fixed_value_in_instance(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = 5.0
+        instance = model.instance_from_vector([10.0])
+        assert instance.one == 5.0
+        assert instance.two == 10.0
+
+    def test_fix_all_parameters(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = 5.0
+        model.two = 10.0
+        assert model.prior_count == 0
+        instance = model.instance_from_vector([])
+        assert instance.one == 5.0
+        assert instance.two == 10.0
+
+
+# ---------------------------------------------------------------------------
+# take_attributes (prior passing)
+# ---------------------------------------------------------------------------
+class TestTakeAttributes:
+    def test_take_from_instance(self):
+        model = af.Model(af.m.MockClassx2)
+        source = af.m.MockClassx2(10.0, 20.0)
+        model.take_attributes(source)
+        assert model.prior_count == 0
+
+    def test_take_from_model(self):
+        """Taking attributes from another model copies priors."""
+        source_model = af.Model(af.m.MockClassx2)
+        source_model.one = af.GaussianPrior(mean=5.0, sigma=1.0)
+        source_model.two = af.GaussianPrior(mean=10.0, sigma=2.0)
+
+        target_model = af.Model(af.m.MockClassx2)
+        target_model.take_attributes(source_model)
+        assert isinstance(target_model.one, af.GaussianPrior)
+
+
+# ---------------------------------------------------------------------------
+# Serialization (dict / from_dict)
+# ---------------------------------------------------------------------------
+class TestSerialization:
+    def test_model_dict_roundtrip(self):
+        model = af.Model(af.m.MockClassx2)
+        d = model.dict()
+        loaded = af.AbstractPriorModel.from_dict(d)
+        assert loaded.prior_count == model.prior_count
+
+    def test_collection_dict_roundtrip(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        d = model.dict()
+        loaded = af.AbstractPriorModel.from_dict(d)
+        assert loaded.prior_count == model.prior_count
+
+    def test_fixed_parameter_survives_roundtrip(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = 5.0
+        d = model.dict()
+        loaded = af.AbstractPriorModel.from_dict(d)
+        assert loaded.prior_count == 1
+
+    def test_linked_prior_survives_roundtrip(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = model.two
+        assert model.prior_count == 1
+        d = model.dict()
+        loaded = af.AbstractPriorModel.from_dict(d)
+        assert loaded.prior_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Log prior computation
+# ---------------------------------------------------------------------------
+class TestLogPrior:
+    def test_log_prior_within_bounds(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = af.UniformPrior(lower_limit=0.0, upper_limit=10.0)
+        model.two = af.UniformPrior(lower_limit=0.0, upper_limit=10.0)
+        log_priors = model.log_prior_list_from_vector([5.0, 5.0])
+        assert all(np.isfinite(lp) for lp in log_priors)
+
+    def test_log_prior_outside_bounds(self):
+        model = af.Model(af.m.MockClassx2)
+        model.one = af.UniformPrior(lower_limit=0.0, upper_limit=10.0)
+        model.two = af.UniformPrior(lower_limit=0.0, upper_limit=10.0)
+        log_priors = model.log_prior_list_from_vector([15.0, 5.0])
+        # Out-of-bounds value should have a lower (or zero) log prior than in-bounds
+        assert log_priors[0] <= log_priors[1]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+class TestEdgeCases:
+    def test_single_parameter_model(self):
+        """A model with a single free parameter using explicit prior."""
+        model = af.Model(af.m.MockClassx2)
+        model.two = 5.0  # Fix one parameter
+        assert model.prior_count == 1
+        instance = model.instance_from_vector([42.0])
+        assert instance.one == 42.0
+        assert instance.two == 5.0
+
+    def test_model_copy_preserves_priors(self):
+        model = af.Model(af.m.MockClassx2)
+        copied = model.copy()
+        assert copied.prior_count == model.prior_count
+        # Priors are independent copies (different objects)
+        assert copied.one is not model.one
+
+    def test_model_copy_linked_priors_independent(self):
+        """Copying a model with linked priors preserves the link in the copy."""
+        model = af.Model(af.m.MockClassx2)
+        model.one = model.two
+        assert model.prior_count == 1
+        copied = model.copy()
+        assert copied.prior_count == 1
+        # The copy's internal link is preserved
+        assert copied.one is copied.two
+
+    def test_prior_ordering_is_deterministic(self):
+        """prior_tuples_ordered_by_id should be stable across calls."""
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx2)
+        order1 = [(n, p.id) for n, p in model.prior_tuples_ordered_by_id]
+        order2 = [(n, p.id) for n, p in model.prior_tuples_ordered_by_id]
+        assert order1 == order2
+
+    def test_prior_count_equals_total_free_parameters(self):
+        model = af.Collection(a=af.m.MockClassx2, b=af.m.MockClassx4)
+        assert model.prior_count == model.total_free_parameters
+
+    def test_has_model(self):
+        model = af.Collection(a=af.Model(af.m.MockClassx2))
+        assert model.has_model(af.m.MockClassx2)
+        assert not model.has_model(af.m.MockClassx4)
+
+    def test_has_instance(self):
+        model = af.Model(af.m.MockClassx2)
+        assert model.has_instance(Prior)
+        assert not model.has_instance(af.m.MockClassx4)


### PR DESCRIPTION
## Summary
- Adds `scripts/cookbooks/model_internal.py` — an intermediate-level guide to PyAutoFit's mapper internals
- Covers 10 topics: prior identity, shared priors, argument dicts, unit vector mapping, tree navigation, model creation, subsetting, freezing, serialization, and assertions
- Fills the gap between high-level API usage and source code for users who need deeper understanding

## Test plan
- [x] All code examples in the cookbook are executable and verified
- [ ] Review for clarity and accuracy of explanations

🤖 Generated with [Claude Code](https://claude.com/claude-code)