### PR TITLE
fix(jax): keep parameterization cache off ModelInstance + auto-register pytrees

### DIFF
--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -1,5 +1,4 @@
 import copy
-import functools
 import inspect
 import json
 import logging
@@ -1860,12 +1859,26 @@ class AbstractPriorModel(AbstractModel):
         ]
         return ":".join(values)
 
-    @functools.cached_property
+    @property
     def parameterization(self) -> str:
         """
         Describes the path to each of the PriorModels, its class
-        and its number of free parameters
+        and its number of free parameters.
+
+        Cached on first access in ``self.__dict__`` under the
+        ``_`` -prefixed key ``_parameterization_cache`` so that
+        ``Collection._instance_for_arguments`` and
+        ``ModelInstance.dict`` (which iterate ``__dict__`` and filter
+        underscore-prefixed keys) do not propagate the cached string
+        onto the constructed ``ModelInstance``. A plain
+        ``functools.cached_property`` writes to ``__dict__[name]``
+        without a leading underscore, which would leak the string as
+        a non-array JAX pytree leaf and break ``jax.jit(fit_from)``.
         """
+        cached = self.__dict__.get("_parameterization_cache")
+        if cached is not None:
+            return cached
+
         from .prior_model import Model
 
         formatter = TextFormatter(line_length=info_whitespace())
@@ -1900,6 +1913,7 @@ class AbstractPriorModel(AbstractModel):
         for group in find_groups(paths, limit=0):
             formatter.add(*group)
 
+        self.__dict__["_parameterization_cache"] = formatter.text
         return formatter.text
 
     @property

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -122,6 +122,12 @@ class Fitness:
         self.use_jax_vmap = use_jax_vmap
         self.use_jax_jit = use_jax_jit
 
+        if getattr(self.analysis, "_use_jax", False):
+            from autofit.jax.pytrees import enable_pytrees, register_model
+
+            enable_pytrees()
+            register_model(self.model)
+
         self._call = self.call
 
         if self.use_jax_vmap:

--- a/test_autofit/mapper/test_parameterization.py
+++ b/test_autofit/mapper/test_parameterization.py
@@ -141,6 +141,41 @@ tuple                                                                           
         assert len(info.split("\n")) == len(mapper.info.split("\n"))
 
 
+def test_parameterization_cache_does_not_leak_into_instance():
+    """Regression: ``parameterization`` is cached in
+    ``self.__dict__["_parameterization_cache"]`` so that
+    ``Collection._instance_for_arguments`` and ``ModelInstance.dict``
+    (which skip underscore-prefixed keys) do not propagate the cached
+    string onto the constructed instance. A plain
+    ``functools.cached_property`` would write to ``__dict__["parameterization"]``
+    without an underscore, leaking the string into ``ModelInstance.dict``
+    and downstream JAX pytree flattening — see commit 4564ae9a1."""
+
+    model = af.Collection(gaussian=af.Model(af.ex.Gaussian))
+
+    # Touch model.info → exercises the same propagation path that every
+    # workspace script hits at construction time.
+    _ = model.info
+    _ = model.parameterization  # second access uses the cache
+
+    # The cache must live behind an underscore key on the model.
+    assert "_parameterization_cache" in model.__dict__
+    assert "parameterization" not in model.__dict__
+
+    instance = model.instance_from_prior_medians()
+
+    # Neither the cached key nor the public name may appear on the
+    # constructed instance.
+    assert "parameterization" not in instance.__dict__
+    assert "_parameterization_cache" not in instance.__dict__
+    assert "parameterization" not in instance.dict
+    assert "_parameterization_cache" not in instance.dict
+
+    # The instance must yield only model components when iterated.
+    for child in instance:
+        assert not isinstance(child, str)
+
+
 def test_integer_attributes():
     model = af.Model(af.ex.Gaussian)
 


### PR DESCRIPTION
## Summary

Two coupled fixes restoring the JAX `jit(fit_from)` path that broke when commit `4564ae9a1` made `AbstractPriorModel.parameterization` a `functools.cached_property`. Surfaced as 40 failing scripts across `autogalaxy_workspace_test`, `autolens_workspace_test`, and `autofit_workspace` in the 2026-05-28 release-prep triage.

- **Fix 1 — parameterization cache**: store the cached string under the underscore-prefixed key `_parameterization_cache` so `Collection._instance_for_arguments` (`collection.py:289`) and `ModelInstance.dict` (`model.py:451`) — both of which iterate `__dict__` and skip only `_`-prefixed keys — filter it out. Preserves the 2.7s → 0.05s perf win from `4564ae9a1`.
- **Fix 2 — auto-register pytrees**: call `enable_pytrees() + register_model(self.model)` from `Fitness.__init__` whenever `analysis._use_jax=True`. Both helpers are idempotent, so workspaces that still call them explicitly keep working. New JAX-enabled workspaces don't need the boilerplate.

## Root cause

`cached_property` writes to `self.__dict__["parameterization"]`. After any `model.info` access (every script does this), `Collection._instance_for_arguments` copies the string onto every `ModelInstance`. The string then either:

- surfaces as a non-array JAX pytree leaf → `TypeError: Error interpreting argument to <jit>... fit_from ... ModelInstance ... static_argnums` in the 38 `jax_likelihood_functions/*` scripts (Cluster C1 of the triage), or
- gets yielded by `for x in instance` → `AttributeError: 'str' object has no attribute 'model_data_from'` in `overview/overview_1_the_basics.py` (Cluster C4).

## Test plan

- [x] `pytest test_autofit` — 1413/1413 pass + new `test_parameterization_cache_does_not_leak_into_instance` regression (numpy-only per `feedback_no_jax_in_unit_tests`).
- [x] `python autofit_workspace/scripts/overview/overview_1_the_basics.py` (C4 reproducer) — runs to completion.
- [x] `python autolens_workspace_test/scripts/jax_likelihood_functions/imaging/rectangular.py` (C1 reproducer) — prints `PASS: jit(fit_from) round-trip matches NumPy scalar.`. Notably worked **without** any explicit `enable_pytrees() + register_model()` in the script, confirming the `Fitness.__init__` auto-call landed correctly.
- [ ] Reviewer to sanity-check that the `_parameterization_cache` key is filtered by every `__dict__`-iterator in `autofit/mapper/` (a follow-up issue will harden this with a `_cached_property_names(cls)` classmethod — see below).

## Follow-up

A systemic audit during planning found the class of bug is structural — 4 `__dict__` iterators in `autofit/mapper/` plus `autoarray/abstract_ndarray.py:108-119` all use opt-out filters that default to leak. The first future `@cached_property` added to `AbstractPriorModel`/`Model`/`Collection`/`ModelInstance` (or to a JAX-pytree-registered Fit class with a non-array return) reintroduces the bug. Plus `AbstractModel.__getstate__` (`model.py:86`) currently pickles the cached `parameterization` string into the SQLAlchemy DB.

A separate `feat(jax): structural defense against cached_property pytree leaks` issue/PR will add a `_cached_property_names(cls)` classmethod applied as an extra exclusion at every leak site, so this entire class of bug is closed permanently in one shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)