### PR TITLE
docs: add signpost llms.txt + consolidate agent instructions into AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,25 +1,10 @@
 # Copilot Coding Agent Instructions
 
-You are working on **PyAutoFit**, a Python probabilistic programming library for model fitting and Bayesian inference.
+You are working on **PyAutoFit**, a probabilistic programming library for model
+composition and non-linear search / Bayesian inference (package `autofit`).
 
-## Key Rules
-
-- Run tests after every change: `python -m pytest test_autofit/`
-- Format code with `black autofit/`
-- All files must use Unix line endings (LF, `\n`)
-- If changing public API (function signatures, class names, import paths), clearly document what changed in your PR description — downstream packages depend on this
-
-## Architecture
-
-- `autofit/non_linear/search/` — Non-linear search algorithms (MCMC, nested sampling, MLE)
-- `autofit/mapper/` — Model composition and prior machinery
-- `autofit/graphical/` — Graphical models and expectation propagation
-- `autofit/aggregator/` — Results aggregation
-- `autofit/database/` — SQLAlchemy results database
-- `test_autofit/` — Test suite
-
-## Sandboxed runs
-
-```bash
-NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest test_autofit/
-```
+The canonical, agent-agnostic instructions for this repo live in **`AGENTS.md`** at
+the repository root — build and test commands, architecture, the model/search
+subsystems, and conventions (including the `[nss]` / blackjax install gotcha). Read
+it directly (Copilot does not process `@`-imports) and treat it as the single source
+of truth.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,20 @@
+# PyAutoFit
+
+> PyAutoFit (package `autofit`) is a probabilistic programming library for model composition and non-linear search / Bayesian inference — `af.Model`/`af.Collection`, the `af.Analysis` interface, MCMC / nested-sampling / MLE searches, and a results aggregator and database. This file is a signpost: it points you to the right resource by intent — use the API, learn it, or work on the library itself.
+
+## Use it (examples & tutorials)
+
+- [autofit_workspace navigator](https://github.com/PyAutoLabs/autofit_workspace/blob/main/llms.txt): end-to-end example scripts and notebooks per task — the paste-friendly task router. Send any "how do I compose a model / run a search / inspect results?" question here.
+- [HowToFit](https://github.com/PyAutoLabs/HowToFit): from-first-principles lecture series on model fitting and Bayesian inference.
+
+## API reference & docs
+
+- [PyAutoFit documentation (ReadTheDocs)](https://pyautofit.readthedocs.io/en/latest/): API reference, feature overviews, and the installation guide.
+
+## Work on it (contributors / coding agents)
+
+- [AGENTS.md](./AGENTS.md): build, tests, architecture, and conventions.
+
+## Ecosystem
+
+- Built on PyAutoConf (config); used by PyAutoGalaxy and PyAutoLens, which build `Analysis` subclasses on it.


### PR DESCRIPTION
## Summary

Two docs-only changes, mirroring the PyAutoLens treatment:

1. **Consolidate agent instructions into canonical `AGENTS.md`** — reduce `.github/copilot-instructions.md` to a thin pointer to `AGENTS.md` (the single source of truth; `CLAUDE.md` already `@`-imports it), dropping content duplicated in or superseded by `AGENTS.md` (including stale decorator names / module maps where present).
2. **Add a signpost `llms.txt`** at the repo root — a thin front door (llms.txt convention: H1 + blockquote, then sections of one-line links) routing an LLM by intent. It only points; no source-tree catalogue, no AGENTS.md/docs duplication.

All links verified live (PyAutoLabs org; workspace `llms.txt` on `origin/main`; docs URLs from README / `.readthedocs.yaml`).

## Scripts Changed
None — docs only.

## API Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)