### PR TITLE
Add ReadTheDocs config with Python 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false


### PR DESCRIPTION
## Summary
- Add `.readthedocs.yaml` specifying Python 3.12 (without this, RTD defaults to 3.11 which is no longer supported)

## Test plan
- [ ] Verify ReadTheDocs build triggers and completes with Python 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)