### PR TITLE
fix: guard interpolator and grid search against edge cases

### DIFF
--- a/autofit/interpolator/abstract.py
+++ b/autofit/interpolator/abstract.py
@@ -95,6 +95,11 @@ class AbstractInterpolator(ABC):
             value_map = self._value_map(item.path)
             x = sorted(value_map)
 
+            if not self.instances:
+                raise IndexError(
+                    "Cannot interpolate: no instances have been added to the interpolator."
+                )
+
             instance = self.instances[0]
             new_instance = copy.copy(instance)
 

--- a/autofit/non_linear/grid/grid_search/result.py
+++ b/autofit/non_linear/grid/grid_search/result.py
@@ -303,7 +303,12 @@ class GridSearchResult(AbstractGridSearchResult):
             The value to subtract from every log likelihood, for example if Bayesian model comparison is performed
             on the grid search and the subtracted value is the maximum log likelihood of a previous search.
         """
-        return [sample.log_evidence - relative_to_value for sample in self.samples]
+        return [
+            sample.log_evidence - relative_to_value
+            if sample.log_evidence is not None
+            else None
+            for sample in self.samples
+        ]
 
     def figure_of_merits(
         self, use_log_evidences: bool, relative_to_value: float = 0.0


### PR DESCRIPTION
## Summary

Two defensive fixes for edge cases surfaced by the Apr 10 release build:

1. **`interpolator.__getitem__`** — raises a clear `IndexError("Cannot interpolate: no instances have been added")` when the instances list is empty, instead of a cryptic `IndexError: list index out of range`.

2. **`grid_search_result.log_evidences()`** — handles `None` log_evidence values (which occur when a nested sampler doesn't compute evidence) by returning `None` in the list instead of crashing with `TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'`.

Relates to Jammy2211/PyAutoArray#269.

## API Changes
`GridSearchResult.log_evidences()` now returns `None` entries for samples where `log_evidence` is `None`, instead of raising `TypeError`. Callers that iterate the result should handle `None` values.

See full details below.

## Test Plan
- [x] `test_autofit/` — 1205 passed
- [ ] Release build re-run after merge

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `GridSearchResult.log_evidences()` — previously crashed if any sample had `log_evidence = None`. Now returns `None` for those entries instead of raising `TypeError`.
- `AbstractInterpolator.__getitem__()` — previously raised bare `IndexError` on empty instances. Now raises `IndexError` with descriptive message.

### Migration
No migration needed. Both changes are backwards-compatible — code that previously worked continues to work. Code that previously crashed now gets a meaningful error or a `None` value.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)