### PR TITLE
fix: pin autoconf dependency version and update homepage URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 keywords = ["cli"]
 dependencies = [
-    "autoconf",
+    "autoconf==2026.4.13.3",
     "array_api_compat",
     "anesthetic==2.8.14; python_version < '3.13'",
     "anesthetic>=2.9.0; python_version >= '3.13'",
@@ -50,7 +50,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/rhayes777/PyAutoFit"
+Homepage = "https://github.com/PyAutoLabs/PyAutoFit"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary
- Pin `autoconf` to exact version (`==2026.4.13.3`) so pip cannot resolve to the wrong PyPI package (GNU autoconf 0.7.7)
- Update homepage URL from `rhayes777/PyAutoFit` to `PyAutoLabs/PyAutoFit`
- The release workflow will auto-update the pinned version via sed

## Test plan
- [ ] `pip install` resolves `autoconf` to the correct PyAuto package
- [ ] Release workflow sed pattern matches and updates the pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)