### PR TITLE
fix: suppress CLI noise from escape sequences and third-party warnings

### DIFF
--- a/autofit/mapper/operator.py
+++ b/autofit/mapper/operator.py
@@ -9,7 +9,7 @@ from autoconf import cached_property
 
 
 class LinearOperator(ABC):
-    """Implements the functionality of a linear operator.
+    r"""Implements the functionality of a linear operator.
 
     All linear operators can be expressed as a tensor/matrix
     However for some it there may be more efficient representations

--- a/autofit/mapper/prior/gaussian.py
+++ b/autofit/mapper/prior/gaussian.py
@@ -15,7 +15,7 @@ class GaussianPrior(Prior):
         sigma: float,
         id_: Optional[int] = None,
     ):
-        """
+        r"""
         A Gaussian prior defined by a normal distribution.
 
         The prior transforms a unit interval input `u` in [0, 1] into a physical parameter `p` via

--- a/autofit/mapper/prior/log_gaussian.py
+++ b/autofit/mapper/prior/log_gaussian.py
@@ -18,7 +18,7 @@ class LogGaussianPrior(Prior):
         sigma: float,
         id_: Optional[int] = None,
     ):
-        """
+        r"""
         A prior for a variable whose logarithm is gaussian distributed. Work in natural log.
 
         The conversion of an input unit value, ``u``, to a physical value, ``p``, via the prior is as follows:

--- a/autofit/mapper/prior/truncated_gaussian.py
+++ b/autofit/mapper/prior/truncated_gaussian.py
@@ -16,7 +16,7 @@ class TruncatedGaussianPrior(Prior):
         upper_limit: float = float("inf"),
         id_: Optional[int] = None,
     ):
-        """
+        r"""
         A Gaussian prior defined by a normal distribution with optional truncation limits.
 
         This prior represents a Gaussian (normal) distribution with mean `mean`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,8 @@ dev = ["pytest", "black"]
 
 [tool.pytest.ini_options]
 testpaths = ["test_autofit"]
+filterwarnings = [
+    "ignore:cuda_plugin_extension:UserWarning",
+    "ignore::DeprecationWarning:jax",
+    "ignore:relationship .* will copy column:sqlalchemy.exc.SAWarning",
+]

--- a/test_autofit/graphical/test_combined_analysis.py
+++ b/test_autofit/graphical/test_combined_analysis.py
@@ -37,7 +37,7 @@ def test_make_result():
     assert child_result.model == model
 
 
-class TestAnalysis(af.Analysis):
+class MockAnalysis(af.Analysis):
     def __init__(self):
         super().__init__()
         calls = []
@@ -81,7 +81,7 @@ class TestAnalysis(af.Analysis):
 
 @pytest.fixture
 def analysis():
-    return TestAnalysis()
+    return MockAnalysis()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Suppress CLI noise during test collection by converting docstrings with LaTeX math to raw strings, renaming a test class that triggered PytestCollectionWarning, and adding pytest warning filters for JAX CUDA, JAX deprecations, and SQLAlchemy relationship warnings.

Closes #1209

## API Changes
None — internal changes only.

## Test Plan
- [x] All 1205 unit tests pass
- [x] `pytest --co` produces zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)