### PR TITLE
fix: numpy-2.x safety in SamplesMCMC.median_pdf

### DIFF
--- a/autofit/non_linear/samples/mcmc.py
+++ b/autofit/non_linear/samples/mcmc.py
@@ -144,7 +144,7 @@ class SamplesMCMC(SamplesPDF):
 
         if self.pdf_converged:
             return [
-                float(np.percentile(self.parameters_extract[i, :], [50]))
+                float(np.percentile(self.parameters_extract[i, :], 50))
                 for i in range(self.model.prior_count)
             ]
 


### PR DESCRIPTION
## Summary
- `np.percentile(arr, [50])` returns a shape-(1,) ndarray; `float()` on that is a deprecated conversion that errors on numpy >= 2.4.
- Pass `50` (scalar) instead of `[50]` (list) so the result is scalar and `float()` is safe.

## Why
This blocks `searches/Emcee.py` in the `autofit_workspace_test` smoke tests on Python 3.13 + numpy 2.4. The script was previously disabled via a commented line in `smoke_tests.txt`. Once this ships, a companion PR in `autofit_workspace_test` will re-enable it.

## Test plan
- [x] `pytest test_autofit/non_linear/samples` — 31 passed
- [x] `scripts/searches/Emcee.py` with `PYAUTO_TEST_MODE=1` (real sampler) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)