### PR TITLE
feat: background thread for on-the-fly visualization

### DIFF
--- a/autofit/config/general.yaml
+++ b/autofit/config/general.yaml
@@ -1,6 +1,7 @@
 updates:
   iterations_per_quick_update: 1e99 # Non-linear search iterations between every quick update, which just displays the maximum likelihood model fit.
-  iterations_per_full_update: 1e99  # Non-linear search iterations between every full update, which outputs all visuals and result fits (e.g. model.result, search.summary), this exits the search and can be slow.  
+  iterations_per_full_update: 1e99  # Non-linear search iterations between every full update, which outputs all visuals and result fits (e.g. model.result, search.summary), this exits the search and can be slow.
+  quick_update_background: false    # If True, quick-update visualization runs on a background thread so sampling is not blocked.
 hpc:
   hpc_mode: false                   # If True, use HPC mode, which disables GUI visualization, logging to screen and other settings which are not suited to running on a super computer.
   iterations_per_quick_update: 1e99 #  Non-linear search iterations between every quick update, which just displays the maximum likelihood model fit.

--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -299,6 +299,16 @@ class Analysis(ABC):
             analysis=analysis,
         )
 
+    @property
+    def supports_background_update(self) -> bool:
+        """Whether this analysis supports background quick updates."""
+        return False
+
+    @property
+    def supports_jax_visualization(self) -> bool:
+        """Whether the visualizer can work directly with JAX arrays."""
+        return False
+
     def perform_quick_update(self, paths, instance):
         raise NotImplementedError
 

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -44,6 +44,7 @@ class Fitness:
         use_jax_vmap : bool = False,
         batch_size : Optional[int] = None,
         iterations_per_quick_update: Optional[int] = None,
+        background_quick_update: bool = False,
     ):
         """
         Interfaces with any non-linear search to fit the model to the data and return a log likelihood via
@@ -128,6 +129,20 @@ class Fitness:
         self.quick_update_max_lh_parameters = None
         self.quick_update_max_lh = -self._xp.inf
         self.quick_update_count = 0
+
+        self._background_quick_update = None
+
+        if background_quick_update and self.iterations_per_quick_update is not None:
+            from autofit.non_linear.quick_update import BackgroundQuickUpdate
+
+            convert_jax = (
+                getattr(self.analysis, "_use_jax", False)
+                and not getattr(self.analysis, "supports_jax_visualization", False)
+            )
+
+            self._background_quick_update = BackgroundQuickUpdate(
+                convert_jax=convert_jax,
+            )
 
         if self.paths is not None:
             self.check_log_likelihood(fitness=self)
@@ -314,10 +329,15 @@ class Fitness:
 
             instance = self.model.instance_from_vector(vector=self.quick_update_max_lh_parameters, xp=self._xp)
 
-            try:
-                self.analysis.perform_quick_update(self.paths, instance)
-            except NotImplementedError:
-                pass
+            if self._background_quick_update is not None:
+                self._background_quick_update.submit(
+                    self.analysis, self.paths, instance,
+                )
+            else:
+                try:
+                    self.analysis.perform_quick_update(self.paths, instance)
+                except NotImplementedError:
+                    pass
 
             result_info = text_util.result_max_lh_info_from(
                 max_log_likelihood_sample=self.quick_update_max_lh_parameters.tolist(),
@@ -332,6 +352,12 @@ class Fitness:
             self.quick_update_count = 0
 
             logger.info(f"Quick update complete in {time.time() - start_time} seconds.")
+
+    def shutdown_quick_update(self):
+        """Shut down the background quick-update worker, if one is running."""
+        if self._background_quick_update is not None:
+            self._background_quick_update.shutdown()
+            self._background_quick_update = None
 
     @timeout(timeout_seconds)
     def __call__(self, parameters, *kwargs):

--- a/autofit/non_linear/quick_update.py
+++ b/autofit/non_linear/quick_update.py
@@ -1,0 +1,107 @@
+import copy
+import logging
+import threading
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def _convert_jax_to_numpy(instance):
+    """
+    Return a deep copy of *instance* with every JAX array replaced by a
+    NumPy array.  Plain NumPy values and non-array attributes are left
+    unchanged.
+
+    This is used so that the background visualisation thread never
+    touches JAX / GPU state, which is not thread-safe.
+    """
+    instance = copy.deepcopy(instance)
+
+    for attr in vars(instance):
+        value = getattr(instance, attr)
+        if hasattr(value, "device"):
+            setattr(instance, attr, np.asarray(value))
+
+    return instance
+
+
+class BackgroundQuickUpdate:
+    """
+    Runs ``analysis.perform_quick_update`` on a background daemon thread so
+    that the sampler is not blocked while matplotlib renders and saves plots.
+
+    Uses a **latest-only** pattern: if a new best-fit arrives before the
+    previous visualisation finishes, the stale request is silently replaced.
+
+    Parameters
+    ----------
+    convert_jax
+        If ``True``, JAX arrays on the model instance are converted to
+        NumPy before handing them to the worker thread.
+    """
+
+    def __init__(self, convert_jax: bool = False):
+        self._convert_jax = convert_jax
+
+        self._lock = threading.Lock()
+        self._pending = None
+        self._has_work = threading.Event()
+        self._stop = threading.Event()
+
+        self._thread = threading.Thread(
+            target=self._worker,
+            daemon=True,
+            name="quick-update-worker",
+        )
+        self._thread.start()
+
+    def submit(self, analysis, paths, instance):
+        """
+        Enqueue a quick-update request.  If a previous request is still
+        pending (not yet picked up by the worker), it is replaced.
+        """
+
+        if self._convert_jax:
+            instance = _convert_jax_to_numpy(instance)
+
+        with self._lock:
+            self._pending = (analysis, paths, instance)
+
+        self._has_work.set()
+
+    def shutdown(self, timeout: float = 10.0):
+        """Signal the worker to stop after draining pending work."""
+        self._stop.set()
+        self._has_work.set()
+        self._thread.join(timeout=timeout)
+
+    def _process_pending(self):
+        with self._lock:
+            work = self._pending
+            self._pending = None
+
+        if work is None:
+            return
+
+        analysis, paths, instance = work
+
+        try:
+            analysis.perform_quick_update(paths, instance)
+        except NotImplementedError:
+            pass
+        except Exception:
+            logger.exception(
+                "Background quick-update raised an exception (ignored)."
+            )
+
+    def _worker(self):
+        while True:
+            self._has_work.wait()
+            self._has_work.clear()
+
+            self._process_pending()
+
+            if self._stop.is_set():
+                self._process_pending()
+                break

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -214,6 +214,12 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         self.iterations_per_full_update = float((iterations_per_full_update or
             conf.instance["general"]["updates"]["iterations_per_full_update"]))
 
+        self.quick_update_background = bool(
+            conf.instance["general"]["updates"].get(
+                "quick_update_background", False,
+            )
+        )
+
         if conf.instance["general"]["hpc"]["hpc_mode"]:
             self.iterations_per_quick_update = float(conf.instance["general"]["hpc"][
                 "iterations_per_quick_update"
@@ -663,6 +669,9 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
             model=model,
             analysis=analysis,
         )
+
+        if hasattr(fitness, "shutdown_quick_update"):
+            fitness.shutdown_quick_update()
 
         samples = self.perform_update(
             model=model,

--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -192,6 +192,7 @@ class Nautilus(abstract_nest.AbstractNest):
                 fom_is_log_likelihood=True,
                 resample_figure_of_merit=-1.0e99,
                 iterations_per_quick_update=self.iterations_per_quick_update,
+                background_quick_update=self.quick_update_background,
                 use_jax_vmap=self.use_jax_vmap,
                 batch_size=self.n_batch,
             )
@@ -210,7 +211,8 @@ class Nautilus(abstract_nest.AbstractNest):
                 paths=self.paths,
                 fom_is_log_likelihood=True,
                 resample_figure_of_merit=-1.0e99,
-                iterations_per_quick_update=self.iterations_per_quick_update
+                iterations_per_quick_update=self.iterations_per_quick_update,
+                background_quick_update=self.quick_update_background,
             )
 
             search_internal = self.fit_multiprocessing(

--- a/test_autofit/non_linear/test_quick_update.py
+++ b/test_autofit/non_linear/test_quick_update.py
@@ -1,0 +1,163 @@
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from autofit.non_linear.quick_update import BackgroundQuickUpdate, _convert_jax_to_numpy
+
+
+class MockPaths:
+    pass
+
+
+class MockAnalysis:
+    """Records calls to perform_quick_update for assertions."""
+
+    def __init__(self, delay=0.0):
+        self.calls = []
+        self._lock = threading.Lock()
+        self._delay = delay
+
+    def perform_quick_update(self, paths, instance):
+        if self._delay:
+            time.sleep(self._delay)
+        with self._lock:
+            self.calls.append(instance)
+
+
+class ErrorAnalysis:
+    """Always raises from perform_quick_update."""
+
+    def perform_quick_update(self, paths, instance):
+        raise RuntimeError("Visualization failed")
+
+
+class TestBackgroundQuickUpdate:
+    def test_single_submit(self):
+        analysis = MockAnalysis()
+        worker = BackgroundQuickUpdate()
+
+        worker.submit(analysis, MockPaths(), "instance_1")
+        worker.shutdown()
+
+        assert analysis.calls == ["instance_1"]
+
+    def test_latest_only(self):
+        """When multiple submits happen before the worker picks up, only the
+        last one should be processed."""
+        analysis = MockAnalysis(delay=0.2)
+        worker = BackgroundQuickUpdate()
+
+        # First submit — will be picked up and start processing (with delay)
+        worker.submit(analysis, MockPaths(), "instance_1")
+        time.sleep(0.05)  # let the worker pick it up and start processing
+
+        # These two land while the worker is busy with instance_1
+        worker.submit(analysis, MockPaths(), "instance_2")
+        worker.submit(analysis, MockPaths(), "instance_3")
+
+        worker.shutdown()
+
+        # instance_1 was already being processed, instance_3 replaces instance_2
+        assert analysis.calls == ["instance_1", "instance_3"]
+
+    def test_shutdown_joins_cleanly(self):
+        worker = BackgroundQuickUpdate()
+        worker.shutdown(timeout=2.0)
+        assert not worker._thread.is_alive()
+
+    def test_exception_does_not_crash(self):
+        analysis = ErrorAnalysis()
+        worker = BackgroundQuickUpdate()
+
+        worker.submit(analysis, MockPaths(), "instance")
+        time.sleep(0.1)  # let the worker process it
+
+        # Worker should still be alive and functional
+        assert worker._thread.is_alive()
+        worker.shutdown()
+
+    def test_exception_followed_by_valid(self):
+        """After an exception, subsequent submits should still work."""
+        error_analysis = ErrorAnalysis()
+        good_analysis = MockAnalysis()
+        worker = BackgroundQuickUpdate()
+
+        worker.submit(error_analysis, MockPaths(), "bad")
+        time.sleep(0.1)
+
+        worker.submit(good_analysis, MockPaths(), "good")
+        worker.shutdown()
+
+        assert good_analysis.calls == ["good"]
+
+
+class TestConvertJaxToNumpy:
+    def test_converts_array_with_device_attr(self):
+        class FakeJaxArray:
+            def __init__(self, data):
+                self.data = data
+                self.device = "gpu:0"
+
+            def __array__(self, dtype=None):
+                return np.array(self.data, dtype=dtype)
+
+        class Instance:
+            def __init__(self):
+                self.param = FakeJaxArray([1.0, 2.0, 3.0])
+                self.name = "test"
+
+        instance = Instance()
+        converted = _convert_jax_to_numpy(instance)
+
+        assert isinstance(converted.param, np.ndarray)
+        np.testing.assert_array_equal(converted.param, [1.0, 2.0, 3.0])
+        assert converted.name == "test"
+        # Original should be unchanged
+        assert hasattr(instance.param, "device")
+
+    def test_leaves_plain_values_alone(self):
+        class Instance:
+            def __init__(self):
+                self.x = 1.0
+                self.arr = np.array([1, 2])
+
+        instance = Instance()
+        converted = _convert_jax_to_numpy(instance)
+
+        assert converted.x == 1.0
+        np.testing.assert_array_equal(converted.arr, [1, 2])
+
+
+class TestConvertJaxFlag:
+    def test_convert_jax_false(self):
+        analysis = MockAnalysis()
+        worker = BackgroundQuickUpdate(convert_jax=False)
+
+        obj = {"key": "value"}  # not a real instance, just checking pass-through
+        worker.submit(analysis, MockPaths(), obj)
+        worker.shutdown()
+
+        assert analysis.calls[0] is obj
+
+    def test_convert_jax_true(self):
+        class FakeJaxArray:
+            def __init__(self, data):
+                self.data = data
+                self.device = "gpu:0"
+
+            def __array__(self, dtype=None):
+                return np.array(self.data, dtype=dtype)
+
+        class Instance:
+            def __init__(self):
+                self.param = FakeJaxArray([1.0])
+
+        analysis = MockAnalysis()
+        worker = BackgroundQuickUpdate(convert_jax=True)
+
+        worker.submit(analysis, MockPaths(), Instance())
+        worker.shutdown()
+
+        assert isinstance(analysis.calls[0].param, np.ndarray)


### PR DESCRIPTION
## Summary
Run `perform_quick_update` on a background daemon thread so the sampler is not blocked while matplotlib renders and saves plots. Uses a latest-only queue — new best-fits silently replace stale pending requests. Opt-in via `quick_update_background: true` in `general.yaml`.

## API Changes
- Added `BackgroundQuickUpdate` class in `autofit.non_linear.quick_update`
- Added `supports_background_update` and `supports_jax_visualization` properties on `Analysis`
- Added `background_quick_update` parameter to `Fitness.__init__`
- Added `quick_update_background` config option under `updates:` in `general.yaml`

No removals or breaking changes. See full details below.

## Test Plan
- [x] 9 new tests for BackgroundQuickUpdate (latest-only, shutdown, exception handling, JAX conversion)
- [x] Full PyAutoFit suite: 1214 passed
- [x] Full PyAutoGalaxy suite: 834 passed

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autofit.non_linear.quick_update.BackgroundQuickUpdate` — daemon thread worker for background visualization
- `autofit.non_linear.quick_update._convert_jax_to_numpy(instance)` — deep-copy with JAX→numpy conversion
- `Analysis.supports_background_update` property (default `False`)
- `Analysis.supports_jax_visualization` property (default `False`)
- `Fitness.__init__(..., background_quick_update=False)` parameter
- `Fitness.shutdown_quick_update()` method
- Config `general.yaml` → `updates.quick_update_background` (default `false`)

### Migration
- No migration needed — feature is opt-in via config

</details>

Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)