### PR TITLE
fix: bump scipy cap to <=1.15.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
     "h5py>=3.11.0",
     "SQLAlchemy==2.0.32",
-    "scipy<=1.14.0",
+    "scipy<=1.15.2",
     "astunparse==1.6.3",
     "threadpoolctl>=3.1.0,<=3.2.0",
     "timeout-decorator==0.5.0",


### PR DESCRIPTION
## Summary
- Bumps scipy upper bound from `<=1.14.0` to `<=1.15.2`
- The hard cap at 1.14.0 caused PyAutoGalaxy CI to fail: when jax pulled in scipy 1.17.1 and autofit forced a downgrade, pip's resolver backtracked into building scipy from source, which failed due to missing OpenBLAS on the CI runner
- All 6 PyAutoGalaxy CI runs on April 12 are affected

## Test plan
- [x] Verified full install chain locally: PyAutoConf → PyAutoFit → PyAutoArray → PyAutoGalaxy (including optional deps) resolves without conflict
- [ ] PyAutoGalaxy CI passes after both this PR and the matching PyAutoArray PR are merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)