### PR TITLE
fix: normalize panel sizes in AggregateImages composite output

### DIFF
--- a/autofit/aggregator/summary/aggregate_images.py
+++ b/autofit/aggregator/summary/aggregate_images.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Optional, List, Union, Callable, Type
+from typing import Optional, List, Tuple, Union, Callable, Type
 from pathlib import Path
 
 from PIL import Image
@@ -104,6 +104,7 @@ class AggregateImages:
         subplots: List[Union[Enum, List[Image.Image], Callable]],
         subplot_width: Optional[int] = sys.maxsize,
         transpose: bool = False,
+        panel_size: Optional[Tuple[int, int]] = None,
     ) -> Image.Image:
         """
         Extract the images at the specified subplots and combine them into
@@ -126,6 +127,12 @@ class AggregateImages:
         transpose
             If True the output image is transposed before being returned, else it
             is returned as is.
+        panel_size
+            If provided, all extracted panels are resized to this `(width, height)`
+            before compositing. If `None` (the default), panels are resized to the
+            maximum width and height across all panels, so that panels extracted
+            from source images with different grid layouts end up the same size
+            in the output.
 
         Returns
         -------
@@ -146,6 +153,8 @@ class AggregateImages:
 
             matrix = [list(row) for row in zip(*matrix)]
 
+        matrix = self._normalize_panel_sizes(matrix, panel_size=panel_size)
+
         return self._matrix_to_image(matrix)
 
     def output_to_folder(
@@ -154,6 +163,7 @@ class AggregateImages:
         name: Union[str, List[str]],
         subplots: List[Union[List[Image.Image], Callable]],
         subplot_width: Optional[int] = sys.maxsize,
+        panel_size: Optional[Tuple[int, int]] = None,
     ):
         """
         Output one subplot image for each fit in the aggregator.
@@ -176,6 +186,12 @@ class AggregateImages:
         name
             The attribute of each fit to use as the name of the output file.
             OR a list of names, one for each fit.
+        panel_size
+            If provided, all extracted panels are resized to this `(width, height)`
+            before compositing. If `None` (the default), panels are resized to the
+            maximum width and height across all panels, so that panels extracted
+            from source images with different grid layouts end up the same size
+            in the output.
         """
         if len(subplots) == 0:
             raise ValueError("At least one subplot must be provided.")
@@ -183,14 +199,16 @@ class AggregateImages:
         folder.mkdir(exist_ok=True, parents=True)
 
         for i, result in enumerate(self._aggregator):
-            image = self._matrix_to_image(
+            matrix = self._normalize_panel_sizes(
                 self._matrix_for_result(
                     i,
                     result,
                     subplots,
                     subplot_width=subplot_width,
-                )
+                ),
+                panel_size=panel_size,
             )
+            image = self._matrix_to_image(matrix)
 
             if isinstance(name, str):
                 output_name = getattr(result, name)
@@ -291,6 +309,38 @@ class AggregateImages:
             matrix.append(row)
 
         return matrix
+
+    @staticmethod
+    def _normalize_panel_sizes(
+        matrix: List[List[Image.Image]],
+        panel_size: Optional[Tuple[int, int]] = None,
+    ) -> List[List[Image.Image]]:
+        """
+        Resize every panel in the matrix to a common `(width, height)` so that
+        panels extracted from source images with different grid layouts are the
+        same size when composited.
+
+        If `panel_size` is `None`, the target size is the maximum width and
+        height across all panels in the matrix. LANCZOS resampling is used to
+        preserve image quality.
+        """
+        if not matrix:
+            return matrix
+
+        if panel_size is None:
+            max_width = max(image.width for row in matrix for image in row)
+            max_height = max(image.height for row in matrix for image in row)
+            target = (max_width, max_height)
+        else:
+            target = panel_size
+
+        return [
+            [
+                image if image.size == target else image.resize(target, Image.LANCZOS)
+                for image in row
+            ]
+            for row in matrix
+        ]
 
     @staticmethod
     def _matrix_to_image(matrix: List[List[Image.Image]]) -> Image.Image:

--- a/test_autofit/aggregator/summary_files/test_aggregate_images.py
+++ b/test_autofit/aggregator/summary_files/test_aggregate_images.py
@@ -152,7 +152,7 @@ def test_custom_images(
         ]
     )
 
-    assert result.size == (193, 120)
+    assert result.size == (244, 120)
 
 
 def test_custom_function(aggregate):
@@ -168,7 +168,30 @@ def test_custom_function(aggregate):
         ]
     )
 
-    assert result.size == (193, 120)
+    assert result.size == (244, 120)
+
+
+def test_panel_size_explicit_normalizes_all_panels(aggregate, aggregator):
+    small = Image.new("RGB", (10, 10), "white")
+    images = [small for _ in aggregator]
+
+    result = aggregate.extract_image(
+        [SubplotFit.Data, images],
+        panel_size=(50, 50),
+    )
+
+    assert result.size == (100, 100)
+
+
+def test_panel_size_defaults_to_max(aggregate, aggregator):
+    small = Image.new("RGB", (10, 10), "white")
+    images = [small for _ in aggregator]
+
+    result = aggregate.extract_image(
+        [SubplotFit.Data, images],
+    )
+
+    assert result.size == (122, 120)
 
 
 def test_custom_subplot_fit(aggregate):


### PR DESCRIPTION
## Summary

When `AggregateImages.output_to_folder` or `extract_image` combined panels from source images with different grid layouts (e.g. a 2x2 `rgb.png` and a 4x3 `subplot_fit.png`), panels were pasted at their native pixel sizes. The RGB panel appeared roughly half the width and height of the fit panels in the composite. Closes #1213.

## API Changes

`AggregateImages.extract_image` and `AggregateImages.output_to_folder` now resize every extracted panel to a common size before compositing. The default target is the maximum width and height across all panels (no user action needed to get consistent panel sizes). A new optional `panel_size=(width, height)` keyword argument was added to both methods to override the default. See full details below.

## Test Plan
- [x] `pytest test_autofit/aggregator/summary_files/test_aggregate_images.py` — 13 passed
- [x] `pytest test_autofit/aggregator/` — 49 passed

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `AggregateImages.extract_image(..., panel_size: Optional[Tuple[int, int]] = None)` — new keyword argument. If provided, all panels are resized to this `(width, height)`. If `None`, panels are resized to the max width and height across all panels.
- `AggregateImages.output_to_folder(..., panel_size: Optional[Tuple[int, int]] = None)` — new keyword argument with the same semantics as above.
- `AggregateImages._normalize_panel_sizes(matrix, panel_size=None)` — internal staticmethod that performs the LANCZOS resizing pass.

### Changed Behaviour
- `AggregateImages.extract_image` and `AggregateImages.output_to_folder` now always resize panels to a common size before compositing. Previously, panels from source images with different grid layouts composited at mismatched sizes. Callers that relied on the previous behaviour (mixed-size panels in the composite) will see different output dimensions; this is the fix.

### Migration
- No action required for the default case — the fix is transparent and produces visually-consistent panels.
- If you want panels at a specific size (e.g. for printing), pass `panel_size=(width, height)`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)