### PR TITLE
refactor: re-export test_mode from autoconf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,13 @@
 - Requires Python >= 3.9
 - Package name: `autofit`
 
+## Dependency Graph
+
+PyAutoFit depends on **autoconf** (shared configuration and utilities).
+PyAutoFit does **NOT** depend on PyAutoArray, PyAutoGalaxy, or PyAutoLens.
+Never import from `autoarray`, `autogalaxy`, or `autolens` in this repo.
+Shared utilities (e.g. `test_mode`, `jax_wrapper`) belong in autoconf.
+
 ## Repository Structure
 
 - `autofit/` - Main package

--- a/autofit/non_linear/test_mode.py
+++ b/autofit/non_linear/test_mode.py
@@ -1,20 +1,3 @@
-import os
+from autoconf.test_mode import test_mode_level, is_test_mode
 
-
-def test_mode_level():
-    """
-    Return the current test mode level.
-
-    0 = off (normal operation)
-    1 = reduce sampler iterations to minimum (existing behavior)
-    2 = bypass sampler entirely, call likelihood once
-    3 = bypass sampler entirely, skip likelihood call
-    """
-    return int(os.environ.get("PYAUTOFIT_TEST_MODE", "0"))
-
-
-def is_test_mode():
-    """
-    Return True if any test mode is active.
-    """
-    return test_mode_level() > 0
+__all__ = ["test_mode_level", "is_test_mode"]


### PR DESCRIPTION
## Summary
The canonical source for `test_mode_level()` and `is_test_mode()` is now `autoconf.test_mode`. This module re-exports for backward compatibility. Also adds dependency graph to CLAUDE.md.

Depends on rhayes777/PyAutoConf#83.

## API Changes
None — internal changes only. `autofit.non_linear.test_mode` still works via re-export.

## Test Plan
- [x] All 1198 PyAutoFit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)