### PR TITLE
chore(docs): remove unused pyprojroot dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,6 @@ gprof2dot==2021.2.21
 matplotlib
 networkx
 numpydoc>=1.0.0
-pyprojroot==0.2.0
 
 h5py>=2.10.0
 SQLAlchemy==1.3.20


### PR DESCRIPTION
## Summary
- Drops the unused `pyprojroot==0.2.0` line from `docs/requirements.txt` — it isn't imported anywhere in `docs/conf.py` or in the source tree.

## Test plan
- [x] readthedocs build (will run automatically on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)