### PR TITLE
ci: pause routine scheduled (cron) workflow runs

### DIFF
--- a/.github/workflows/nss_install_smoke.yml
+++ b/.github/workflows/nss_install_smoke.yml
@@ -18,9 +18,11 @@ name: NSS install smoke
 
 on:
   pull_request:
-  schedule:
-    # Sundays at 03:00 UTC — quiet hours, catches upstream drift weekly.
-    - cron: '0 3 * * 0'
+  workflow_dispatch:
+  # --- PAUSED 2026-07-06: routine cron disabled org-wide; re-enable by uncommenting ---
+  # schedule:
+  #   # Sundays at 03:00 UTC — quiet hours, catches upstream drift weekly.
+  #   - cron: '0 3 * * 0'
 
 jobs:
   fresh_venv_install:


### PR DESCRIPTION
## Summary

Pauses all routine **scheduled (cron)** workflow runs across the org for now. The `schedule:` trigger in each routine workflow is commented out (not deleted) so the infrastructure stays fully in place and re-enabling is a one-line uncomment of the marked block.

Prompted by recurring GitHub failure emails from the daily release pushing version-bump commits to each library, which fired now-stale test runs. Rather than chase individual green-ness, the decision was to quiet all cron noise until we revisit.

## What's preserved

Every workflow file remains, and every non-cron trigger is kept, so all workflows stay manually runnable:

- `workflow_dispatch` (manual "Run workflow" button)
- `workflow_call` (reusable-workflow callers)
- `pull_request` (PR-time gating)

`nss_install_smoke.yml` gains a `workflow_dispatch:` so it too stays hand-runnable after its cron is paused.

## Note

For PyAutoBuild: this pauses the **scheduled** production release (weekdays 02:00 UTC). Releases can still be triggered manually via `workflow_dispatch`. No PyPI/tagging behaviour is otherwise changed.

Each paused block is marked `# --- PAUSED 2026-07-06: routine cron disabled org-wide; re-enable by uncommenting ---`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)