### PR TITLE
ci: add live URL audit (weekly cron) + grandfather current broken URLs

### DIFF
--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -4,9 +4,16 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    - cron: '0 4 * * 1'  # Mondays 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  url_check:
+  url_check_patterns:
+    name: Offline regex guard
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -21,3 +28,68 @@ jobs:
           path: PyAutoBuild
       - name: Run url_check.sh
         run: bash PyAutoBuild/autobuild/url_check.sh repo
+
+  url_check_live:
+    name: Live HTTP audit (weekly)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: repo
+      - name: Checkout PyAutoBuild
+        uses: actions/checkout@v4
+        with:
+          repository: PyAutoLabs/PyAutoBuild
+          ref: main
+          path: PyAutoBuild
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install requests
+        run: pip install --quiet requests
+      - name: Run live URL audit
+        id: audit
+        run: |
+          set +e
+          body=$(bash PyAutoBuild/autobuild/url_check_live.sh repo)
+          rc=$?
+          printf '%s\n' "$body" > /tmp/url_audit_body.md
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          cat /tmp/url_audit_body.md
+          exit 0
+      - name: Open or update [url-check] tracking issue
+        if: steps.audit.outputs.rc != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd repo
+          existing=$(gh issue list --search '"[url-check]"' --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Updating existing tracking issue #$existing"
+            gh issue comment "$existing" --body-file /tmp/url_audit_body.md
+          else
+            echo "Opening new tracking issue"
+            gh issue create \
+              --title "[url-check] New broken URLs detected" \
+              --body-file /tmp/url_audit_body.md \
+              --label url-check 2>/dev/null \
+              || gh issue create \
+                --title "[url-check] New broken URLs detected" \
+                --body-file /tmp/url_audit_body.md
+          fi
+      - name: Close stale tracking issue if audit is clean
+        if: steps.audit.outputs.rc == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd repo
+          for n in $(gh issue list --search '"[url-check]"' --state open --json number --jq '.[].number'); do
+            echo "Closing now-clean tracking issue #$n"
+            gh issue close "$n" --comment "Weekly URL audit is clean — closing automatically."
+          done

--- a/.url_check_allowlist.txt
+++ b/.url_check_allowlist.txt
@@ -1,0 +1,27 @@
+# Known broken URLs grandfathered for url_check_live.sh.
+# Format: one URL per line. Lines starting with '#' and blank lines are ignored.
+# Sample location follows each URL as a trailing comment.
+#
+# This file is referenced by .github/workflows/url_check.yml (weekly cron).
+# url_check_live.sh fails CI when a URL is broken AND not in this file.
+# To accept new breakage: append the URL here. To force a fix: leave it out.
+
+# Code of Conduct boilerplate
+http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy  # CODE_OF_CONDUCT.md:306
+
+# GitHub refs (workspaces / removed tutorials)
+https://github.com/PyAutoLabs/autofit_workspace/blob/main/notebooks/features/database.ipynb  # docs/api/database.rst:12
+https://github.com/PyAutoLabs/autofit_workspace/tree/main/notebooks/guides/plot  # docs/api/plot.rst:11
+https://github.com/PyAutoLabs/autofit_workspace/tree/main/projects/astro  # docs/science_examples/astronomy.md:325
+
+# Internal PyAuto docs — pages renamed, need editorial fix
+https://pyautofit.readthedocs.io/en/latest/cookbooks/database.html  # autofit/aggregator/aggregator.py:121
+https://pyautofit.readthedocs.io/en/latest/features/database.html  # docs/api/database.rst:11
+https://pyautofit.readthedocs.io/en/latest/general/adding_a_model_component.html  # autofit/mapper/prior/width_modifier.py:69
+https://pyautofit.readthedocs.io/en/latest/general/installation.html#forking-cloning  # CONTRIBUTING.md:96
+https://pyautofit.readthedocs.io/en/latest/general/installation.html#installation-with-pip  # docs/general/workspace.md:7
+
+# Internal image refs missing from main
+https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/features/images/hi.png  # docs/features/interpolate.md:51
+https://raw.githubusercontent.com/PyAutoLabs/PyAutoFit/main/docs/images/corner.png  # docs/cookbooks/samples.md:302
+https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_1_lensing/schematic.jpg  # docs/science_examples/astronomy.md:11


### PR DESCRIPTION
## Summary

Add the live URL-audit CI infrastructure described in PyAutoLabs/PyAutoBuild#87 to **PyAutoFit**.

- **`.url_check_allowlist.txt`** at repo root — 12 URLs the audit currently flags as broken in this repo. Mostly external paywalled / dead links and internal docs renames. Each is grouped by category with the originating file:line as an inline comment.
- **`.github/workflows/url_check.yml`** — extended:
  - **Offline regex guard** (existing job, expanded to ~17 patterns) — runs on every PR + push. Fast, no network. Catches typos like `hhttps://`, stale `Jammy2211/` refs, etc.
  - **Live HTTP audit (NEW)** — runs on `schedule` (Monday 04:00 UTC) and `workflow_dispatch`. Validates every URL in the repo's docs against the allowlist. On new breakage, opens or appends to a tracking issue titled `[url-check] New broken URLs detected`. On a clean run, automatically closes any prior open tracking issue.

No code changes. Doc / CI-only.

## Test plan

- [x] Workflow YAML parses
- [x] `url_check_live.sh PyAutoFit` exits 0 against the current allowlist (post-merge cron run will be a no-op until something new breaks)
- [ ] First weekly cron run after merge confirms the issue-create path works end-to-end

## Related

- Tool PR: PyAutoLabs/PyAutoBuild#87 (must merge first — provides the new live tool and the extended regex patterns)