### PR TITLE
fix: treat test mode zero as disabled

### DIFF
--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -11,6 +11,7 @@ from typing import Optional
 import numpy as np
 
 from autoconf import conf
+from autoconf.test_mode import is_test_mode
 from autofit.mapper.identifier import Identifier, IdentifierField
 from autofit.non_linear.samples.summary import SamplesSummary
 
@@ -24,15 +25,15 @@ pattern = re.compile(r"(?<!^)(?=[A-Z])")
 
 def _test_mode_segment() -> Optional[str]:
     """
-    Returns ``"test_mode"`` when ``PYAUTO_TEST_MODE`` is set in the
-    environment, else ``None``.
+    Returns ``"test_mode"`` when ``PYAUTO_TEST_MODE`` is active, else
+    ``None``.
 
     Inserted into the output-path composition so that smoke runs land
     under ``output/test_mode/...`` instead of sharing a directory with
     real runs. Without this, a cached test-mode result short-circuits
     a later real run at the same paths ("Fit Already Completed").
     """
-    return "test_mode" if os.environ.get("PYAUTO_TEST_MODE") else None
+    return "test_mode" if is_test_mode() else None
 
 
 class AbstractPaths(ABC):
@@ -66,7 +67,7 @@ class AbstractPaths(ABC):
 
         /path/to/output/folder_0/folder_1/name
 
-        If the ``PYAUTO_TEST_MODE`` environment variable is set, a
+        If the ``PYAUTO_TEST_MODE`` environment variable is active, a
         ``test_mode`` segment is inserted directly after the output
         root:
 

--- a/test_autofit/non_linear/paths/test_paths.py
+++ b/test_autofit/non_linear/paths/test_paths.py
@@ -96,6 +96,11 @@ class TestTestModeOutputPath:
         paths = af.DirectoryPaths(name="name", path_prefix="prefix")
         assert "test_mode" not in paths.output_path.parts
 
+    def test_output_path_excludes_segment_when_env_zero(self, monkeypatch):
+        monkeypatch.setenv("PYAUTO_TEST_MODE", "0")
+        paths = af.DirectoryPaths(name="name", path_prefix="prefix")
+        assert "test_mode" not in paths.output_path.parts
+
     def test_make_path_contains_segment_when_env_set(self, monkeypatch):
         monkeypatch.setenv("PYAUTO_TEST_MODE", "2")
         paths = af.DirectoryPaths(name="name", path_prefix="prefix")


### PR DESCRIPTION
## Summary
Treat the documented `PYAUTO_TEST_MODE=0` value as disabled when composing search output paths. This keeps release-profile searches in the normal output tree while preserving `output/test_mode/` isolation for active test levels.

## API Changes
`DirectoryPaths` now treats `PYAUTO_TEST_MODE=0` the same as an unset variable. Active levels `1`, `2`, and `3` continue to add the `test_mode` output segment.
See full details below.

## Test Plan
- [x] `python -m pytest test_autofit/ -x` — 1422 passed, 14 skipped
- [x] Clean release-profile Nautilus run writes to `output/results_folder/`
- [x] `PYAUTO_TEST_MODE=2` remains covered by path tests

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- None.

### Renamed
- None.

### Changed Signature
- None.

### Changed Behaviour
- `autofit.DirectoryPaths.output_path` — `PYAUTO_TEST_MODE=0` no longer inserts a `test_mode` path segment; only active test-mode levels do.

### Migration
- None required. Existing active test-mode paths are unchanged.

</details>

🤖 Generated with [Codex](https://openai.com/codex/)