### PR TITLE
perf: defer scipy.stats import in PriorVectorized

### DIFF
--- a/autofit/mapper/prior/vectorized.py
+++ b/autofit/mapper/prior/vectorized.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy.stats import norm
 
 from autofit.mapper.prior.gaussian import GaussianPrior
 from autofit.mapper.prior.truncated_gaussian import TruncatedGaussianPrior
@@ -97,6 +96,8 @@ class PriorVectorized:
                         uppers - self.truncated_gaussian_means
                 ) / self.truncated_gaussian_sigmas
 
+            from scipy.stats import norm
+
             self.truncated_gaussian_cdf_a = norm.cdf(a)
             self.truncated_gaussian_cdf_b = norm.cdf(b)
 
@@ -153,6 +154,8 @@ class PriorVectorized:
 
         # 3) Batch‐process all GaussianPriors
         if self.gaussian_idx:
+            from scipy.stats import norm
+
             subcube = cube[:, self.gaussian_idx]  # (n_samples, n_gaussians)
 
             inv = norm.ppf(subcube)  # inverse CDF of standard normal
@@ -162,6 +165,8 @@ class PriorVectorized:
         if self.truncated_gaussian_idx:
 
             subcube = cube[:, self.truncated_gaussian_idx]  # (n_samples, n_truncs)
+
+            from scipy.stats import norm
 
             truncated_cdf = self.truncated_gaussian_cdf_a + subcube * (
                     self.truncated_gaussian_cdf_b - self.truncated_gaussian_cdf_a


### PR DESCRIPTION
## Summary
Move `scipy.stats.norm` from module-level import to local imports inside `PriorVectorized.__init__` and `__call__` methods. This avoids loading scipy during `import autofit`, reducing the import floor for downstream packages.

Part of Jammy2211/PyAutoLens#426.

## API Changes
None — internal changes only.

## Test Plan
- [x] `pytest test_autofit/ -x` — 1198 passed
- [ ] Smoke tests via downstream `/smoke-test`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

No public API changes. Single internal import reorganization:
- `autofit/mapper/prior/vectorized.py` — `from scipy.stats import norm` moved from module level to local imports in `PriorVectorized.__init__` and `PriorVectorized.__call__`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)