### PR TITLE
Make bypass test mode write a complete on-disk result

### DIFF
--- a/autofit/non_linear/samples/pdf.py
+++ b/autofit/non_linear/samples/pdf.py
@@ -429,7 +429,7 @@ class SamplesPDF(Samples):
 
     @property
     def log_evidence(self):
-        return None
+        return self.samples_info.get("log_evidence")
 
 
 def marginalize(

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -505,8 +505,16 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
                 info=info,
             )
         else:
-            if hasattr(self.paths, '_save_model_info'):
-                self.paths._save_model_info(model=model)
+            # Bypass mode still needs the metadata + identifier files written
+            # so downstream aggregator scraping can discover the search
+            # directory. `save_all` is lightweight (a handful of JSON dumps)
+            # and skips the expensive `analysis.save_attributes` /
+            # `visualize_before_fit` calls that `pre_fit_output` would add.
+            if hasattr(self.paths, "save_all"):
+                self.paths.save_all(
+                    search_config_dict=self.config_dict_search,
+                    info=info,
+                )
 
         if not self.paths.is_complete:
             result = self.start_resume_fit(
@@ -852,16 +860,28 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             log_likelihood=log_likelihood,
         )
 
+        # Stub log_evidence in samples_info so downstream arithmetic
+        # (grid search log_evidences, subhalo Bayesian model comparison,
+        # scrape aggregator assertions) doesn't crash on None. SamplesPDF
+        # reads log_evidence from samples_info.
         samples = SamplesPDF(
             model=model,
             sample_list=sample_list,
             samples_info={
                 "total_iterations": 1,
                 "time": 0.0,
+                "log_evidence": log_likelihood,
             },
         )
 
         samples_summary = samples.summary()
+
+        # Persist samples + summary to disk so downstream code that reads
+        # from the output folder (database scrape, paths.load_samples_summary)
+        # sees a complete result. Matches the docstring's promise. NullPaths
+        # and DatabasePaths both handle these calls safely.
+        self.paths.save_samples_summary(samples_summary=samples_summary)
+        self.paths.save_samples(samples=samples)
 
         result = analysis.make_result(
             samples_summary=samples_summary,


### PR DESCRIPTION
## Summary

Three tightly-coupled bugs in `PYAUTOFIT_TEST_MODE=2` (bypass mode) were causing the post-API-drift mega-run cluster of `NoneType` arithmetic errors on `log_evidence` and the database scrape test's IndexError.

All three ship together because they share the same root cause — bypass mode was supposed to produce a fully-populated result folder, but its implementation was incomplete:

- `SamplesPDF.log_evidence` returned `None` unconditionally
- `_fit_bypass_test_mode` never called `save_samples` or `save_samples_summary` (despite its docstring)
- `fit()` skipped `pre_fit_output` in bypass mode, which meant the `metadata` file used by the aggregator to discover search directories was never written

After this PR, `autofit features/search_grid_search.py`, `autolens imaging/features/advanced/subhalo/detect/start_here.py`, and `autofit_workspace_test database/scrape/grid_search.py` all pass end-to-end in bypass mode.

## API Changes

- `SamplesPDF.log_evidence` now returns `samples_info.get("log_evidence")` instead of `None`.
- Bypass test mode now writes `metadata`, `samples.csv`, and `samples_summary.json` to the output folder. No public signatures changed; this only affects what files exist on disk after a bypass-mode run.

See full details below.

## Test Plan

- [x] PyAutoFit unit tests: `test_autofit/non_linear/search` + `test_autofit/non_linear/samples` — 65 passed
- [x] Full PyAutoFit test suite — 1205 passed
- [x] 27-script workspace smoke test suite across all four workspaces — all passed
- [x] The three originally-failing scripts wiped-and-rerun in bypass mode — all exit 0

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour

- `autofit.non_linear.samples.pdf.SamplesPDF.log_evidence` — now returns `self.samples_info.get("log_evidence")` instead of hardcoded `None`. Only affects pure `SamplesPDF` instances; `SamplesNest` and `SamplesMCMC` override and are unchanged.
- `autofit.non_linear.search.abstract_search.NonLinearSearch._fit_bypass_test_mode` — now stubs `log_evidence` in `samples_info` (set to the single evaluated `log_likelihood`) and calls `self.paths.save_samples_summary(...)` and `self.paths.save_samples(...)` so downstream readers see a complete result folder.
- `autofit.non_linear.search.abstract_search.NonLinearSearch.fit` — when `test_mode_level() >= 2`, now calls `self.paths.save_all(...)` instead of only `_save_model_info`. This writes the `metadata` file that the aggregator uses to discover search directories. Still skips `analysis.save_attributes` and `visualize_before_fit` to keep bypass mode cheap.

### Migration

No migration needed for library consumers. If you have custom code that relied on `SamplesPDF.log_evidence` being `None`, replace with an explicit check against `samples_info`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)