### PR TITLE
Add PYAUTOFIT_TEST_MODE levels 2 and 3 to bypass sampler

### DIFF
--- a/autofit/non_linear/analysis/visualize.py
+++ b/autofit/non_linear/analysis/visualize.py
@@ -6,6 +6,7 @@ from autofit.non_linear.paths.abstract import AbstractPaths
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.paths.database import DatabasePaths
 from autofit.non_linear.paths.null import NullPaths
+from autofit.non_linear.test_mode import is_test_mode
 
 class Visualizer:
 
@@ -40,7 +41,7 @@ class Visualizer:
         A bool determining whether visualization should be performed or not.
         """
 
-        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
+        if is_test_mode():
             return False
 
         if isinstance(paths, DatabasePaths) or isinstance(paths, NullPaths):

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -456,7 +456,8 @@ class Fitness:
         """
         import numpy as np
 
-        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
+        from autofit.non_linear.test_mode import is_test_mode
+        if is_test_mode():
             return
 
         if not conf.instance["general"]["test"]["check_likelihood_function"]:

--- a/autofit/non_linear/initializer.py
+++ b/autofit/non_linear/initializer.py
@@ -8,6 +8,7 @@ from typing import Dict, Tuple, List, Optional
 import numpy as np
 
 from autofit import exc
+from autofit.non_linear.test_mode import is_test_mode
 from autofit.non_linear.paths.abstract import AbstractPaths
 from autofit.mapper.prior.abstract import Prior
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
@@ -61,7 +62,7 @@ class AbstractInitializer(ABC):
             of free dimensions of the model.
         """
 
-        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1" and test_mode_samples:
+        if is_test_mode() and test_mode_samples:
             return self.samples_in_test_mode(total_points=total_points, model=model)
 
         if n_cores == 1:
@@ -219,7 +220,8 @@ class AbstractInitializer(ABC):
         """
 
         logger.warning(
-            f"TEST MODE ON: SAMPLES BEING ASSIGNED ABRITRARY LARGE LIKELIHOODS"
+            "TEST MODE 1 (reduced iterations): Initial samples assigned "
+            "arbitrary large likelihoods to accelerate sampler convergence."
         )
 
         unit_parameter_lists = []

--- a/autofit/non_linear/plot/plot_util.py
+++ b/autofit/non_linear/plot/plot_util.py
@@ -1,9 +1,11 @@
-import os
 import logging
+import os
 from functools import wraps
 from pathlib import Path
 
 import numpy as np
+
+from autofit.non_linear.test_mode import is_test_mode
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +13,7 @@ logger = logging.getLogger(__name__)
 def skip_in_test_mode(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
+        if is_test_mode():
             return
         return func(*args, **kwargs)
 

--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -13,6 +13,7 @@ from autoconf import conf
 from autoconf.class_path import get_class_path
 from autofit import exc
 from autofit.mapper.model import ModelInstance
+from autofit.non_linear.test_mode import is_test_mode
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.samples.sample import Sample
 
@@ -378,7 +379,7 @@ class Samples(SamplesInterface, ABC):
         if weight_threshold is None:
             weight_threshold = conf.instance["output"]["samples_weight_threshold"]
 
-        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
+        if is_test_mode():
             weight_threshold = None
 
         if weight_threshold is None:

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -49,6 +49,7 @@ from autofit.graphical.declarative.abstract import PriorFactor
 from autofit.graphical.expectation_propagation import AbstractFactorOptimiser
 
 from autofit.non_linear.fitness import get_timeout_seconds
+from autofit.non_linear.test_mode import is_test_mode, test_mode_level
 
 logger = logging.getLogger(__name__)
 
@@ -650,6 +651,14 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         ):
             self.timer.start()
 
+        mode = test_mode_level()
+        if mode >= 2:
+            return self._fit_bypass_test_mode(
+                model=model,
+                analysis=analysis,
+                call_likelihood=(mode == 2),
+            )
+
         model.freeze()
         search_internal, fitness = self._fit(
             model=model,
@@ -770,13 +779,124 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         if not conf.instance["output"]["search_internal"]:
             self.logger.info("Removing search internal folder.")
             self.paths.remove_search_internal()
-        else:
+        elif search_internal is not None:
             self.output_search_internal(search_internal=search_internal)
 
         if not self.disable_output:
             self.logger.info("Removing all files except for .zip file")
 
         self.paths.zip_remove()
+
+    def _fit_bypass_test_mode(
+        self,
+        model: AbstractPriorModel,
+        analysis: Analysis,
+        call_likelihood: bool = True,
+    ):
+        """
+        Bypass the sampler entirely in test mode (levels 2 and 3).
+
+        Generates fake samples and writes all expected output files so that
+        downstream code sees a complete result folder.
+
+        Parameters
+        ----------
+        model
+            The model being fitted.
+        analysis
+            The analysis object with the log likelihood function.
+        call_likelihood
+            If True (mode 2), call the likelihood function once to verify it
+            works. If False (mode 3), skip the likelihood call entirely.
+        """
+        from autofit.non_linear.samples.pdf import SamplesPDF
+        from autofit.non_linear.samples.sample import Sample
+
+        mode = test_mode_level()
+        if mode == 2:
+            logger.warning(
+                "TEST MODE 2 (bypass + likelihood): Skipping sampler, "
+                "calling likelihood function once to verify it works."
+            )
+        else:
+            logger.warning(
+                "TEST MODE 3 (full bypass): Skipping sampler and likelihood "
+                "entirely for maximum speed. No likelihood verification."
+            )
+
+        model.freeze()
+
+        unit_vector = [0.5] * model.prior_count
+        parameter_vector = [
+            float(v) for v in model.vector_from_unit_vector(
+                unit_vector=unit_vector,
+            )
+        ]
+
+        log_likelihood = -1.0e99
+        if call_likelihood:
+            instance = model.instance_from_vector(vector=parameter_vector)
+            log_likelihood = float(
+                analysis.log_likelihood_function(instance)
+            )
+
+        sample_list = self._build_fake_samples(
+            model=model,
+            parameter_vector=parameter_vector,
+            log_likelihood=log_likelihood,
+        )
+
+        samples = SamplesPDF(
+            model=model,
+            sample_list=sample_list,
+            samples_info={
+                "total_iterations": 1,
+                "time": 0.0,
+            },
+        )
+
+        samples_summary = samples.summary()
+        self.paths.save_samples_summary(samples_summary=samples_summary)
+        self.paths.save_samples(samples=samples)
+
+        result = analysis.make_result(
+            samples_summary=samples_summary,
+            paths=self.paths,
+            samples=samples,
+            search_internal=None,
+        )
+
+        analysis.save_results(paths=self.paths, result=result)
+        analysis.save_results_combined(paths=self.paths, result=result)
+
+        model.unfreeze()
+
+        self.paths.completed()
+
+        return result
+
+    @staticmethod
+    def _build_fake_samples(model, parameter_vector, log_likelihood):
+        """
+        Build a minimal list of fake Sample objects for test mode bypass.
+
+        Creates two samples: the "best" at the prior median and a second
+        with slightly perturbed parameters and worse likelihood, so that
+        SamplesPDF methods like median_pdf work correctly.
+        """
+        from autofit.non_linear.samples.sample import Sample
+
+        perturbed = [
+            p * 1.001 if p != 0.0 else 0.001 for p in parameter_vector
+        ]
+
+        return Sample.from_lists(
+            model=model,
+            parameter_lists=[parameter_vector, perturbed],
+            log_likelihood_list=[log_likelihood, log_likelihood - 1.0],
+            log_prior_list=[0.0, 0.0],
+            weight_list=[1.0, 0.5],
+        )
 
     @abstractmethod
     def _fit(self, model: AbstractPriorModel, analysis: Analysis):
@@ -815,8 +935,11 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             except KeyError:
                 pass
 
-        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
-            logger.warning(f"TEST MODE ON: SEARCH WILL SKIP SAMPLING\n\n")
+        if is_test_mode():
+            logger.warning(
+                "TEST MODE 1 (reduced iterations): Sampler will run with "
+                "minimal iterations for faster completion."
+            )
 
             config_dict = self.config_dict_test_mode_from(config_dict=config_dict)
 

--- a/autofit/non_linear/search/mcmc/auto_correlations.py
+++ b/autofit/non_linear/search/mcmc/auto_correlations.py
@@ -3,6 +3,8 @@ import os
 
 from typing import Optional
 
+from autofit.non_linear.test_mode import is_test_mode
+
 class AutoCorrelationsSettings:
 
     def __init__(
@@ -47,7 +49,7 @@ class AutoCorrelationsSettings:
         self.check_for_convergence = self.check_for_convergence if self.check_for_convergence is not None else config_dict["check_for_convergence"]
         self.check_size = self.check_size or config_dict["check_size"]
 
-        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
+        if is_test_mode():
             self.check_size = 1
 
         self.required_length = self.required_length or config_dict["required_length"]

--- a/autofit/non_linear/search/mcmc/emcee/search.py
+++ b/autofit/non_linear/search/mcmc/emcee/search.py
@@ -13,6 +13,7 @@ from autofit.non_linear.initializer import Initializer
 from autofit.non_linear.search.mcmc.abstract_mcmc import AbstractMCMC
 from autofit.non_linear.search.mcmc.auto_correlations import AutoCorrelationsSettings
 from autofit.non_linear.search.mcmc.auto_correlations import AutoCorrelations
+from autofit.non_linear.test_mode import is_test_mode
 from autofit.non_linear.samples.sample import Sample
 from autofit.non_linear.samples.mcmc import SamplesMCMC
 
@@ -266,7 +267,7 @@ class Emcee(AbstractMCMC):
 
         search_internal = search_internal or self.backend
 
-        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
+        if is_test_mode():
             samples_after_burn_in = search_internal.get_chain(
                 discard=5, thin=5, flat=True
             )

--- a/autofit/non_linear/search/mcmc/zeus/search.py
+++ b/autofit/non_linear/search/mcmc/zeus/search.py
@@ -13,6 +13,7 @@ from autofit.non_linear.search.mcmc.abstract_mcmc import AbstractMCMC
 from autofit.non_linear.search.mcmc.auto_correlations import AutoCorrelationsSettings
 from autofit.non_linear.search.mcmc.auto_correlations import AutoCorrelations
 from autofit.non_linear.samples.sample import Sample
+from autofit.non_linear.test_mode import is_test_mode
 from autofit.non_linear.samples.mcmc import SamplesMCMC
 
 
@@ -285,7 +286,7 @@ class Zeus(AbstractMCMC):
 
         search_internal = search_internal or self.paths.load_search_internal()
 
-        if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
+        if is_test_mode():
 
             samples_after_burn_in = search_internal.get_chain(
                 discard=5, thin=5, flat=True

--- a/autofit/non_linear/test_mode.py
+++ b/autofit/non_linear/test_mode.py
@@ -1,0 +1,20 @@
+import os
+
+
+def test_mode_level():
+    """
+    Return the current test mode level.
+
+    0 = off (normal operation)
+    1 = reduce sampler iterations to minimum (existing behavior)
+    2 = bypass sampler entirely, call likelihood once
+    3 = bypass sampler entirely, skip likelihood call
+    """
+    return int(os.environ.get("PYAUTOFIT_TEST_MODE", "0"))
+
+
+def is_test_mode():
+    """
+    Return True if any test mode is active.
+    """
+    return test_mode_level() > 0


### PR DESCRIPTION
## Summary
Adds two new test mode levels that bypass the sampler entirely, enabling much faster integration/smoke testing. Level 2 calls the likelihood function once (to verify it works), level 3 skips everything for maximum speed. Both produce the full output folder structure so downstream code works unchanged.

Also centralizes all scattered `os.environ.get("PYAUTOFIT_TEST_MODE")` checks into a shared `test_mode.py` module and improves log messages to describe each level's behavior.

Timing on `model_fit.py`: mode 1 ~71s → mode 2 ~37s → mode 3 ~32s.

Closes #1179

## API Changes
Added `autofit.non_linear.test_mode` module with `is_test_mode()` and `test_mode_level()` public helpers. Existing `PYAUTOFIT_TEST_MODE=1` behavior is unchanged. New levels 2 and 3 are opt-in via the same environment variable.
See full details below.

## Test Plan
- [x] PyAutoFit unit tests: 1198 passed
- [x] PyAutoArray unit tests: 739 passed
- [x] PyAutoGalaxy unit tests: 852 passed
- [x] PyAutoLens unit tests: 286 passed
- [x] Smoke tests with mode 2 and 3: no new failures

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autofit.non_linear.test_mode.test_mode_level()` — returns current test mode level (0-3)
- `autofit.non_linear.test_mode.is_test_mode()` — returns True if any test mode is active
- `AbstractSearch._fit_bypass_test_mode(model, analysis, call_likelihood)` — internal method to bypass sampler in modes 2/3
- `AbstractSearch._build_fake_samples(model, parameter_vector, log_likelihood)` — internal method to build minimal Sample objects for bypass mode
- `PYAUTOFIT_TEST_MODE=2` — bypass sampler, call likelihood once
- `PYAUTOFIT_TEST_MODE=3` — bypass sampler and likelihood entirely

### Changed Behaviour
- All internal `os.environ.get("PYAUTOFIT_TEST_MODE") == "1"` checks replaced with `is_test_mode()` which returns True for levels 1, 2, and 3
- Test mode log messages now describe each level's specific behavior

### Migration
- No migration needed — existing `PYAUTOFIT_TEST_MODE=1` behavior is unchanged
- Downstream repos should import `from autofit.non_linear.test_mode import is_test_mode` instead of checking the env var directly

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)