### PR TITLE
build: raise scipy cap, relax threadpoolctl and SQLAlchemy pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,10 @@ dependencies = [
     "numpydoc>=1.0.0",
 
     "h5py>=3.11.0",
-    "SQLAlchemy==2.0.32",
-    "scipy<=1.15.2",
+    "SQLAlchemy>=2.0.32,<2.1.0",
+    "scipy<=1.17.1",
     "astunparse==1.6.3",
-    "threadpoolctl>=3.1.0,<=3.2.0",
+    "threadpoolctl>=3.1.0",
     "timeout-decorator==0.5.0",
     "xxhash<=3.4.1",
     "networkx==3.1",


### PR DESCRIPTION
## Summary
Raise scipy cap from <=1.15.2 to <=1.17.1, remove threadpoolctl upper bound, widen SQLAlchemy from ==2.0.32 to >=2.0.32,<2.1.0.

Part of cross-ecosystem dependency sweep (PyAutoLabs/PyAutoConf#87).

## API Changes
None — internal changes only.

## Test Plan
- [x] PyAutoFit unit tests pass (1,205/1,205)
- [x] Full stack tests pass (3,070 across 5 repos)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)