### PR TITLE
perf: Skip VRAM, I/O, model.info in test mode 2+ and add PYAUTO_DISABLE_JAX

### DIFF
--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1778,6 +1778,10 @@ class AbstractPriorModel(AbstractModel):
         parameter of the overall model.
         This information is extracted from each priors *model_info* property.
         """
+        from autofit.non_linear.test_mode import test_mode_level
+
+        if test_mode_level() >= 2:
+            return f"Total Free Parameters = {self.prior_count}\n\n[test mode — info skipped]"
 
         formatter = TextFormatter(line_length=info_whitespace())
 

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -35,6 +35,9 @@ class Analysis(ABC):
     def __init__(
         self, use_jax : bool = False, **kwargs
     ):
+        import os
+        if os.environ.get("PYAUTO_DISABLE_JAX") == "1":
+            use_jax = False
 
         self._use_jax = use_jax
         self.kwargs = kwargs
@@ -325,6 +328,11 @@ class Analysis(ABC):
         batch_size
             The batch size to profile, which is the number of model evaluations JAX will perform simultaneously.
         """
+        from autofit.non_linear.test_mode import test_mode_level
+
+        if test_mode_level() >= 2:
+            return
+
         if not self._use_jax:
             print("use_jax=False for this analysis, therefore does not use GPU and VRAM use cannot be profiled.")
             return

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -497,11 +497,13 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         analysis = analysis.modify_before_fit(paths=self.paths, model=model)
         model.unfreeze()
 
-        self.pre_fit_output(
-            analysis=analysis,
-            model=model,
-            info=info,
-        )
+        mode = test_mode_level()
+        if mode < 2:
+            self.pre_fit_output(
+                analysis=analysis,
+                model=model,
+                info=info,
+            )
 
         if not self.paths.is_complete:
             result = self.start_resume_fit(
@@ -514,13 +516,14 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
                 model=model,
             )
 
-        analysis = analysis.modify_after_fit(
-            paths=self.paths, model=model, result=result
-        )
+        if mode < 2:
+            analysis = analysis.modify_after_fit(
+                paths=self.paths, model=model, result=result
+            )
 
-        self.post_fit_output(
-            search_internal=result.search_internal,
-        )
+            self.post_fit_output(
+                search_internal=result.search_internal,
+            )
 
         gc.collect()
 
@@ -856,8 +859,6 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         )
 
         samples_summary = samples.summary()
-        self.paths.save_samples_summary(samples_summary=samples_summary)
-        self.paths.save_samples(samples=samples)
 
         result = analysis.make_result(
             samples_summary=samples_summary,
@@ -866,12 +867,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             search_internal=None,
         )
 
-        analysis.save_results(paths=self.paths, result=result)
-        analysis.save_results_combined(paths=self.paths, result=result)
-
         model.unfreeze()
-
-        self.paths.completed()
 
         return result
 

--- a/autofit/text/text_util.py
+++ b/autofit/text/text_util.py
@@ -55,6 +55,11 @@ def result_info_from(samples) -> str:
     Output the full model.results file, which include the most-likely model, most-probable model at 1 and 3
     sigma confidence and information on the maximum log likelihood.
     """
+    from autofit.non_linear.test_mode import test_mode_level
+
+    if test_mode_level() >= 2:
+        return "[test mode — result info skipped]"
+
     results = []
 
     if hasattr(samples, "log_evidence"):


### PR DESCRIPTION
## Summary

When `PYAUTOFIT_TEST_MODE >= 2`, skip expensive operations that aren't needed for smoke testing: VRAM estimation (16s), pre/post-fit file I/O (10s), model.info formatting (7s), and result.info formatting (5s). Also adds `PYAUTO_DISABLE_JAX=1` env var to force `use_jax=False` in the Analysis base class.

Combined with the earlier `PYAUTO_WORKSPACE_SMALL_DATASETS` and `PYAUTO_DISABLE_CRITICAL_CAUSTICS` env vars, this reduces smoke test runtime from ~100s to ~22s per modeling script.

## API Changes

Added one environment variable: `PYAUTO_DISABLE_JAX=1`. When set, `Analysis.__init__` forces `use_jax=False` regardless of what the caller passes.

In test mode 2+, `model.info` returns a stub string and `result.info` returns a stub string. `print_vram_use()` is a no-op. `search.fit()` skips pre-fit output, post-fit output, and all file I/O in the bypass path. These are internal behavioural changes that only apply when the test mode env var is explicitly set.

See full details below.

## Test Plan
- [x] PyAutoFit unit tests pass (1198 passed)
- [x] imaging/modeling.py completes in ~22s with all env vars
- [x] interferometer/modeling.py completes in ~22s with all env vars
- [x] Without env vars, original behaviour preserved

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- Environment variable `PYAUTO_DISABLE_JAX=1` — forces `use_jax=False` in `Analysis.__init__`

### Changed Behaviour (test mode 2+ only)
- `Analysis.print_vram_use()` — returns immediately (no-op)
- `AbstractSearch.fit()` — skips `pre_fit_output()`, `post_fit_output()`, `modify_after_fit()`
- `AbstractSearch._fit_bypass_test_mode()` — skips `save_samples()`, `save_results()`, `save_results_combined()`, `paths.completed()`
- `AbstractPriorModel.info` — returns stub string
- `text_util.result_info_from()` — returns stub string

### Migration
None — all changes are gated behind `PYAUTOFIT_TEST_MODE >= 2` or `PYAUTO_DISABLE_JAX=1`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)