### PR TITLE
Re-enable model.info output in test mode 2+

### DIFF
--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1778,11 +1778,6 @@ class AbstractPriorModel(AbstractModel):
         parameter of the overall model.
         This information is extracted from each priors *model_info* property.
         """
-        from autofit.non_linear.test_mode import test_mode_level
-
-        if test_mode_level() >= 2:
-            return f"Total Free Parameters = {self.prior_count}\n\n[test mode — info skipped]"
-
         formatter = TextFormatter(line_length=info_whitespace())
 
         for t in find_groups(

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -504,6 +504,9 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
                 model=model,
                 info=info,
             )
+        else:
+            if hasattr(self.paths, '_save_model_info'):
+                self.paths._save_model_info(model=model)
 
         if not self.paths.is_complete:
             result = self.start_resume_fit(


### PR DESCRIPTION
## Summary
Re-enable `model.info` generation and file output when `PYAUTOFIT_TEST_MODE` is 2 or 3. Benchmarking showed it adds only ~0.18s per call — negligible — while allowing smoke tests to verify model composition is correct.

## API Changes
None — internal changes only.

## Test Plan
- [x] All 1198 PyAutoFit unit tests pass
- [x] `PYAUTOFIT_TEST_MODE=2` smoke test of `autolens_workspace/scripts/imaging/modeling.py` produces full `model.info` (4041 bytes)
- [x] `PYAUTOFIT_TEST_MODE=3` also produces full `model.info`
- [x] Runtime unchanged (~14.5s → ~14.9s, within noise)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `AbstractPriorModel.info` property — no longer returns a stub string in test mode 2+; always generates full model info text
- `AbstractSearch.fit()` — now writes `model.info` file to output path in test mode 2+, even though the rest of `pre_fit_output` is still skipped

### Migration
No migration needed — this is an internal test-mode behaviour change with no public API impact.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)