### PR TITLE
chore(deps): allow anesthetic>=2.9.0 to unblock jax>=0.7 / numpy>=2 resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ keywords = ["cli"]
 dependencies = [
     "autoconf",
     "array_api_compat",
-    "anesthetic==2.8.14; python_version < '3.13'",
-    "anesthetic>=2.9.0; python_version >= '3.13'",
+    "anesthetic>=2.9.0",
     "corner==2.2.2",
     "decorator>=4.2.1",
     "dill>=0.3.1.1",
@@ -94,10 +93,11 @@ optional = [
 #
 # blackjax SHA `ef45acd2` is the May 2026 "Merge PR #60 — double_compile"
 # revision, locally validated against the Phase 1-3 work. blackjax HEAD
-# (5dbf89a9 at pin time) introduced `numpy>=1.25`, which conflicts with
-# autofit's `anesthetic==2.8.14` (numpy<2.0) — bump only after both pins
-# move together. See PyAutoPrompt/issued/nss_install_simplification.md
-# notes #3-4 for context.
+# (5dbf89a9 at pin time) introduced `numpy>=1.25`. autofit's anesthetic
+# pin has since been bumped to `>=2.9.0` (numpy>=2 compatible) so the
+# previous "bump only after both pins move together" constraint is now
+# resolved. See PyAutoPrompt/issued/nss_install_simplification.md notes
+# #3-4 for the historic context.
 #
 # `fastprogress<1.1` stays here as a regular PyPI dep — it keeps fastprogress
 # from pulling `python-fasthtml` (1.1.5 transitively requires it).


### PR DESCRIPTION
## Summary

- Bumps `anesthetic` from the exact pin `==2.8.14` (python<3.13 branch) to `>=2.9.0`, collapsing the previous two python-version-conditional lines into one.
- The old pin transitively required `numpy<2`, which caused pip's resolver in `release.yml`'s `until ... pip install autoconf[optional]==$VERSION ...` block to backsolve `jax` to `0.4.28`. Subsequent steps then silently dropped JAX from the environment entirely, so every `run_scripts` job failed in ~0.1s with `ModuleNotFoundError: No module named 'jax'`.
- After this bump, `pip install -e .[optional]` locally resolves to **anesthetic 2.14.6, numpy 2.2.6, jax 0.9.2**.

## Why this is safe

- `anesthetic>=2.9.0` supports Python 3.9 (the existing `python_version<'3.13'` branch's lower bound), so the conditional pin is no longer needed.
- The new `>=` constraint matches what was already in place for python>=3.13.
- The nss/blackjax compatibility note in the file is updated: the previous "bump only after both pins move together" constraint is now resolved.

## Test plan

- [x] Local `pip install -e .[optional]` resolves jax 0.7+ (got 0.9.2)
- [x] `pytest test_autofit` — 1404 passed, 13 failed (all pre-existing NSS tests requiring the manually-installed `handley-lab/blackjax` fork via `pip install autofit[nss]`, unrelated to anesthetic)
- [ ] CI on this PR
- [ ] Paired with PyAutoBuild release.yml backstop PR before next `pre_build` dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)