### PR TITLE
nss extras: strip git+https URLs to unblock PyPI uploads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,6 +137,13 @@ jobs:
         pip install --upgrade pip
         pip install pytest pytest-cov
         pip install ./PyAutoConf "./PyAutoFit[nss]"
+        # blackjax (handley-lab fork) and yallup/nss can't live in the [nss]
+        # extra — PyPI bans direct git+ URLs in uploaded wheel metadata.
+        # Install them post-extras instead. SHAs are the single source of
+        # truth in PyAutoFit/pyproject.toml's [nss] comment — keep in sync.
+        pip install \
+          "blackjax @ git+https://github.com/handley-lab/blackjax.git@ef45acd2f2fa0cca15adbdcd3ff7cb3a98987cb5" \
+          "nss @ git+https://github.com/yallup/nss.git@69159b0f4a3a53123b9eec7df91e4ed3885e4dc4"
     - name: Run NSS tests
       run: |
         export PYTHONPATH=$PWD/PyAutoConf:$PWD/PyAutoFit

--- a/.github/workflows/nss_install_smoke.yml
+++ b/.github/workflows/nss_install_smoke.yml
@@ -1,10 +1,20 @@
 name: NSS install smoke
 
-# Phase 4 of nss_first_class_sampler — verifies that `pip install autofit[nss]`
-# remains a single safe command. Runs on every PR (so we catch local regressions
-# in pyproject.toml before merging) and on a weekly cron (so we catch upstream
-# regressions in handley-lab/blackjax or yallup/nss that drift past the pinned
-# SHAs).
+# Phase 4 of nss_first_class_sampler — verifies that the documented two-step
+# install (`pip install autofit[nss]` followed by the manual `pip install
+# git+...` for the handley-lab/blackjax fork and yallup/nss) lands a working
+# NSS environment.
+#
+# Why two steps: PyPI bans `git+https://` URLs in uploaded wheel metadata
+# (rejection: "400 Can't have direct dependency"), so the fork-based deps
+# cannot live in pyproject.toml's [nss] extra. The SHAs themselves are
+# documented in PyAutoFit/pyproject.toml just above the [nss] entry — keep
+# the two in sync.
+#
+# Runs on every PR (so we catch local regressions in pyproject.toml or in
+# the documented manual install before merging) and on a weekly cron (so we
+# catch upstream regressions in handley-lab/blackjax or yallup/nss that
+# drift past the pinned SHAs).
 
 on:
   pull_request:
@@ -37,6 +47,14 @@ jobs:
         run: python -m pip install -e PyAutoConf
       - name: Install PyAutoFit with [nss] extra
         run: python -m pip install -e PyAutoFit[nss]
+      - name: Install handley-lab/blackjax and yallup/nss (manual, post-extras)
+        # Mirrors the documented two-step install path. Keep these SHAs in
+        # sync with the block at the top of PyAutoFit/pyproject.toml's [nss]
+        # comment — that's the single source of truth.
+        run: |
+          python -m pip install \
+            "blackjax @ git+https://github.com/handley-lab/blackjax.git@ef45acd2f2fa0cca15adbdcd3ff7cb3a98987cb5" \
+            "nss @ git+https://github.com/yallup/nss.git@69159b0f4a3a53123b9eec7df91e4ed3885e4dc4"
       - name: Import smoke
         run: |
           python -c "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,23 +76,33 @@ optional = [
     "nautilus-sampler==1.0.5",
     "zeus-mcmc==2.5.4",
 ]
-# Phase 4 of nss_first_class_sampler — single safe install for `af.NSS`.
-# Pins the `handley-lab/blackjax` fork (BSD-3-Clause) which carries the
-# `blackjax.ns.adaptive.init` entrypoint that mainline blackjax lacks,
-# plus `yallup/nss` (BSD-3-Clause) on top. Both pinned to specific SHAs
-# so installs are reproducible. `fastprogress<1.1` keeps `fastprogress`
+# Phase 4 of nss_first_class_sampler — support package for `af.NSS`.
+#
+# The `handley-lab/blackjax` fork (BSD-3-Clause) carries the
+# `blackjax.ns.adaptive.init` entrypoint that mainline blackjax lacks, and
+# `yallup/nss` (BSD-3-Clause) sits on top. Both are pinned to specific SHAs
+# below — but installed manually rather than declared here, because PyPI and
+# TestPyPI reject direct `git+https://` URLs in uploaded wheels with:
+#
+#   400 Can't have direct dependency: blackjax @ git+...
+#
+# After `pip install autofit[nss]`, complete the install with:
+#
+#   pip install \
+#     "blackjax @ git+https://github.com/handley-lab/blackjax.git@ef45acd2f2fa0cca15adbdcd3ff7cb3a98987cb5" \
+#     "nss @ git+https://github.com/yallup/nss.git@69159b0f4a3a53123b9eec7df91e4ed3885e4dc4"
+#
+# blackjax SHA `ef45acd2` is the May 2026 "Merge PR #60 — double_compile"
+# revision, locally validated against the Phase 1-3 work. blackjax HEAD
+# (5dbf89a9 at pin time) introduced `numpy>=1.25`, which conflicts with
+# autofit's `anesthetic==2.8.14` (numpy<2.0) — bump only after both pins
+# move together. See PyAutoPrompt/issued/nss_install_simplification.md
+# notes #3-4 for context.
+#
+# `fastprogress<1.1` stays here as a regular PyPI dep — it keeps fastprogress
 # from pulling `python-fasthtml` (1.1.5 transitively requires it).
-# Re-pin SHAs periodically — see `autofit/install_nss.py` for the manual
-# fallback when pip's resolver cannot sequence the URL deps cleanly.
 nss = [
     "fastprogress<1.1",
-    # blackjax pinned to ef45acd2 (May 2026 "Merge pull request #60 — double_compile").
-    # Locally-validated against the entire Phase 1-3 nss_first_class_sampler work.
-    # HEAD as of pin time (5dbf89a9) introduced `numpy>=1.25` which conflicts with
-    # autofit's `anesthetic==2.8.14` (numpy<2.0). Bump only after both pins move
-    # together — see PyAutoPrompt/issued/nss_install_simplification.md notes #3-4.
-    "blackjax @ git+https://github.com/handley-lab/blackjax.git@ef45acd2f2fa0cca15adbdcd3ff7cb3a98987cb5",
-    "nss @ git+https://github.com/yallup/nss.git@69159b0f4a3a53123b9eec7df91e4ed3885e4dc4",
 ]
 docs=[
     "sphinx",


### PR DESCRIPTION
## Summary

- Removes the two `git+https://...` direct deps from PyAutoFit's `[nss]` extra (`blackjax @ git+...` and `nss @ git+...`).
- Documents the manual `pip install git+...` step for the fork-based deps directly in the pyproject.toml comment, where users will see it after `pip install autofit[nss]`.
- Keeps the `[nss]` extra functional — `fastprogress<1.1` (the only true PyPI dep) stays.
- SHAs are unchanged; this is purely a metadata-cleanup change.

## Why

The `[nss]` extra was added in commit 4d42e55a (2026-05-16). PyPI and TestPyPI both reject wheels that declare direct `git+` URLs in their `Requires-Dist` metadata:

```
400 Can't have direct dependency: blackjax @ git+https://github.com/handley-lab/blackjax.git@... ; extra == "nss"
```

Last successful PyAutoFit PyPI release was 2026.5.14.2 (May 14). Every release since has been silently blocked at the twine upload step. Today's TestPyPI rehearsal for the JAX 0.7.0 floor bump surfaced this — autoconf / autoarray / autogalaxy / autolens uploaded fine; autofit failed.

## Test plan

- [x] `python -m build --wheel` produces a clean wheel; METADATA contains no `git+` strings
- [x] METADATA still has `Requires-Dist: fastprogress<1.1; extra == "nss"` and `Requires-Dist: blackjax>=1.2.0; extra == "optional"`
- [x] PyAutoFit `test_autofit/mapper` smoke: 632 passed
- [ ] CI green
- [ ] Confirm next TestPyPI rehearsal goes through cleanly

## Companion context

This unblocks the JAX 0.7.0 floor bump shipping to PyPI (PyAutoConf #108, PyAutoArray #328, PyAutoGalaxy #432, PyAutoBuild #92 — all merged but waiting on this fix before a TestPyPI rehearsal can succeed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)