### PR TITLE
feat(dynesty): support JAX-jitted likelihoods via use_jax_jit

### DIFF
--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -42,6 +42,7 @@ class Fitness:
         convert_to_chi_squared: bool = False,
         store_history: bool = False,
         use_jax_vmap : bool = False,
+        use_jax_jit : bool = False,
         batch_size : Optional[int] = None,
         iterations_per_quick_update: Optional[int] = None,
         background_quick_update: bool = False,
@@ -118,11 +119,14 @@ class Fitness:
         self.log_likelihood_history_list = []
 
         self.use_jax_vmap = use_jax_vmap
+        self.use_jax_jit = use_jax_jit
 
         self._call = self.call
 
         if self.use_jax_vmap:
             self._call = self._vmap
+        elif self.use_jax_jit:
+            self._call = self._jit
 
         self.batch_size = batch_size
         self.iterations_per_quick_update = iterations_per_quick_update
@@ -234,6 +238,9 @@ class Fitness:
                 parameters = np.array(parameters)[None, :]
 
         figure_of_merit = self._call(parameters)
+
+        if self.use_jax_jit:
+            figure_of_merit = float(figure_of_merit)
 
         if self.convert_to_chi_squared:
             log_likelihood = -0.5 * figure_of_merit
@@ -382,15 +389,22 @@ class Fitness:
         """
         return self.call_wrap(parameters)
 
-    # def __getstate__(self):
-    #     state = self.__dict__.copy()
-    #     # Remove non-pickleable attributes
-    #     state.pop('_call', None)
-    #     state.pop('_grad', None)
-    #     return state
-    #
-    # def __setstate__(self, state):
-    #     self.__dict__.update(state)
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Strip JAX-compiled callables: jax.jit / jax.vmap / jax.grad return
+        # functions tied to C++ XLA state that can't roundtrip through pickle.
+        # cached_property values lazily recompile on first access after unpickle.
+        for attr in ("_call", "_jit", "_vmap", "_grad"):
+            state.pop(attr, None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._call = self.call
+        if getattr(self, "use_jax_vmap", False):
+            self._call = self._vmap
+        elif getattr(self, "use_jax_jit", False):
+            self._call = self._jit
 
     @cached_property
     def _vmap(self):

--- a/autofit/non_linear/search/nest/dynesty/search/abstract.py
+++ b/autofit/non_linear/search/nest/dynesty/search/abstract.py
@@ -53,6 +53,7 @@ class AbstractDynesty(AbstractNest, ABC):
         number_of_cores: int = 1,
         silence: bool = False,
         force_x1_cpu: bool = False,
+        use_jax_jit: bool = True,
         session: Optional[sa.orm.Session] = None,
         **kwargs,
     ):
@@ -117,6 +118,7 @@ class AbstractDynesty(AbstractNest, ABC):
 
         self.maxcall = maxcall
         self.force_x1_cpu = force_x1_cpu
+        self.use_jax_jit = use_jax_jit
 
         self.logger.debug(f"Creating {self.__class__.__name__} Search")
 
@@ -179,6 +181,7 @@ class AbstractDynesty(AbstractNest, ABC):
             paths=self.paths,
             fom_is_log_likelihood=True,
             resample_figure_of_merit=-1.0e99,
+            use_jax_jit=getattr(analysis, "_use_jax", False) and self.use_jax_jit,
         )
 
         if not isinstance(self.paths, NullPaths):
@@ -225,13 +228,22 @@ class AbstractDynesty(AbstractNest, ABC):
 
             except RuntimeError:
                 if not checkpoint_exists:
-                    self.logger.info(
-                        """
-                        Your operating system does not support Python multiprocessing.
+                    if getattr(analysis, "_use_jax", False):
+                        self.logger.info(
+                            "Running Dynesty with JAX-jitted likelihood (single CPU, no pool)."
+                        )
+                    elif self.force_x1_cpu:
+                        self.logger.info(
+                            "Running Dynesty single-CPU per `force_x1_cpu=True` (no pool)."
+                        )
+                    else:
+                        self.logger.info(
+                            """
+                            Your operating system does not support Python multiprocessing.
 
-                        A single CPU non-multiprocessing Dynesty run is being performed.
-                        """
-                    )
+                            A single CPU non-multiprocessing Dynesty run is being performed.
+                            """
+                        )
 
                 search_internal = self.search_internal_from(
                     model=model,

--- a/test_autofit/non_linear/test_dict.py
+++ b/test_autofit/non_linear/test_dict.py
@@ -43,6 +43,7 @@ def make_dynesty_dict():
             "slices": 5,
             "unique_tag": None,
             "update_interval": None,
+            "use_jax_jit": True,
             "walks": 5,
         },
         "class_path": "autofit.non_linear.search.nest.dynesty.search.static.DynestyStatic",

--- a/test_autofit/non_linear/test_fitness_jax_dispatch.py
+++ b/test_autofit/non_linear/test_fitness_jax_dispatch.py
@@ -1,0 +1,67 @@
+import pickle
+
+import numpy as np
+
+import autofit as af
+from autofit.non_linear.fitness import Fitness
+
+
+def _make_fitness(**kwargs):
+    model = af.Model(af.ex.Gaussian)
+    data = np.ones(20)
+    noise_map = np.ones(20) * 0.1
+    analysis = af.ex.Analysis(data=data, noise_map=noise_map)
+    return Fitness(model=model, analysis=analysis, **kwargs)
+
+
+def test_default_dispatch_is_call():
+    fitness = _make_fitness()
+    # `self.call` produces a fresh bound method each access — compare the
+    # underlying function instead of the bound-method instance.
+    assert fitness._call.__func__ is Fitness.call
+    assert fitness.use_jax_jit is False
+    assert fitness.use_jax_vmap is False
+
+
+def test_jit_dispatch_sets_call_to_jit():
+    fitness = _make_fitness(use_jax_jit=True)
+    assert fitness.use_jax_jit is True
+    assert fitness._call is fitness._jit
+
+
+def test_vmap_takes_precedence_over_jit():
+    fitness = _make_fitness(use_jax_jit=True, use_jax_vmap=True)
+    assert fitness._call is fitness._vmap
+
+
+def test_pickle_strips_jax_cached_attrs():
+    """
+    Dynesty's checkpoint writes pickle the loglikelihood. JAX-compiled
+    callables (jax.jit / jax.vmap / jax.grad) carry C++ XLA state that
+    cannot roundtrip through pickle. ``Fitness.__getstate__`` must drop
+    them; ``Fitness.__setstate__`` re-derives the dispatch on resume.
+    """
+    fitness = _make_fitness(use_jax_jit=True)
+
+    state = fitness.__getstate__()
+    assert "_call" not in state
+    assert "_jit" not in state
+    assert "_vmap" not in state
+    assert "_grad" not in state
+
+    blob = pickle.dumps(fitness)
+    restored = pickle.loads(blob)
+
+    assert restored.use_jax_jit is True
+    assert restored._call is restored._jit
+
+
+def test_pickle_default_path_unchanged():
+    fitness = _make_fitness()
+
+    blob = pickle.dumps(fitness)
+    restored = pickle.loads(blob)
+
+    assert restored.use_jax_jit is False
+    assert restored.use_jax_vmap is False
+    assert restored._call.__func__ is Fitness.call


### PR DESCRIPTION
## Summary

- Adds `jax.jit` likelihood support to `DynestyStatic` / `DynestyDynamic`. When `analysis._use_jax=True`, dynesty now runs against a `jax.jit`-compiled likelihood, mirroring (but not duplicating) the existing Nautilus JAX-vmap path.
- Re-enables `Fitness.__getstate__` / `__setstate__` to strip JAX-compiled callables before pickle — required because dynesty's `run_nested(checkpoint_file=...)` pickles the loglikelihood, and JAX-compiled functions hold C++ XLA state that doesn't roundtrip.
- Three-way branch in dynesty's no-pool fallback log message (JAX / force_x1_cpu / OS multiprocessing) — the previous single message was misleading.

## Why

Follow-up to PyAutoFit#1240 (Nautilus_jax merged). The user wants the same fast-CPU/GPU likelihood path on dynesty for inference workloads where Nautilus isn't preferred. Explicitly **no autodiff** — just `jax.jit`, no `jax.grad` or HMC plumbing.

dynesty 2.1.5 has no `vectorized` parameter (verified against the installed package), so Nautilus's vmap-batching approach doesn't apply. `jax.jit` alone wins here: JAX caches compiled functions by argument signature, so dynesty's one-sample-at-a-time call pattern still benefits from compilation.

## Hard blocker uncovered during planning

`Fitness.__getstate__` / `__setstate__` were commented out at `fitness.py:385-393` (with a TODO referencing `_call` and `_grad`). Once `self._call = self._jit` is assigned, the `cached_property` materializes a `jax.jit`-compiled function — **not pickleable**. Without the fix, dynesty's first checkpoint write would crash. Re-enabled and extended to also cover `_jit` and `_vmap`. `__setstate__` re-derives the dispatch on resume so the cached_property recompiles lazily.

## API

```python
from autofit.jax.pytrees import enable_pytrees, register_model

enable_pytrees()
model = af.Model(af.ex.Gaussian)
register_model(model)
analysis = af.ex.Analysis(data=data, noise_map=noise_map, use_jax=True)

# Default: jit auto-on when analysis._use_jax. Disable with use_jax_jit=False.
search = af.DynestyStatic(nlive=30)
result = search.fit(model=model, analysis=analysis)
```

Stdout includes `JAX: Applying jit to likelihood function` (analogous to Nautilus's `JAX: Applying vmap and jit...`) and `Running Dynesty with JAX-jitted likelihood (single CPU, no pool).` from the new log branch.

## Tests

- 5 new unit tests in `test_fitness_jax_dispatch.py` cover dispatch + pickle round-trip. Per project policy these don't import jax (library unit tests stay numpy-only).
- `test_dict` fixture updated for the new `use_jax_jit` kwarg on `DynestyStatic`.
- All 244 tests in `test_autofit/non_linear/` pass.

## Companion workspace test

`autofit_workspace_test` PR will follow with `scripts/searches/Dynesty_jax.py` (mirroring `Nautilus_jax.py`). Verified locally: `log_Z ≈ -54.0, dlogz ≈ 0.014` on the 1D Gaussian dataset, ~3.5s runtime. Nautilus_jax.py also re-verified for vmap-path regression — still green (`log_Z ≈ -54.13, N_eff = 366`).

## Test plan

- [x] `pytest test_autofit/non_linear` passes (244/244)
- [x] `Dynesty_jax.py` runs end-to-end and emits the JAX-jit log line
- [x] `Nautilus_jax.py` still passes (vmap regression check)
- [ ] CI green
- [ ] Companion `autofit_workspace_test` PR opened after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)