### PR TITLE
fix: populate NUTS samples_info keys under test-mode bypass

### DIFF
--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -858,14 +858,16 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         # (grid search log_evidences, subhalo Bayesian model comparison,
         # scrape aggregator assertions) doesn't crash on None. SamplesPDF
         # reads log_evidence from samples_info.
+        samples_info = {
+            "total_iterations": 1,
+            "time": 0.0,
+            "log_evidence": log_likelihood,
+        }
+        samples_info.update(self._test_mode_samples_info())
         samples = SamplesPDF(
             model=model,
             sample_list=sample_list,
-            samples_info={
-                "total_iterations": 1,
-                "time": 0.0,
-                "log_evidence": log_likelihood,
-            },
+            samples_info=samples_info,
         )
 
         samples_summary = samples.summary()
@@ -887,6 +889,19 @@ class NonLinearSearch(AbstractFactorOptimiser, ABC):
         model.unfreeze()
 
         return result
+
+    def _test_mode_samples_info(self) -> dict:
+        """
+        Sampler-specific keys to merge into ``samples_info`` when the
+        sampler is bypassed via ``PYAUTO_TEST_MODE=2`` or ``=3``.
+
+        Override in subclasses to add the diagnostic keys that the real
+        run would populate (e.g. NUTS ESS, MCMC autocorrelations) so that
+        tutorial scripts and downstream code can access those keys
+        without ``KeyError``. Use NaN/0 placeholders — the bypass did not
+        actually sample.
+        """
+        return {}
 
     @staticmethod
     def _build_fake_samples(model, parameter_vector, log_likelihood):

--- a/autofit/non_linear/search/mcmc/blackjax/nuts/search.py
+++ b/autofit/non_linear/search/mcmc/blackjax/nuts/search.py
@@ -378,6 +378,20 @@ class BlackJAXNUTS(AbstractMCMC):
         with open(self.backend_filename, "wb") as f:
             pickle.dump(search_internal, f)
 
+    def _test_mode_samples_info(self) -> dict:
+        return {
+            "num_warmup": int(self.num_warmup),
+            "num_samples": 0,
+            "num_chains": int(self.num_chains),
+            "ess_min": float("nan"),
+            "ess_per_param": [],
+            "mean_acceptance": float("nan"),
+            "n_divergent": 0,
+            "n_logl_evals": 0,
+            "total_walkers": int(self.num_chains),
+            "total_steps": 0,
+        }
+
     def samples_info_from(self, search_internal=None):
         search_internal = search_internal if search_internal is not None else self.backend
 


### PR DESCRIPTION
## Summary
- Adds `_test_mode_samples_info()` hook on `AbstractSearch` so subclasses can declare which diagnostic keys their `samples_info_from()` would normally populate. Hook return is merged into the bypass `samples_info` so downstream code reading per-sampler diagnostics doesn't `KeyError`.
- Overrides the hook in `BlackJAXNUTS` to return `num_warmup`, `num_samples`, `num_chains`, `ess_min`, `ess_per_param`, `mean_acceptance`, `n_divergent`, `n_logl_evals`, `total_walkers`, `total_steps` with NaN/0 placeholders.
- Unblocks `autofit_workspace/scripts/searches/mcmc.py` smoke (NUTS section) under `PYAUTO_TEST_MODE=2`.

## Test plan
- [x] Local: `PYAUTO_TEST_MODE=2 python autofit_workspace/scripts/searches/mcmc.py` runs to completion, prints `ESS (min over dims): nan / 0` etc.
- [ ] CI: Tests workflow on this PR
- [ ] CI: autofit_workspace smoke on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)