### PR TITLE
refactor: remove dead samples_cls and align Drawer with standard samples flow

### DIFF
--- a/autofit/non_linear/mock/mock_search.py
+++ b/autofit/non_linear/mock/mock_search.py
@@ -153,10 +153,6 @@ class MockMLE(MockSearch):
     def __init__(self, **kwargs):
         super().__init__(fit_fast=False, **kwargs)
 
-    @property
-    def samples_cls(self):
-        return MockMLE
-
     def project(
         self, factor_approx: FactorApproximation, status: Status = Status()
     ) -> Tuple[FactorApproximation, Status]:

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -1211,10 +1211,6 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             paths_override=paths,
         )
 
-    @property
-    def samples_cls(self):
-        raise NotImplementedError()
-
     def samples_from(self, model: AbstractPriorModel, search_internal=None) -> Samples:
         """
         Loads the samples of a non-linear search from its output files.

--- a/autofit/non_linear/search/mcmc/abstract_mcmc.py
+++ b/autofit/non_linear/search/mcmc/abstract_mcmc.py
@@ -4,7 +4,6 @@ from autoconf import conf
 from autofit.database.sqlalchemy_ import sa
 from autofit.non_linear.search.abstract_search import NonLinearSearch
 from autofit.non_linear.initializer import Initializer, InitializerBall
-from autofit.non_linear.samples import SamplesMCMC
 from autofit.non_linear.search.mcmc.auto_correlations import AutoCorrelationsSettings
 from autofit.non_linear.plot import corner_cornerpy
 
@@ -40,10 +39,6 @@ class AbstractMCMC(NonLinearSearch):
             session=session,
             **kwargs
         )
-
-    @property
-    def samples_cls(self):
-        return SamplesMCMC
 
     def plot_results(self, samples):
 

--- a/autofit/non_linear/search/mle/abstract_mle.py
+++ b/autofit/non_linear/search/mle/abstract_mle.py
@@ -3,7 +3,6 @@ from abc import ABC
 from autoconf import conf
 from autofit.non_linear.search.abstract_search import NonLinearSearch
 from autofit.non_linear.initializer import InitializerBall
-from autofit.non_linear.samples import Samples
 from autofit.non_linear.plot import subplot_parameters, log_likelihood_vs_iteration
 
 
@@ -16,10 +15,6 @@ class AbstractMLE(NonLinearSearch, ABC):
             ),
             **kwargs,
         )
-
-    @property
-    def samples_cls(self):
-        return Samples
 
     def plot_results(self, samples):
 

--- a/autofit/non_linear/search/mle/drawer/search.py
+++ b/autofit/non_linear/search/mle/drawer/search.py
@@ -143,7 +143,7 @@ class Drawer(AbstractMLE):
 
         return search_internal, fitness
 
-    def samples_from(self, model, search_internal):
+    def samples_via_internal_from(self, model, search_internal=None):
         search_internal_dict = self.paths.load_search_internal()
 
         parameter_lists = search_internal_dict["parameter_lists"]

--- a/autofit/non_linear/search/nest/abstract_nest.py
+++ b/autofit/non_linear/search/nest/abstract_nest.py
@@ -10,7 +10,6 @@ from autofit.non_linear.initializer import (
     AbstractInitializer,
     InitializerParamBounds,
 )
-from autofit.non_linear.samples import SamplesNest
 from autofit.non_linear.plot import corner_anesthetic
 
 
@@ -62,10 +61,6 @@ class AbstractNest(NonLinearSearch, ABC):
             session=session,
             **kwargs
         )
-
-    @property
-    def samples_cls(self):
-        return SamplesNest
 
     def plot_results(self, samples):
 

--- a/test_autofit/graphical/regression/test_static.py
+++ b/test_autofit/graphical/regression/test_static.py
@@ -22,10 +22,6 @@ class StaticSearch(af.NonLinearSearch):
     def _fit(self, model, analysis):
         pass
 
-    @property
-    def samples_cls(self):
-        pass
-
     def samples_from(self, model):
         pass
 


### PR DESCRIPTION
## Summary

Remove the unused `samples_cls` property from all search classes — it was defined in 5 places but never called anywhere. Convert `Drawer` to use `samples_via_internal_from` instead of overriding `samples_from`, so it follows the same pattern as every other search class.

Closes #1203

## API Changes

None — internal changes only.

## Test Plan

- [x] Full test suite passes (1205 tests)
- [ ] Smoke test workspace scripts

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- `AbstractSearch.samples_cls` — dead property, never called
- `AbstractMLE.samples_cls` — dead property override
- `AbstractMCMC.samples_cls` — dead property override
- `AbstractNest.samples_cls` — dead property override
- `MockMLE.samples_cls` — dead property override

### Changed Behaviour
- `Drawer` now implements `samples_via_internal_from` instead of overriding `samples_from`. No change in external behaviour — `samples_from` on the base class delegates to `samples_via_internal_from` automatically.

### Migration
No migration needed — `samples_cls` was never called externally.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)