### PR TITLE
docs: update Python version to 3.12-3.13

### DIFF
--- a/docs/installation/overview.rst
+++ b/docs/installation/overview.rst
@@ -3,7 +3,7 @@
 Overview
 ========
 
-**PyAutoFit** requires Python 3.9 - 3.12 and support the Linux, MacOS and Windows operating systems.
+**PyAutoFit** requires Python 3.12 - 3.13 and supports the Linux, MacOS and Windows operating systems.
 
 **PyAutoFit** can be installed via the Python distribution `Anaconda <https://www.anaconda.com/>`_ or using
 `Pypi <https://pypi.org/>`_ to ``pip install`` **PyAutoFit** into your Python distribution.


### PR DESCRIPTION
## Summary
Update installation docs to reflect Python 3.12-3.13 support (was 3.9-3.12).

## API Changes
None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)