### PR TITLE
Remove pyprojroot dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "gprof2dot==2021.2.21",
     "matplotlib",
     "numpydoc>=1.0.0",
-    "pyprojroot==0.2.0",
     "pyswarms==1.3.0",
     "h5py>=3.11.0",
     "SQLAlchemy==2.0.32",


### PR DESCRIPTION
## Summary
- Removes `pyprojroot==0.2.0` from dependencies
- No longer needed — workspace notebooks now use `autoconf.setup_notebook()`

## Test plan
- [x] Verified no PyAutoFit code imports pyprojroot

🤖 Generated with [Claude Code](https://claude.com/claude-code)