### PR TITLE
docs: audit-driven URL fixes across docs, READMEs, and docstrings

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -1,9 +1,9 @@
 # Citations & References
 
 The bibtex entries for **PyAutoFit** and its affiliated software packages can be found
-[here](https://github.com/rhayes777/PyAutoFit/blob/main/files/citations.bib), with example text for citing **PyAutoFit**
-in [.tex format here](https://github.com/rhayes777/PyAutoFit/blob/main/files/citation.tex) format here and
-[.md format here](https://github.com/rhayes777/PyAutoFit/blob/main/files/citations.md). As shown in the examples, we
+[here](https://github.com/PyAutoLabs/PyAutoFit/blob/main/files/citations.bib), with example text for citing **PyAutoFit**
+in [.tex format here](https://github.com/PyAutoLabs/PyAutoFit/blob/main/files/citation.tex) format here and
+[.md format here](https://github.com/PyAutoLabs/PyAutoFit/blob/main/files/citations.md). As shown in the examples, we
 would greatly appreciate it if you mention **PyAutoFit** by name and include a link to our GitHub page!
 
 **PyAutoFit** is published in the [Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.02550#) and its

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -302,7 +302,7 @@ the situation is not yet resolved.
 
 ## License
 
-This code of conduct has been adapted from [*NUMFOCUS code of conduct*](https://github.com/numfocus/numfocus/blob/main/manual/numfocus-coc.md#the-short-version),
-which is adapted from numerous sources, including the [*Geek Feminism wiki, created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license*](http://geekfeminism.wikia.com/wiki/Fiterence_anti-harassment/Policy), the [*Contributor Covenant version 1.2.0*](http://contributor-covenant.org/version/1/2/0/), the [*Bokeh Code of Conduct*](https://github.com/bokeh/bokeh/blob/main/CODE_OF_CONDUCT.md), the [*SciPy Code of Conduct*](https://github.com/jupyter/governance/blob/main/conduct/enforcement.md), the [*Carpentries Code of Conduct*](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual), and the [*NeurIPS Code of Conduct*](https://neurips.cc/public/CodeOfConduct).
+This code of conduct has been adapted from [*NUMFOCUS code of conduct*](https://numfocus.org/code-of-conduct),
+which is adapted from numerous sources, including the [*Geek Feminism wiki, created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license*](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), the [*Contributor Covenant version 1.2.0*](http://contributor-covenant.org/version/1/2/0/), the [*Bokeh Code of Conduct*](https://github.com/bokeh/bokeh/blob/main/docs/CODE_OF_CONDUCT.md), the [*SciPy Code of Conduct*](https://github.com/jupyter/governance/blob/main/conduct/enforcement.md), the [*Carpentries Code of Conduct*](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual), and the [*NeurIPS Code of Conduct*](https://neurips.cc/public/CodeOfConduct).
 
 **PyAutoFit Code of Conduct is licensed under the [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Contributions are welcome and greatly appreciated!
 
 ### Report Bugs
 
-Report bugs at https://github.com/rhayes777/PyAutoFit/issues
+Report bugs at https://github.com/PyAutoLabs/PyAutoFit/issues
 
 If you are playing with the PyAutoFit library and find a bug, please
 reporting it including:
@@ -68,7 +68,7 @@ reporting it including:
 ### Propose New `NonLinearSearch` or Features
 
 The best way to send feedback is to open an issue at
-https://github.com/rhayes777/PyAutoFit/issues
+https://github.com/PyAutoLabs/PyAutoFit/issues
 with tag *enhancement*.
 
 If you are proposing a new `NonLinearSearch` or a new feature:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Project Status: Active](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Python Versions](https://img.shields.io/pypi/pyversions/autofit)](https://pypi.org/project/autofit/)
 [![PyPI Version](https://img.shields.io/pypi/v/autofit.svg)](https://pypi.org/project/autofit/)
-[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.5.14.2/start_here.ipynb)
-[![Tests](https://github.com/rhayes777/PyAutoFit/actions/workflows/main.yml/badge.svg)](https://github.com/rhayes777/PyAutoFit/actions)
-[![Build](https://github.com/rhayes777/PyAutoBuild/actions/workflows/release.yml/badge.svg)](https://github.com/rhayes777/PyAutoBuild/actions)
+[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.5.14.2/notebooks/overview/overview_1_the_basics.ipynb)
+[![Tests](https://github.com/PyAutoLabs/PyAutoFit/actions/workflows/main.yml/badge.svg)](https://github.com/PyAutoLabs/PyAutoFit/actions)
+[![Build](https://github.com/PyAutoLabs/PyAutoBuild/actions/workflows/release.yml/badge.svg)](https://github.com/PyAutoLabs/PyAutoBuild/actions)
 [![Documentation Status](https://readthedocs.org/projects/pyautofit/badge/?version=latest)](https://pyautofit.readthedocs.io/en/latest/?badge=latest)
 [![JOSS](https://joss.theoj.org/papers/10.21105/joss.02550/status.svg)](https://doi.org/10.21105/joss.02550)
 
@@ -32,13 +32,13 @@ The following links are useful for new starters:
 
 - [The PyAutoFit readthedocs](https://pyautofit.readthedocs.io/en/latest), which includes an [installation guide](https://pyautofit.readthedocs.io/en/latest/installation/overview.html) and an overview of **PyAutoFit**'s core features.
 - [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.5.14.2/notebooks/overview/overview_1_the_basics.ipynb), where you can try **PyAutoFit** in a web browser (without installation).
-- [The autofit_workspace GitHub repository](https://github.com/Jammy2211/autofit_workspace), which includes example scripts demonstrating **PyAutoFit**'s features.
+- [The autofit_workspace GitHub repository](https://github.com/PyAutoLabs/autofit_workspace), which includes example scripts demonstrating **PyAutoFit**'s features.
 - [The standalone HowToFit repository](https://github.com/PyAutoLabs/HowToFit), a series of Jupyter notebook lectures which give new users a step-by-step introduction to **PyAutoFit**.
 
 ## Support
 
 Support for installation issues, help with Fit modeling and using **PyAutoFit** is available by
-[raising an issue on the GitHub issues page](https://github.com/rhayes777/PyAutoFit/issues).
+[raising an issue on the GitHub issues page](https://github.com/PyAutoLabs/PyAutoFit/issues).
 
 We also offer support on the **PyAutoFit** [Slack channel](https://pyautoFit.slack.com/), where we also provide the
 latest updates on **PyAutoFit**. Slack is invitation-only, so if you'd like to join send
@@ -57,7 +57,7 @@ The lectures are available in the [standalone HowToFit repository](https://githu
 To illustrate the **PyAutoFit** API, we use an illustrative toy model of fitting a one-dimensional Gaussian to
 noisy 1D data. Here's the `data` (black) and the model (red) we'll fit:
 
-<img src="https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/files/toy_model_fit.png" width="400" />
+<img src="https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/files/toy_model_fit.png" width="400" />
 
 We define our model, a 1D Gaussian by writing a Python class using the format below:
 

--- a/autofit/mapper/prior_model/collection.py
+++ b/autofit/mapper/prior_model/collection.py
@@ -137,7 +137,7 @@ class Collection(AbstractPriorModel):
 
         For a complete description of the model composition API, see the **PyAutoFit** model API cookbooks:
 
-        https://pyautofit.readthedocs.io/en/latest/cookbooks/cookbook_1_basics.html
+        https://pyautofit.readthedocs.io/en/latest/cookbooks/model.html
 
         The Python class input into a ``Model`` to create a model component is written using the following format:
 

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -66,7 +66,7 @@ class Model(AbstractPriorModel):
 
         For a complete description of the model composition API, see the **PyAutoFit** model API cookbooks:
 
-        https://pyautofit.readthedocs.io/en/latest/cookbooks/cookbook_1_basics.html
+        https://pyautofit.readthedocs.io/en/latest/cookbooks/model.html
 
         The Python class input into a ``Model`` to create a model component is written using the following format:
 

--- a/docs/api/analysis.rst
+++ b/docs/api/analysis.rst
@@ -8,9 +8,9 @@ It acts as an interface between the data, model and the non-linear search.
 
 **Examples / Tutorials:**
 
-- `readthedocs: example using Analysis object <https://pyautofit.readthedocs.io/en/latest/overview/model_fit.html>`_.
-- `autofit_workspace: simple tutorial <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/overview/simple/fit.ipynb>`_
-- `autofit_workspace: complex tutorial <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/overview/complex/fit.ipynb>`_
+- `readthedocs: example using Analysis object <https://pyautofit.readthedocs.io/en/latest/overview/the_basics.html>`_.
+- `autofit_workspace: simple tutorial <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/overview/overview_1_the_basics.ipynb>`_
+- `autofit_workspace: complex tutorial <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/overview/overview_2_scientific_workflow.ipynb>`_
 - `HowToFit: tutorial lectures (detailed step-by-step examples) <https://github.com/PyAutoLabs/HowToFit>`_
 
 --------

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -9,7 +9,7 @@ inspection, analysis and interpretation.
 **Examples / Tutorials:**
 
 - `readthedocs: example using database functionality <https://pyautofit.readthedocs.io/en/latest/features/database.html>`_
-- `autofit_workspace: tutorial using database <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/features/database.ipynb>`_
+- `autofit_workspace: tutorial using database <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/features/database.ipynb>`_
 - `HowToFit: tutorial lectures (detailed step-by-step examples) <https://github.com/PyAutoLabs/HowToFit>`_
 
 ----------

--- a/docs/api/model.rst
+++ b/docs/api/model.rst
@@ -4,16 +4,16 @@ Models
 
 Model objects are used for composing models that are fitted to data.
 
-It is recommended the `model API cookbooks <https://pyautofit.readthedocs.io/en/latest/cookbooks/cookbook_1_basics.html>`_ are used for guidance on building complex model.
+It is recommended the `model API cookbooks <https://pyautofit.readthedocs.io/en/latest/cookbooks/model.html>`_ are used for guidance on building complex model.
 
 **Examples / Tutorials:**
 
-- `Model API Cookbooks (recommended) <https://pyautofit.readthedocs.io/en/latest/cookbooks/cookbook_1_basics.html>`_.
+- `Model API Cookbooks (recommended) <https://pyautofit.readthedocs.io/en/latest/cookbooks/model.html>`_.
 
-- `readthedocs: example using Model object <https://pyautofit.readthedocs.io/en/latest/overview/model_fit.html>`_.
-- `readthedocs: example using Collection object <https://pyautofit.readthedocs.io/en/latest/overview/model_complex.html>`_.
-- `autofit_workspace: simple tutorial <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/overview/simple/fit.ipynb>`_
-- `autofit_workspace: complex tutorial <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/overview/complex/fit.ipynb>`_
+- `readthedocs: example using Model object <https://pyautofit.readthedocs.io/en/latest/overview/the_basics.html>`_.
+- `readthedocs: example using Collection object <https://pyautofit.readthedocs.io/en/latest/cookbooks/model.html>`_.
+- `autofit_workspace: simple tutorial <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/overview/overview_1_the_basics.ipynb>`_
+- `autofit_workspace: complex tutorial <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/overview/overview_2_scientific_workflow.ipynb>`_
 - `HowToFit: tutorial lectures (detailed step-by-step examples) <https://github.com/PyAutoLabs/HowToFit>`_
 
 ------

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -7,8 +7,8 @@ by **PyAutoFit**.
 
 **Examples / Tutorials:**
 
-- `readthedocs: non-linear search example <https://pyautofit.readthedocs.io/en/latest/overview/non_linear_search.html>`_
-- `autofit_workspace: plot tutorials <https://github.com/Jammy2211/autofit_workspace/tree/release/notebooks/plot>`_
+- `readthedocs: non-linear search example <https://pyautofit.readthedocs.io/en/latest/cookbooks/search.html>`_
+- `autofit_workspace: plot tutorials <https://github.com/PyAutoLabs/autofit_workspace/tree/main/notebooks/guides/plot>`_
 - `HowToFit: tutorial lectures (detailed step-by-step examples) <https://github.com/PyAutoLabs/HowToFit>`_
 
 --------

--- a/docs/api/priors.rst
+++ b/docs/api/priors.rst
@@ -6,12 +6,12 @@ The priors of parameters of every component of a mdoel, which is fitted to data,
 
 **Examples / Tutorials:**
 
-- `Model API Cookbooks (recommended) <https://pyautofit.readthedocs.io/en/latest/cookbooks/cookbook_1_basics.html>`_.
+- `Model API Cookbooks (recommended) <https://pyautofit.readthedocs.io/en/latest/cookbooks/model.html>`_.
 
-- `readthedocs: example using Model object <https://pyautofit.readthedocs.io/en/latest/overview/model_fit.html>`_.
-- `readthedocs: example using Collection object <https://pyautofit.readthedocs.io/en/latest/overview/model_complex.html>`_.
-- `autofit_workspace: simple tutorial <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/overview/simple/fit.ipynb>`_
-- `autofit_workspace: complex tutorial <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/overview/complex/fit.ipynb>`_
+- `readthedocs: example using Model object <https://pyautofit.readthedocs.io/en/latest/overview/the_basics.html>`_.
+- `readthedocs: example using Collection object <https://pyautofit.readthedocs.io/en/latest/cookbooks/model.html>`_.
+- `autofit_workspace: simple tutorial <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/overview/overview_1_the_basics.ipynb>`_
+- `autofit_workspace: complex tutorial <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/overview/overview_2_scientific_workflow.ipynb>`_
 - `HowToFit: tutorial lectures (detailed step-by-step examples) <https://github.com/PyAutoLabs/HowToFit>`_
 
 Priors

--- a/docs/api/samples.rst
+++ b/docs/api/samples.rst
@@ -9,9 +9,9 @@ For example, for an MCMC model-fit, the ``Samples`` objects contains every sampl
 
 **Examples / Tutorials:**
 
-- `readthedocs: example on using results <https://pyautofit.readthedocs.io/en/latest/overview/result.html>`_.
-- `autofit_workspace: simple results tutorial <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/overview/simple/result.ipynb>`_
-- `autofit_workspace: complex result tutorial <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/overview/complex/result.ipynb>`_
+- `readthedocs: example on using results <https://pyautofit.readthedocs.io/en/latest/cookbooks/result.html>`_.
+- `autofit_workspace: simple results tutorial <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/cookbooks/result.ipynb>`_
+- `autofit_workspace: complex result tutorial <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/cookbooks/result.ipynb>`_
 - `HowToFit: tutorial lectures (detailed step-by-step examples) <https://github.com/PyAutoLabs/HowToFit>`_
 
 Samples

--- a/docs/api/searches.rst
+++ b/docs/api/searches.rst
@@ -9,9 +9,9 @@ Markov Chain Monte Carlo (MCMC) and Maximum Likelihood Estimators (MLE).
 
 **Examples / Tutorials:**
 
-- `readthedocs: example using non-linear searches <https://pyautofit.readthedocs.io/en/latest/overview/non_linear_search.html>`_.
-- `autofit_workspace: simple tutorial <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/overview/simple/fit.ipynb>`_
-- `autofit_workspace: complex tutorial <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/overview/complex/fit.ipynb>`_
+- `readthedocs: example using non-linear searches <https://pyautofit.readthedocs.io/en/latest/cookbooks/search.html>`_.
+- `autofit_workspace: simple tutorial <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/overview/overview_1_the_basics.ipynb>`_
+- `autofit_workspace: complex tutorial <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/overview/overview_2_scientific_workflow.ipynb>`_
 - `HowToFit: tutorial lectures (detailed step-by-step examples) <https://github.com/PyAutoLabs/HowToFit>`_
 
 Nested Samplers
@@ -79,7 +79,7 @@ model are fitted in over a discrete grid.
 **Examples / Tutorials:**
 
 - `readthedocs: example using a non-linear search grid search <https://pyautofit.readthedocs.io/en/latest/features/search_grid_search.html>`_.
-- `autofit_workspace: example using a non-linear search grid search <https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/features/search_grid_search.ipynb>`_
+- `autofit_workspace: example using a non-linear search grid search <https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/features/search_grid_search.ipynb>`_
 
 GridSearch
 ----------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@ import datetime
 #
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
-# https://www.sphinx-doc.org/en/main/usage/configuration.html
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
 
@@ -61,7 +61,7 @@ extlinks = {
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "sphinx": ("https://www.sphinx-doc.org/en/main", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
 }
 
 # -- Options for TODOs -------------------------------------------------------

--- a/docs/cookbooks/multiple_datasets.md
+++ b/docs/cookbooks/multiple_datasets.md
@@ -89,17 +89,17 @@ for data, noise_map in zip(data_list, noise_map_list):
 
 Here is what the plots look like:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/feature/docs_update/docs/images/multi_data_0.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/multi_data_0.png
 :alt: Alternative text
 :width: 300
 ```
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/feature/docs_update/docs/images/multi_data_1.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/multi_data_1.png
 :alt: Alternative text
 :width: 300
 ```
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/feature/docs_update/docs/images/multi_data_2.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/multi_data_2.png
 :alt: Alternative text
 :width: 300
 ```
@@ -246,17 +246,17 @@ for data, result in zip(data_list, result_list):
 
 The image appears as follows:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/feature/docs_update/docs/images/multi_model_data_0.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/multi_model_data_0.png
 :alt: Alternative text
 :width: 300
 ```
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/feature/docs_update/docs/images/multi_model_data_1.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/multi_model_data_1.png
 :alt: Alternative text
 :width: 300
 ```
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/feature/docs_update/docs/images/multi_model_data_2.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/multi_model_data_2.png
 :alt: Alternative text
 :width: 300
 ```
@@ -305,17 +305,17 @@ for data, noise_map in zip(data_list, noise_map_list):
 
 The images appear as follows:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/feature/docs_update/docs/images/multi_model_data_0.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/multi_model_data_0.png
 :alt: Alternative text
 :width: 300
 ```
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/feature/docs_update/docs/images/multi_model_data_1.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/multi_model_data_1.png
 :alt: Alternative text
 :width: 300
 ```
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/feature/docs_update/docs/images/multi_model_data_2.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/multi_model_data_2.png
 :alt: Alternative text
 :width: 300
 ```

--- a/docs/cookbooks/samples.md
+++ b/docs/cookbooks/samples.md
@@ -154,7 +154,7 @@ plt.close()
 
 This plot appears as follows:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/images/toy_model_fit.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/toy_model_fit.png
 :alt: Alternative text
 :width: 600
 ```
@@ -299,7 +299,7 @@ plotter.corner()
 
 This plot appears as follows:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/images/corner.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/corner.png
 :alt: Alternative text
 :width: 600
 ```

--- a/docs/features/graphical.md
+++ b/docs/features/graphical.md
@@ -52,17 +52,17 @@ for dataset_index in range(total_gaussians):
 
 This is what our three Gaussians look like:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x1_1__low_snr.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x1_1__low_snr.png
 :alt: Alternative text
 :width: 600
 ```
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x1_2__low_snr.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x1_2__low_snr.png
 :alt: Alternative text
 :width: 600
 ```
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x1_3__low_snr.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x1_3__low_snr.png
 :alt: Alternative text
 :width: 600
 ```

--- a/docs/features/interpolate.md
+++ b/docs/features/interpolate.md
@@ -48,7 +48,7 @@ for time in range(3):
 Visual comparison of the datasets shows that the `centre` of each `Gaussian` varies smoothly over time, with it moving
 from pixel 40 at t=0 to pixel 60 at t=2.
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/hi.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/hi.png
 :alt: Alternative text
 :width: 600
 ```

--- a/docs/features/search_chaining.md
+++ b/docs/features/search_chaining.md
@@ -27,7 +27,7 @@ precise, most accurate model that best fits the dataset available.
 In this example we demonstrate search chaining using the example data where there are two `Gaussians` that are visibly
 split:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x2_split.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x2_split.png
 :alt: Alternative text
 :width: 600
 ```
@@ -49,7 +49,7 @@ procedure.
 To fit the left `Gaussian`, our first `analysis` receive only half data removing the right `Gaussian`. Note that
 this give a speed-up in log likelihood evaluation.
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x2_left.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x2_left.png
 :alt: Alternative text
 :width: 600
 ```
@@ -92,7 +92,7 @@ result_1 = search_1.fit(model=model_1, analysis=analysis_1)
 
 By plotting the result we can see we have fitted the left `Gaussian` reasonably well.
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x2_left_fit.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x2_left_fit.png
 :alt: Alternative text
 :width: 600
 ```
@@ -149,7 +149,7 @@ result_2 = search_2.fit(model=model_2, analysis=analysis_2)
 
 We can now see our model has successfully fitted both Gaussian's:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x2_right_fit.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x2_right_fit.png
 :alt: Alternative text
 :width: 600
 ```
@@ -206,7 +206,7 @@ result_3 = search_3.fit(model=model_3, analysis=analysis_3)
 
 We can now see our model has successfully fitted both Gaussians simultaneously:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x2_fit.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x2_fit.png
 :alt: Alternative text
 :width: 600
 ```

--- a/docs/features/search_grid_search.md
+++ b/docs/features/search_grid_search.md
@@ -24,7 +24,7 @@ In this example we will demonstrate the search grid search feature, again using 
 in noisy data. This 1D data includes a small feature to the right of the central `Gaussian`, a second `Gaussian`
 centred on pixel 70.
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x1_with_feature.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x1_with_feature.png
 :alt: Alternative text
 :width: 600
 ```
@@ -53,7 +53,7 @@ which the non linear search may miss.
 
 The image below shows a fit where we failed to detect the feature:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x1_with_feature_fit_no_feature.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x1_with_feature_fit_no_feature.png
 :alt: Alternative text
 :width: 600
 ```
@@ -110,7 +110,7 @@ This shows a peak evidence value on the 4th cell of grid-search, where the `Unif
 60 -> 80 and therefore included the Gaussian feature. By plotting this model-fit we can see it has successfully
 detected the feature.
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x1_with_feature_fit_feature.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x1_with_feature_fit_feature.png
 :alt: Alternative text
 :width: 600
 ```

--- a/docs/features/sensitivity_mapping.md
+++ b/docs/features/sensitivity_mapping.md
@@ -19,7 +19,7 @@ evidence increase we should expect for datasets of varying quality and / or mode
 To illustrate sensitivity mapping we will again use the example of fitting 1D Gaussian's in noisy data. This 1D data
 includes a small feature to the right of the central `Gaussian`, a second `Gaussian` centred on pixel 70.
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/gaussian_x1_with_feature.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/gaussian_x1_with_feature.png
 :alt: Alternative text
 :width: 600
 ```
@@ -175,12 +175,12 @@ def __call__(instance, simulate_path):
 
 Here are what the two most extreme simulated datasets look like, corresponding to the highest and lowest normalization values
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/sensitivity_data_low.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/sensitivity_data_low.png
 :alt: Alternative text
 :width: 600
 ```
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/sensitivity_data_high.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/sensitivity_data_high.png
 :alt: Alternative text
 :width: 600
 ```
@@ -218,12 +218,12 @@ sensitivity_result = sensitivity.run()
 Here are what the fits to the two most extreme simulated datasets look like, for the models including the Gaussian
 feature.
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/sensitivity_data_low_fit.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/sensitivity_data_low_fit.png
 :alt: Alternative text
 :width: 600
 ```
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/features/images/sensitivity_data_high_fit.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/sensitivity_data_high_fit.png
 :alt: Alternative text
 :width: 600
 ```

--- a/docs/general/citations.md
+++ b/docs/general/citations.md
@@ -3,9 +3,9 @@
 # Citations & References
 
 The bibtex entries for **PyAutoFit** and its affiliated software packages can be found
-[here](https://github.com/rhayes777/PyAutoFit/blob/main/files/citations.bib), with example text for citing **PyAutoFit**
-in [.tex format here](https://github.com/rhayes777/PyAutoFit/blob/main/files/citation.tex) format here and
-[.md format here](https://github.com/rhayes777/PyAutoFit/blob/main/files/citations.md). As shown in the examples, we
+[here](https://github.com/PyAutoLabs/PyAutoFit/blob/main/files/citations.bib), with example text for citing **PyAutoFit**
+in [.tex format here](https://github.com/PyAutoLabs/PyAutoFit/blob/main/files/citation.tex) format here and
+[.md format here](https://github.com/PyAutoLabs/PyAutoFit/blob/main/files/citations.md). As shown in the examples, we
 would greatly appreciate it if you mention **PyAutoFit** by name and include a link to our GitHub page!
 
 **PyAutoFit** is published in the [Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.02550#) and its

--- a/docs/general/configs.md
+++ b/docs/general/configs.md
@@ -4,7 +4,7 @@
 visualization and other aspects of **PyAutoFit**.
 
 Descriptions of every configuration file and their input parameters are provided in the `README.md` in
-the [config directory of the workspace](https://github.com/Jammy2211/autofit_workspace/tree/release/config)
+the [config directory of the workspace](https://github.com/PyAutoLabs/autofit_workspace/tree/main/config)
 
 ## Setup
 

--- a/docs/general/roadmap.md
+++ b/docs/general/roadmap.md
@@ -13,7 +13,7 @@ Supported for autodiff is nearly implemented, including JAX fits.
 
 We are always striving to add new non-linear searches to PyAutoFit\*. In the short term, we aim to provide a wrapper to the many method available in the `scipy.optimize` library with support for outputting results to hard-disk.
 
-If you would like to see a non-linear search implemented in **PyAutoFit** please [raise an issue on GitHub](https://github.com/rhayes777/PyAutoFit/issues)!
+If you would like to see a non-linear search implemented in **PyAutoFit** please [raise an issue on GitHub](https://github.com/PyAutoLabs/PyAutoFit/issues)!
 
 **Approximate Bayesian Computation**
 

--- a/docs/general/software.md
+++ b/docs/general/software.md
@@ -4,10 +4,10 @@
 
 The following software projects use **PyAutoFit**:
 
-[PyAutoLens](https://github.com/Jammy2211/PyAutoLens) -
+[PyAutoLens](https://github.com/PyAutoLabs/PyAutoLens) -
 Astronomy software for modeling Strong Gravitational Lenses.
 
-[PyAutoGalaxy](https://github.com/Jammy2211/PyAutoGalaxy) -
+[PyAutoGalaxy](https://github.com/PyAutoLabs/PyAutoGalaxy) -
 Astronomy software for modeling galaxy light profiles and dynamics.
 
 [PyAutoCTI](https://github.com/Jammy2211/PyAutoCTI) -

--- a/docs/general/workspace.md
+++ b/docs/general/workspace.md
@@ -2,7 +2,7 @@
 
 # Workspace Tour
 
-You should have downloaded and configured the [autofit_workspace](https://github.com/Jammy2211/autofit_workspace)
+You should have downloaded and configured the [autofit_workspace](https://github.com/PyAutoLabs/autofit_workspace)
 when you installed **PyAutoFit**. If you didn't, checkout the
 [installation instructions](https://pyautofit.readthedocs.io/en/latest/general/installation.html#installation-with-pip)
 for how to downloaded and configure the workspace.
@@ -26,7 +26,7 @@ There are numerous example describing how perform model-fitting with **PyAutoFit
 advanced model-fitting features. All examples are provided as Python scripts and Jupyter notebooks.
 
 Descriptions of every configuration file and their input parameters are provided in the `README.md` in
-the [config directory of the workspace](https://github.com/Jammy2211/autofit_workspace/tree/release/config)
+the [config directory of the workspace](https://github.com/PyAutoLabs/autofit_workspace/tree/main/config)
 
 ## Config
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,13 +18,13 @@ The following links are useful for new starters:
 
 - [The PyAutoFit readthedocs](https://pyautofit.readthedocs.io/en/latest), which includes an [installation guide](https://pyautofit.readthedocs.io/en/latest/installation/overview.html) and an overview of **PyAutoFit**'s core features.
 - [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.5.14.2/notebooks/overview/overview_1_the_basics.ipynb), where you can try **PyAutoFit** in a web browser (without installation).
-- [The autofit_workspace GitHub repository](https://github.com/Jammy2211/autofit_workspace), which includes example scripts demonstrating **PyAutoFit**'s features.
+- [The autofit_workspace GitHub repository](https://github.com/PyAutoLabs/autofit_workspace), which includes example scripts demonstrating **PyAutoFit**'s features.
 - [The standalone HowToFit repository](https://github.com/PyAutoLabs/HowToFit), a series of Jupyter notebook lectures which give new users a step-by-step introduction to **PyAutoFit**.
 
 ## Support
 
 Support for installation issues, help with Fit modeling and using **PyAutoFit** is available by
-[raising an issue on the GitHub issues page](https://github.com/rhayes777/PyAutoFit/issues).
+[raising an issue on the GitHub issues page](https://github.com/PyAutoLabs/PyAutoFit/issues).
 
 We also offer support on the **PyAutoFit** [Slack channel](https://pyautoFit.slack.com/), where we also provide the
 latest updates on **PyAutoFit**. Slack is invitation-only, so if you'd like to join send
@@ -43,7 +43,7 @@ The lectures are available in the [standalone HowToFit repository](https://githu
 To illustrate the **PyAutoFit** API, we use an illustrative toy model of fitting a one-dimensional Gaussian to
 noisy 1D data. Here's the `data` (black) and the model (red) we'll fit:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/files/toy_model_fit.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/files/toy_model_fit.png
 :width: 400
 ```
 

--- a/docs/installation/conda.md
+++ b/docs/installation/conda.md
@@ -32,7 +32,7 @@ the `autofit_workspace`, reducing the download size):
 
 ```bash
 cd /path/on/your/computer/you/want/to/put/the/autofit_workspace
-git clone https://github.com/Jammy2211/autofit_workspace --depth 1
+git clone https://github.com/PyAutoLabs/autofit_workspace --depth 1
 cd autofit_workspace
 ```
 

--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -24,7 +24,7 @@ There are currently no known issues with installing **PyAutoFit**.
 
 ## Dependencies
 
-**PyAutoConf** <https://github.com/rhayes777/PyAutoConf>
+**PyAutoConf** <https://github.com/PyAutoLabs/PyAutoConf>
 
 **dynesty** <https://github.com/joshspeagle/dynesty>
 

--- a/docs/installation/pip.md
+++ b/docs/installation/pip.md
@@ -27,7 +27,7 @@ the `autofit_workspace`, reducing the download size):
 
 ```bash
 cd /path/on/your/computer/you/want/to/put/the/autofit_workspace
-git clone https://github.com/Jammy2211/autofit_workspace --depth 1
+git clone https://github.com/PyAutoLabs/autofit_workspace --depth 1
 cd autofit_workspace
 ```
 

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -9,7 +9,7 @@ contribute the development **PyAutoFit** or experiment with yourself!
 First, clone (or fork) the **PyAutoFit** GitHub repository:
 
 ```bash
-git clone https://github.com/Jammy2211/PyAutoFit
+git clone https://github.com/PyAutoLabs/PyAutoFit
 ```
 
 Next, install the **PyAutoFit** dependencies via pip:

--- a/docs/installation/troubleshooting.md
+++ b/docs/installation/troubleshooting.md
@@ -25,5 +25,5 @@ are not running the script with the `autofit_workspace` as the working directory
 ## Support
 
 If you are still having issues with installation or using **PyAutoFit** in general, please raise an issue on the
-[autofit_workspace issues page](https://github.com/Jammy2211/autofit_workspace/issues) with a description of the
+[autofit_workspace issues page](https://github.com/PyAutoLabs/autofit_workspace/issues) with a description of the
 problem and your system setup (operating system, Python version, etc.).

--- a/docs/overview/backup.md
+++ b/docs/overview/backup.md
@@ -24,7 +24,7 @@ plt.close()
 
 The data appear as follows:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/images/data_2.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/data_2.png
 :alt: Alternative text
 :width: 600
 ```
@@ -371,7 +371,7 @@ plt.close()
 
 The plot appears as follows:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/images/toy_model_fit.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/toy_model_fit.png
 :alt: Alternative text
 :width: 600
 ```

--- a/docs/overview/scientific_workflow.md
+++ b/docs/overview/scientific_workflow.md
@@ -141,7 +141,7 @@ search = af.Emcee(
 
 The screenshot below shows the output folder where all output is enabled:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoFit/main/docs/overview/image/output_example.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/overview/image/output_example.png
 :alt: Alternative text
 :width: 400
 ```

--- a/docs/overview/statistical_methods.md
+++ b/docs/overview/statistical_methods.md
@@ -14,7 +14,7 @@ This is achieved through a concise API and scientific workflow that ensures scal
 
 A full description of using graphical models is given below:
 
-<https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/features/graphical_models.ipynb>
+<https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/features/graphical_models.ipynb>
 
 ## Hierarchical Models
 
@@ -36,7 +36,7 @@ and comparing how well they fit the data.
 
 A full description of using model comparison is given below:
 
-<https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/features/model_comparison.ipynb>
+<https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/features/model_comparison.ipynb>
 
 ## Interpolation
 
@@ -51,7 +51,7 @@ to determine the most likely model parameters at any point in time.
 
 **PyAutoFit**'s interpolation feature allows for this, and a full description of its use is given below:
 
-<https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/features/interpolate.ipynb>
+<https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/features/interpolate.ipynb>
 
 ## Search Grid Search
 
@@ -70,7 +70,7 @@ space to further aid the fitting process.
 
 A full description of using search grid searches is given below:
 
-<https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/features/search_grid_search.ipynb>
+<https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/features/search_grid_search.ipynb>
 
 ## Search Chaining
 
@@ -85,7 +85,7 @@ of **bite-sized** searches which are faster and more reliable than fitting the m
 
 A full description of using search chaining is given below:
 
-<https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/features/search_grid_search.ipynb>
+<https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/features/search_grid_search.ipynb>
 
 ## Sensitivity Mapping
 
@@ -102,4 +102,4 @@ how much the change in the model led to a measurable change in the data. This is
 
 A full description of using sensitivity mapping is given below:
 
-<https://github.com/Jammy2211/autofit_workspace/blob/release/notebooks/features/sensitivity_mapping.ipynb>
+<https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/features/sensitivity_mapping.ipynb>

--- a/docs/overview/the_basics.md
+++ b/docs/overview/the_basics.md
@@ -36,7 +36,7 @@ import numpy as np
 
 The example `data` with errors (black) is shown below:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/images/data.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/data.png
 :alt: Alternative text
 :width: 600
 ```
@@ -277,7 +277,7 @@ plt.clf()
 
 Here is what the plot looks like:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/images/model_gaussian.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/model_gaussian.png
 :alt: Alternative text
 :width: 600
 ```
@@ -518,7 +518,7 @@ plt.close()
 
 The plot appears as follows:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/images/toy_model_fit.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/toy_model_fit.png
 :alt: Alternative text
 :width: 600
 ```
@@ -545,7 +545,7 @@ plotter.corner_anesthetic()
 
 The plot appears as follows:
 
-```{image} https://raw.githubusercontent.com/rhayes777/PyAutoFit/main/docs/images/corner.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/corner.png
 :alt: Alternative text
 :width: 600
 ```
@@ -640,7 +640,7 @@ interpretation of the results remains feasible and insightful.
 
 ## Resources
 
-The [autofit_workspace:](https://github.com/Jammy2211/autofit_workspace/) repository on GitHub provides numerous
+The [autofit_workspace:](https://github.com/PyAutoLabs/autofit_workspace/) repository on GitHub provides numerous
 examples demonstrating more complex model-fitting tasks.
 
 This includes cookbooks, which provide a concise reference guide to the **PyAutoFit** API for advanced model-fitting:

--- a/docs/science_examples/astronomy.md
+++ b/docs/science_examples/astronomy.md
@@ -4,11 +4,11 @@
 
 This example illustrates model-component and fitting for an Astronomy science case, based are the phenomena
 of strong gravitational lensing. This is the science case that sparked the development of **PyAutoFit** as a spin
-off of our astronomy software [PyAutoLens](https://github.com/Jammy2211/PyAutoLens).
+off of our astronomy software [PyAutoLens](https://github.com/PyAutoLabs/PyAutoLens).
 
 The schematic below depicts a strong gravitational lens:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_1_lensing/schematic.jpg
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1_lensing/schematic.jpg
 :alt: Alternative text
 :width: 600
 ```
@@ -25,7 +25,7 @@ lens. The amount light is deflected by is defined by the distances between each 
 We therefore need a model which contains separate model-components for every galaxy, and where each galaxy contains
 separate model-components describing its light and mass. A multi-level representation of this model is as follows:
 
-```{image} https://github.com/rhayes777/PyAutoFit/blob/main/docs/overview/image/lens_model.png?raw=true
+```{image} https://github.com/PyAutoLabs/PyAutoFit/blob/main/docs/overview/image/lens_model.png?raw=true
 :alt: Alternative text
 :width: 600
 ```
@@ -259,7 +259,7 @@ modeling features to compose and fits models of arbitrary complexity and dimensi
 
 To illustrate this further, consider the following dataset which is called a **strong lens galaxy cluster**:
 
-```{image} https://github.com/rhayes777/PyAutoFit/blob/main/docs/overview/image/cluster_example.jpg?raw=true
+```{image} https://github.com/PyAutoLabs/PyAutoFit/blob/main/docs/overview/image/cluster_example.jpg?raw=true
 :alt: Alternative text
 :width: 600
 ```
@@ -304,7 +304,7 @@ model = af.Collection(
 
 Here is an illustration of this model's graph:
 
-```{image} https://github.com/rhayes777/PyAutoFit/blob/main/docs/overview/image/lens_model_cluster.png?raw=true
+```{image} https://github.com/PyAutoLabs/PyAutoFit/blob/main/docs/overview/image/lens_model_cluster.png?raw=true
 :alt: Alternative text
 :width: 600
 ```
@@ -318,8 +318,8 @@ An example project on the **autofit_workspace** shows how to use **PyAutoFit** t
 lensing data, using **multi-level model composition**.
 
 If you'd like to perform the fit shown in this script, checkout the
-[simple examples](https://github.com/Jammy2211/autofit_workspace/tree/main/notebooks/overview/simplee) on the
+[simple examples](https://github.com/PyAutoLabs/autofit_workspace/tree/main/notebooks/overview) on the
 `autofit_workspace`. We detail how **PyAutoFit** works in the first 3 tutorials of
 the [HowToFit lecture series](https://github.com/PyAutoLabs/HowToFit).
 
-<https://github.com/Jammy2211/autofit_workspace/tree/release/projects/astro>
+<https://github.com/PyAutoLabs/autofit_workspace/tree/main/projects/astro>

--- a/files/citations.md
+++ b/files/citations.md
@@ -1,6 +1,6 @@
 I**nesrt in the main body of the paper:**
 
-We use the probabilistic programming language `PyAutoFit` https://github.com/rhayes777/PyAutoFit) [@pyautofit] to...
+We use the probabilistic programming language `PyAutoFit` https://github.com/PyAutoLabs/PyAutoFit) [@pyautofit] to...
 
 **At the end of the paper (delete as appropriate, see https://pyautofit.readthedocs.io/en/latest/general/citations.html):**
 
@@ -13,7 +13,7 @@ This work uses the following software packages:
 - `emcee` https://github.com/dfm/emcee [@emcee]
 - `matplotlib` https://github.com/matplotlib/matplotlib [@matplotlib]
 - `NumPy` https://github.com/numpy/numpy [@numpy]
-- `PyAutoFit` https://github.com/rhayes777/PyAutoFit [@pyautofit]
+- `PyAutoFit` https://github.com/PyAutoLabs/PyAutoFit [@pyautofit]
 - `PyMultiNest` https://github.com/JohannesBuchner/PyMultiNest [@multinest] [@pymultinest]
 
 - `Python` https://www.python.org/ [@python]

--- a/paper/README.md
+++ b/paper/README.md
@@ -1,5 +1,5 @@
 PyAutoFit JOSS Paper
 ====================
 
-Paper accompanying [PyAutoFit](https://github.com/rhayes777/PyAutoFit) for submission to the Journal of Open Source 
+Paper accompanying [PyAutoFit](https://github.com/PyAutoLabs/PyAutoFit) for submission to the Journal of Open Source 
 Software (JOSS).

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -21,7 +21,7 @@ affiliations:
   - name: ConcR Ltd, London, UK
     index: 2    
 date: 17 July 2020
-codeRepository: https://github.com/rhayes777/PyAutoFit
+codeRepository: https://github.com/PyAutoLabs/PyAutoFit
 license: MIT
 bibliography: paper.bib
 ---
@@ -35,11 +35,11 @@ interfaces with all aspects of the modeling (e.g., the model, data, fitting proc
 therefore provides complete management of every aspect of modeling. This includes composing high-dimensionality models 
 from individual model components, customizing the fitting procedure and performing data augmentation before a model-fit. 
 Advanced features include database tools for analysing large suites of modeling results and exploiting domain-specific 
-knowledge of a problem via non-linear search chaining. Accompanying `PyAutoFit` is the [autofit workspace](https://github.com/Jammy2211/autofit_workspace), 
+knowledge of a problem via non-linear search chaining. Accompanying `PyAutoFit` is the [autofit workspace](https://github.com/PyAutoLabs/autofit_workspace), 
 which includes example scripts, together with the standalone [HowToFit](https://github.com/PyAutoLabs/HowToFit)
 lecture series which introduces non-experts to model-fitting and provides a guide on how to begin a project
 using `PyAutoFit`. Readers can try `PyAutoFit` right now by 
-going to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.5.14.2/start_here.ipynb)
+going to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.5.14.2/notebooks/overview/overview_1_the_basics.ipynb)
 or checkout our [readthedocs](https://pyautofit.readthedocs.io/en/latest/) for a complete overview
 of **PyAutoFit**'s features.
 
@@ -118,7 +118,7 @@ and thus enable accurate fitting of models of arbitrary complexity.
 
 # History
 
-`PyAutoFit` is a generalization of [PyAutoLens](https://github.com/Jammy2211/PyAutoLens), an Astronomy package 
+`PyAutoFit` is a generalization of [PyAutoLens](https://github.com/PyAutoLabs/PyAutoLens), an Astronomy package 
 developed to analyse images of gravitationally lensed galaxies. Modeling gravitational lenses historically requires 
 large amounts of human time and supervision, an approach which does not scale to the incoming samples of 100000 objects. 
 Domain exploitation enabled full automation of the lens modeling procedure [@Nightingale2015; @Nightingale2018], with 
@@ -128,13 +128,13 @@ of cancer tumour growth.
  
 # Workspace and HowToFit Tutorials
 
-`PyAutoFit` is distributed with the [autofit workspace](https://github.com/Jammy2211/autofit_workspace), which 
+`PyAutoFit` is distributed with the [autofit workspace](https://github.com/PyAutoLabs/autofit_workspace), which 
 contains example scripts for composing a model, performing a fit, using the `Aggregator` and `PyAutoFit`'s advanced 
 statistical inference methods. Complementing the workspace is the standalone
 [HowToFit](https://github.com/PyAutoLabs/HowToFit) repository, a series of Jupyter notebook tutorials aimed at
 non-experts, introducing them to model-fitting and Bayesian inference. They teach users how to write model-components 
 and `Analysis` classes in `PyAutoFit`, use these to fit a dataset and interpret the model-fitting results. The lectures 
-are available on our [Colab](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.5.14.2/start_here.ipynb) and may therefore be 
+are available on our [Colab](https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.5.14.2/notebooks/overview/overview_1_the_basics.ipynb) and may therefore be 
 taken without a local `PyAutoFit` installation.
 
 # Software Citations


### PR DESCRIPTION
## Summary

Doc-only URL cleanup driven by the new `admin_jammy/software/url_check/` audit tool (Jammy2211/admin_jammy#21). Fixes the user-reported `hhttps://` typo in `overview_2_new_user_guide.md` plus ~20 mechanical URL rewrites covering:

- Renamed GitHub orgs: `Jammy2211/<workspace>` → `PyAutoLabs/<workspace>`; `Jammy2211|rhayes777/<library>` → `PyAutoLabs/<library>`
- Removed `release` branch on workspaces: `/blob/release/` → `/blob/main/`, `/tree/release/` → `/tree/main/`
- nautilus sampler moved orgs: `joshspeagle/nautilus` → `johannesulf/nautilus`
- PyAutoBuild moved orgs: `rhayes777/PyAutoBuild` → `PyAutoLabs/PyAutoBuild`
- Dead Code of Conduct links: bokeh CoC → `/docs/CODE_OF_CONDUCT.md`; numfocus → `numfocus.org/code-of-conduct`
- Sphinx-doc: `/en/main` → `/en/master`
- pyautofit.readthedocs.io renames: `cookbook_1_basics` → `cookbooks/model`, `overview/model_fit` → `overview/the_basics`, `overview/result` → `cookbooks/result`, etc.
- Workspace notebook reorganisations: `overview/simple/fit.ipynb` → `overview/overview_1_the_basics.ipynb`, `modeling/imaging/features/<x>.ipynb` → `imaging/features/<x>/modeling.ipynb`, etc.
- Colab badge URL: workspace-root `start_here.ipynb` → `notebooks/<type>/start_here.ipynb` (the bare-root file never existed)

No source-code behaviour changes — only docstring and `.md / .rst / Python-comment` text. CRLF line endings preserved (no whitespace churn).

## Test plan

- [x] `python -m pytest test_<library>` passes
- [x] `python -c "import <library>"` succeeds (verifies docstring edits don't break parsing)
- [ ] Audit re-run after this PR + paired PRs merge

## Related

- Tool PR: Jammy2211/admin_jammy#21
- Issue: PyAutoLabs/PyAutoLens#508
- Workspace-phase follow-up: HowToFit, HowToGalaxy, HowToLens, autofit_workspace, autogalaxy_workspace, autolens_workspace (URLs in symlinked workspace files were SCANNED but not FIXED in this phase)