### PR TITLE
refactor: separate PYAUTOFIT_TEST_MODE into distinct PYAUTO_* env vars

### DIFF
--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -328,9 +328,9 @@ class Analysis(ABC):
         batch_size
             The batch size to profile, which is the number of model evaluations JAX will perform simultaneously.
         """
-        from autofit.non_linear.test_mode import test_mode_level
+        from autofit.non_linear.test_mode import skip_fit_output
 
-        if test_mode_level() >= 2:
+        if skip_fit_output():
             return
 
         if not self._use_jax:

--- a/autofit/non_linear/analysis/visualize.py
+++ b/autofit/non_linear/analysis/visualize.py
@@ -6,7 +6,7 @@ from autofit.non_linear.paths.abstract import AbstractPaths
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.paths.database import DatabasePaths
 from autofit.non_linear.paths.null import NullPaths
-from autofit.non_linear.test_mode import is_test_mode
+from autofit.non_linear.test_mode import skip_visualization
 
 class Visualizer:
 
@@ -41,7 +41,7 @@ class Visualizer:
         A bool determining whether visualization should be performed or not.
         """
 
-        if is_test_mode():
+        if skip_visualization():
             return False
 
         if isinstance(paths, DatabasePaths) or isinstance(paths, NullPaths):

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -456,8 +456,8 @@ class Fitness:
         """
         import numpy as np
 
-        from autofit.non_linear.test_mode import is_test_mode
-        if is_test_mode():
+        from autofit.non_linear.test_mode import skip_fit_output
+        if skip_fit_output():
             return
 
         if not conf.instance["general"]["test"]["check_likelihood_function"]:

--- a/autofit/non_linear/plot/plot_util.py
+++ b/autofit/non_linear/plot/plot_util.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import numpy as np
 
-from autofit.non_linear.test_mode import is_test_mode
+from autofit.non_linear.test_mode import skip_visualization
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 def skip_in_test_mode(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if is_test_mode():
+        if skip_visualization():
             return
         return func(*args, **kwargs)
 

--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -13,7 +13,7 @@ from autoconf import conf
 from autoconf.class_path import get_class_path
 from autofit import exc
 from autofit.mapper.model import ModelInstance
-from autofit.non_linear.test_mode import is_test_mode
+from autofit.non_linear.test_mode import skip_checks
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.samples.sample import Sample
 
@@ -379,7 +379,7 @@ class Samples(SamplesInterface, ABC):
         if weight_threshold is None:
             weight_threshold = conf.instance["output"]["samples_weight_threshold"]
 
-        if is_test_mode():
+        if skip_checks():
             weight_threshold = None
 
         if weight_threshold is None:

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -49,7 +49,7 @@ from autofit.graphical.declarative.abstract import PriorFactor
 from autofit.graphical.expectation_propagation import AbstractFactorOptimiser
 
 from autofit.non_linear.fitness import get_timeout_seconds
-from autofit.non_linear.test_mode import is_test_mode, test_mode_level
+from autofit.non_linear.test_mode import is_test_mode, test_mode_level, skip_fit_output
 
 logger = logging.getLogger(__name__)
 
@@ -497,15 +497,14 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         analysis = analysis.modify_before_fit(paths=self.paths, model=model)
         model.unfreeze()
 
-        mode = test_mode_level()
-        if mode < 2:
+        if not skip_fit_output():
             self.pre_fit_output(
                 analysis=analysis,
                 model=model,
                 info=info,
             )
         else:
-            # Bypass mode still needs the metadata + identifier files written
+            # Skip mode still needs the metadata + identifier files written
             # so downstream aggregator scraping can discover the search
             # directory. `save_all` is lightweight (a handful of JSON dumps)
             # and skips the expensive `analysis.save_attributes` /
@@ -527,7 +526,7 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
                 model=model,
             )
 
-        if mode < 2:
+        if not skip_fit_output():
             analysis = analysis.modify_after_fit(
                 paths=self.paths, model=model, result=result
             )

--- a/autofit/non_linear/test_mode.py
+++ b/autofit/non_linear/test_mode.py
@@ -1,3 +1,3 @@
-from autoconf.test_mode import test_mode_level, is_test_mode
+from autoconf.test_mode import test_mode_level, is_test_mode, skip_fit_output, skip_visualization, skip_checks
 
-__all__ = ["test_mode_level", "is_test_mode"]
+__all__ = ["test_mode_level", "is_test_mode", "skip_fit_output", "skip_visualization", "skip_checks"]

--- a/autofit/text/text_util.py
+++ b/autofit/text/text_util.py
@@ -55,10 +55,10 @@ def result_info_from(samples) -> str:
     Output the full model.results file, which include the most-likely model, most-probable model at 1 and 3
     sigma confidence and information on the maximum log likelihood.
     """
-    from autofit.non_linear.test_mode import test_mode_level
+    from autofit.non_linear.test_mode import skip_fit_output
 
-    if test_mode_level() >= 2:
-        return "[test mode — result info skipped]"
+    if skip_fit_output():
+        return "[fit output skipped — PYAUTO_SKIP_FIT_OUTPUT=1]"
 
     results = []
 

--- a/test_autofit/non_linear/test_initializer.py
+++ b/test_autofit/non_linear/test_initializer.py
@@ -80,7 +80,7 @@ def test__priors__samples_from_model__raise_exception_if_all_likelihoods_identic
 
 
 def test__priors__samples_in_test_mode():
-    os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+    os.environ["PYAUTO_TEST_MODE"] = "1"
 
     model = af.Model(af.m.MockClassx4)
     model.one = af.UniformPrior(lower_limit=0.099, upper_limit=0.101)
@@ -121,7 +121,7 @@ def test__priors__samples_in_test_mode():
 
     assert figure_of_merit_list == [-1.0e99, -1.0e100]
 
-    os.environ["PYAUTOFIT_TEST_MODE"] = "0"
+    os.environ["PYAUTO_TEST_MODE"] = "0"
 
 
 def test__ball__samples_sample_centre_of_priors():


### PR DESCRIPTION
## Summary
Update all `PYAUTOFIT_TEST_MODE` call sites to use the new purpose-specific functions from `autoconf.test_mode`. Visualization → `skip_visualization()`, fit I/O → `skip_fit_output()`, weight thresholds → `skip_checks()`. Sampler-related sites keep using `test_mode_level()` / `is_test_mode()` unchanged.

Depends on: rhayes777/PyAutoConf#86

## API Changes
None — internal changes only. The `autofit.non_linear.test_mode` re-export module now includes 3 additional symbols (`skip_fit_output`, `skip_visualization`, `skip_checks`).

## Test Plan
- [x] All 1205 PyAutoFit tests pass
- [x] `test_initializer.py` updated to use `PYAUTO_TEST_MODE`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added (re-exports)
- `autofit.non_linear.test_mode.skip_fit_output`
- `autofit.non_linear.test_mode.skip_visualization`
- `autofit.non_linear.test_mode.skip_checks`

### Changed Behaviour
- `Visualizer.should_visualize()` now checks `PYAUTO_SKIP_VISUALIZATION` instead of `PYAUTOFIT_TEST_MODE`
- Pre/post-fit output now checks `PYAUTO_SKIP_FIT_OUTPUT` instead of `test_mode_level() >= 2`
- `print_vram_use()` now checks `PYAUTO_SKIP_FIT_OUTPUT` instead of `test_mode_level() >= 2`
- `check_likelihood_function()` now checks `PYAUTO_SKIP_FIT_OUTPUT` instead of `is_test_mode()`
- `result_info_from()` now checks `PYAUTO_SKIP_FIT_OUTPUT` instead of `test_mode_level() >= 2`
- `samples_that_exceed_weight_threshold()` now checks `PYAUTO_SKIP_CHECKS` instead of `is_test_mode()`
- `skip_in_test_mode` decorator now checks `PYAUTO_SKIP_VISUALIZATION` instead of `is_test_mode()`

### Migration
- Before: `export PYAUTOFIT_TEST_MODE=2` controlled everything
- After: Set each independently: `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)