### PR TITLE
refactor!: depend on and import `autonerves` (renamed from autoconf)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ model composition, non-linear search, and Bayesian inference: `af.Model` /
 `af.Collection`, the `af.Analysis` interface, MCMC / nested-sampling / MLE
 searches, samples, aggregator, and a SQLAlchemy results database.
 
-Dependency direction: autofit depends on **autoconf** only. It does **not**
+Dependency direction: autofit depends on **autonerves** only. It does **not**
 import `autoarray`, `autogalaxy`, or `autolens` — never add such an import.
-Shared utilities (e.g. `test_mode`, `jax_wrapper`) belong in autoconf.
+Shared utilities (e.g. `test_mode`, `jax_wrapper`) belong in autonerves.
 
 ## Related repos
 
@@ -47,7 +47,7 @@ is no black/ruff/flake8 gate — formatting is advisory. (`requires-python` in
 
 ## Configuration & defaults
 
-autoconf supplies the packaged defaults under `autofit/config/`. Workspaces
+autonerves supplies the packaged defaults under `autofit/config/`. Workspaces
 override them via their own `config/` directory; the test suite pushes a local
 config dir via `conf.instance.push(...)` in `test_autofit/conftest.py`. When a
 change adds a new config key, mirror it into the packaged defaults so
@@ -70,7 +70,7 @@ nautilus; MLE: LBFGS/BFGS/drawer), `mapper/` (model + priors),
 
 ## Key rules / footguns
 
-- Import direction: autoconf only — never `autoarray` / `autogalaxy` /
+- Import direction: autonerves only — never `autoarray` / `autogalaxy` /
   `autolens`.
 - **The EP seam rule**: `autofit/graphical` is two layers — the inner
   factor-graph/message engine and the `declarative/` user layer. A new

--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -1,5 +1,5 @@
-from autoconf import jax_wrapper
-from autoconf.dictable import register_parser
+from autonerves import jax_wrapper
+from autonerves.dictable import register_parser
 from . import conf
 
 conf.instance.register(__file__)
@@ -146,34 +146,34 @@ def save_abc(pickler, obj):
 
 __version__ = "2026.7.9.1"
 
-from autoconf import check_version
+from autonerves import check_version
 
 check_version(__version__)
 
 # ---------------------------------------------------------------------------
-# Public re-export of the autoconf configuration / serialization surface.
+# Public re-export of the autonerves configuration / serialization surface.
 #
 # Workspaces, tutorials and downstream code import these names from the science
 # library (e.g. ``from autolens import conf``) rather than depending on the
-# ``autoconf`` package directly, so the underlying configuration / serialization
+# ``autonerves`` package directly, so the underlying configuration / serialization
 # layer stays an implementation detail of the library.
 # ---------------------------------------------------------------------------
 # ``conf`` is already exported above (``from . import conf``); the names below
 # complete the surface.
-from autoconf import jax_wrapper
-from autoconf import fitsable
-from autoconf import setup_colab
-from autoconf import setup_notebook
-from autoconf.conf import with_config
-from autoconf.dictable import from_dict, from_json, to_dict, output_to_json
-from autoconf.fitsable import (
+from autonerves import jax_wrapper
+from autonerves import fitsable
+from autonerves import setup_colab
+from autonerves import setup_notebook
+from autonerves.conf import with_config
+from autonerves.dictable import from_dict, from_json, to_dict, output_to_json
+from autonerves.fitsable import (
     output_to_fits,
     hdu_list_for_output_from,
     ndarray_via_fits_from,
     ndarray_via_hdu_from,
     header_obj_from,
 )
-from autoconf.test_mode import (
+from autonerves.test_mode import (
     with_test_mode_segment,
     skip_visualization,
     skip_fit_output,

--- a/autofit/aggregator/file_output.py
+++ b/autofit/aggregator/file_output.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import dill
 
-from autoconf.dictable import from_dict
+from autonerves.dictable import from_dict
 
 
 class FileOutput(ABC):

--- a/autofit/aggregator/search_output.py
+++ b/autofit/aggregator/search_output.py
@@ -9,8 +9,8 @@ from typing import Generator, Tuple, Optional, List, cast, Type
 import dill
 from PIL import Image
 
-from autoconf import cached_property
-from autoconf.class_path import get_class
+from autonerves import cached_property
+from autonerves.class_path import get_class
 from autofit.non_linear.samples import Samples
 
 from autofit.non_linear.samples.pdf import SamplesPDF
@@ -20,7 +20,7 @@ from autofit.aggregator.file_output import (
 )
 from autofit.mapper.identifier import Identifier
 from autofit.non_linear.samples.sample import samples_from_iterator
-from autoconf.dictable import from_dict
+from autonerves.dictable import from_dict
 from autofit.non_linear.samples.summary import SamplesSummary
 from autofit.non_linear.samples.util import simple_model_for_kwargs
 from . import fit_interface
@@ -164,7 +164,7 @@ class AbstractSearchOutput(ABC):
         This may be a pickle, json, csv or fits file.
 
         If the JSON has a specified type it is parsed as that type. See dictable.py
-        in autoconf.
+        in autonerves.
 
         Returns None if the file does not exist.
 

--- a/autofit/conf.py
+++ b/autofit/conf.py
@@ -1,1 +1,1 @@
-from autoconf.conf import *
+from autonerves.conf import *

--- a/autofit/database/__init__.py
+++ b/autofit/database/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from .sqlalchemy_ import sa
 
-from autoconf import conf
+from autonerves import conf
 from .aggregator import *
 from .migration.steps import migrator
 from .model import *

--- a/autofit/database/model/array.py
+++ b/autofit/database/model/array.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from autoconf.class_path import get_class_path, get_class
+from autonerves.class_path import get_class_path, get_class
 from .model import Object
 from ..sqlalchemy_ import sa
 

--- a/autofit/database/model/fit.py
+++ b/autofit/database/model/fit.py
@@ -6,7 +6,7 @@ from typing import List
 
 import numpy as np
 
-from autoconf.dictable import from_dict
+from autonerves.dictable import from_dict
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.samples import Samples
 from .model import Base, Object

--- a/autofit/database/model/model.py
+++ b/autofit/database/model/model.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Any, Iterable, Union, ItemsView, Type
 
 import numpy as np
 
-from autoconf.class_path import get_class, get_class_path
+from autonerves.class_path import get_class, get_class_path
 from ..sqlalchemy_ import sa
 from sqlalchemy.orm import declarative_base
 

--- a/autofit/exc.py
+++ b/autofit/exc.py
@@ -1,4 +1,4 @@
-from autoconf.exc import PriorException
+from autonerves.exc import PriorException
 
 
 class MessageException(PriorException):

--- a/autofit/graphical/expectation_propagation/ep_mean_field.py
+++ b/autofit/graphical/expectation_propagation/ep_mean_field.py
@@ -3,7 +3,7 @@ from typing import Dict, Tuple, Optional, List
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit.graphical.factor_graphs.factor import Factor
 from autofit.graphical.factor_graphs.graph import FactorGraph
 from autofit.graphical.mean_field import MeanField, FactorApproximation

--- a/autofit/graphical/factor_graphs/abstract.py
+++ b/autofit/graphical/factor_graphs/abstract.py
@@ -13,7 +13,7 @@ from typing import (
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit.graphical.utils import (
     FlattenArrays,
     nested_filter,

--- a/autofit/graphical/factor_graphs/graph.py
+++ b/autofit/graphical/factor_graphs/graph.py
@@ -5,7 +5,7 @@ from typing import Tuple, Dict, Collection, List, Type
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit.graphical.factor_graphs.abstract import FactorValue, AbstractNode
 from autofit.graphical.factor_graphs.factor import Factor
 from autofit.graphical.factor_graphs.jacobians import VectorJacobianProduct

--- a/autofit/graphical/factor_graphs/jacobians.py
+++ b/autofit/graphical/factor_graphs/jacobians.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit.graphical.utils import (
     nested_filter,
     nested_update,

--- a/autofit/graphical/factor_graphs/transform.py
+++ b/autofit/graphical/factor_graphs/transform.py
@@ -3,7 +3,7 @@ from typing import Dict, Tuple, Optional, List
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit.graphical.factor_graphs.abstract import AbstractNode, Value, FactorValue
 # from ...mapper.operator import
 from autofit.mapper.operator import (

--- a/autofit/graphical/laplace/line_search.py
+++ b/autofit/graphical/laplace/line_search.py
@@ -12,7 +12,7 @@ from typing import Optional, Dict, Tuple
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit.graphical.factor_graphs.abstract import (
     FactorValue,
     FactorInterface,

--- a/autofit/graphical/mean_field.py
+++ b/autofit/graphical/mean_field.py
@@ -6,7 +6,7 @@ from operator import attrgetter
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit import exc
 from autofit.graphical.factor_graphs.abstract import AbstractNode
 from autofit.graphical.factor_graphs.factor import Factor

--- a/autofit/jax/pytrees.py
+++ b/autofit/jax/pytrees.py
@@ -2,12 +2,12 @@
 
 The classes themselves already carry the necessary ``tree_flatten`` /
 ``tree_unflatten`` methods. This module simply registers them with
-``jax.tree_util`` on demand, via the lazy autoconf wrapper, so callers can
+``jax.tree_util`` on demand, via the lazy autonerves wrapper, so callers can
 pass ``Model`` / ``Collection`` / ``ModelInstance`` / prior instances
 through ``jax.jit`` and ``jax.vmap`` directly.
 """
 
-from autoconf.jax_wrapper import register_pytree_node, register_pytree_node_class
+from autonerves.jax_wrapper import register_pytree_node, register_pytree_node_class
 
 _ENABLED = False
 _REGISTERED_INSTANCE_CLASSES: set = set()

--- a/autofit/mapper/identifier.py
+++ b/autofit/mapper/identifier.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from hashlib import md5
 from typing import Optional
 
-from autoconf.class_path import get_class_path
+from autonerves.class_path import get_class_path
 
 # floats are rounded to this increment so floating point errors
 # have no impact on identifier value

--- a/autofit/mapper/model.py
+++ b/autofit/mapper/model.py
@@ -95,7 +95,7 @@ class AbstractModel(ModelObject):
         downstream JAX pytree flattening. See PyAutoFit#1300 for the
         diagnosed leak this defends against.
         """
-        from autoconf.tools.decorators import cached_property_names
+        from autonerves.tools.decorators import cached_property_names
 
         return cached_property_names(cls)
 

--- a/autofit/mapper/model_object.py
+++ b/autofit/mapper/model_object.py
@@ -3,8 +3,8 @@ import itertools
 from typing import Type, Union, Tuple, Optional, Dict
 import logging
 
-from autoconf.class_path import get_class
-from autoconf.dictable import from_dict, to_dict
+from autonerves.class_path import get_class
+from autonerves.dictable import from_dict, to_dict
 from .identifier import Identifier
 
 logger = logging.getLogger(__name__)

--- a/autofit/mapper/operator.py
+++ b/autofit/mapper/operator.py
@@ -5,7 +5,7 @@ from typing import Tuple, List
 import numpy as np
 
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 
 class LinearOperator(ABC):

--- a/autofit/mapper/prior/abstract.py
+++ b/autofit/mapper/prior/abstract.py
@@ -6,7 +6,7 @@ from typing import Union, Tuple, Optional, Dict
 
 import numpy as np
 
-from autoconf import conf
+from autonerves import conf
 
 from autofit.mapper.prior.arithmetic import ArithmeticMixin
 from autofit.mapper.prior.constant import Constant

--- a/autofit/mapper/prior/width_modifier.py
+++ b/autofit/mapper/prior/width_modifier.py
@@ -3,8 +3,8 @@ import logging
 import sys
 from abc import ABC, abstractmethod
 
-from autoconf import conf
-from autoconf.exc import ConfigException
+from autonerves import conf
+from autonerves.exc import ConfigException
 
 logger = logging.getLogger(__name__)
 

--- a/autofit/mapper/prior_model/abstract.py
+++ b/autofit/mapper/prior_model/abstract.py
@@ -9,8 +9,8 @@ from typing import Tuple, Optional, Dict, List, Iterable, Generator, Union, Type
 
 import numpy as np
 
-from autoconf import conf
-from autoconf.exc import ConfigException
+from autonerves import conf
+from autonerves.exc import ConfigException
 from autofit import exc
 from autofit.mapper import model
 from autofit.mapper.model import AbstractModel, frozen_cache

--- a/autofit/mapper/prior_model/array.py
+++ b/autofit/mapper/prior_model/array.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Dict, Optional, Union
 
-from autoconf.dictable import from_dict
+from autonerves.dictable import from_dict
 from .abstract import AbstractPriorModel
 from autofit.mapper.prior.abstract import Prior
 import numpy as np

--- a/autofit/mapper/prior_model/prior_model.py
+++ b/autofit/mapper/prior_model/prior_model.py
@@ -6,8 +6,8 @@ import numpy as np
 import typing
 from typing import *
 
-from autoconf.class_path import get_class_path
-from autoconf.exc import ConfigException
+from autonerves.class_path import get_class_path
+from autonerves.exc import ConfigException
 from autofit.mapper.model import assert_not_frozen
 from autofit.mapper.model_object import ModelObject
 from autofit.mapper.prior.abstract import Prior

--- a/autofit/mapper/variable.py
+++ b/autofit/mapper/variable.py
@@ -6,7 +6,7 @@ from functools import wraps, reduce
 from math import sqrt
 
 import numpy as np
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autofit.mapper.model_object import ModelObject
 

--- a/autofit/mapper/variable_operator.py
+++ b/autofit/mapper/variable_operator.py
@@ -5,7 +5,7 @@ from collections import ChainMap
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autofit.mapper.operator import (
     LinearOperator,

--- a/autofit/messages/abstract.py
+++ b/autofit/messages/abstract.py
@@ -11,7 +11,7 @@ from typing import Optional, Union, Type, List
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from ..mapper.variable import Variable
 
 from .interface import MessageInterface

--- a/autofit/messages/beta.py
+++ b/autofit/messages/beta.py
@@ -4,7 +4,7 @@ from typing import Tuple, Union
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from ..messages.abstract import AbstractMessage
 
 

--- a/autofit/messages/fixed.py
+++ b/autofit/messages/fixed.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit.messages.abstract import AbstractMessage
 
 

--- a/autofit/messages/gamma.py
+++ b/autofit/messages/gamma.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit.messages.abstract import AbstractMessage
 from autofit.messages.utils import invpsilog
 

--- a/autofit/messages/interface.py
+++ b/autofit/messages/interface.py
@@ -4,7 +4,7 @@ from typing import Union
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 
 class MessageInterface(ABC):

--- a/autofit/messages/normal.py
+++ b/autofit/messages/normal.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit.mapper.operator import LinearOperator
 from autofit.messages.abstract import AbstractMessage
 from .composed_transform import TransformedMessage

--- a/autofit/messages/truncated_normal.py
+++ b/autofit/messages/truncated_normal.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 from autofit.mapper.operator import LinearOperator
 from autofit.messages.abstract import AbstractMessage
 from .composed_transform import TransformedMessage

--- a/autofit/non_linear/analysis/latent.py
+++ b/autofit/non_linear/analysis/latent.py
@@ -174,7 +174,7 @@ def latent_samples_from(
             def batched_compute_latent(x):
                 return np.array([_safe_compute(xx) for xx in x])
 
-        from autoconf.test_mode import inject_latent_nans
+        from autonerves.test_mode import inject_latent_nans
 
         parameter_array = np.array(samples.parameter_lists)
 

--- a/autofit/non_linear/analysis/visualize.py
+++ b/autofit/non_linear/analysis/visualize.py
@@ -1,6 +1,6 @@
 import os
 
-from autoconf import conf
+from autonerves import conf
 
 from autofit.non_linear.paths.abstract import AbstractPaths
 from autofit.mapper.prior_model.abstract import AbstractPriorModel

--- a/autofit/non_linear/fitness.py
+++ b/autofit/non_linear/fitness.py
@@ -7,8 +7,8 @@ import time
 from timeout_decorator import timeout
 from typing import Optional
 
-from autoconf import conf
-from autoconf import cached_property
+from autonerves import conf
+from autonerves import cached_property
 
 from autofit import exc
 

--- a/autofit/non_linear/grid/grid_search/__init__.py
+++ b/autofit/non_linear/grid/grid_search/__init__.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from typing import List, Tuple, Union, Type, Optional, Dict
 
-from autoconf.dictable import to_dict
+from autonerves.dictable import to_dict
 from autofit import exc
 from autofit.mapper import prior as p
 from autofit.non_linear.parallel import Process

--- a/autofit/non_linear/grid/sensitivity/__init__.py
+++ b/autofit/non_linear/grid/sensitivity/__init__.py
@@ -5,8 +5,8 @@ import numpy as np
 from pathlib import Path
 from typing import List, Generator, Callable, ClassVar, Optional, Union, Tuple
 
-from autoconf import cached_property
-from autoconf.dictable import to_dict
+from autonerves import cached_property
+from autonerves.dictable import to_dict
 from autofit.mapper.model import ModelInstance
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.grid.grid_search import make_lists, Sequential

--- a/autofit/non_linear/parallel/sneaky.py
+++ b/autofit/non_linear/parallel/sneaky.py
@@ -5,7 +5,7 @@ import multiprocessing as mp
 import os
 from typing import Iterable, Optional, Callable
 
-from autoconf import conf
+from autonerves import conf
 
 from autofit.non_linear.paths.abstract import AbstractPaths
 from .process import AbstractJob, Process, StopCommand

--- a/autofit/non_linear/paths/abstract.py
+++ b/autofit/non_linear/paths/abstract.py
@@ -10,8 +10,8 @@ from typing import Optional
 
 import numpy as np
 
-from autoconf import conf
-from autoconf.test_mode import is_test_mode
+from autonerves import conf
+from autonerves.test_mode import is_test_mode
 from autofit.mapper.identifier import Identifier, IdentifierField
 from autofit.non_linear.samples.summary import SamplesSummary
 
@@ -55,7 +55,7 @@ class AbstractPaths(ABC):
         The output path within which the *Paths* objects path structure is contained is set via PyAutoConf, using the
         command:
 
-        from autoconf import conf
+        from autonerves import conf
         conf.instance = conf.Config(output_path="path/to/output")
 
         If we assume all the input strings above are used with the following example names:

--- a/autofit/non_linear/paths/database.py
+++ b/autofit/non_linear/paths/database.py
@@ -1,13 +1,13 @@
 import shutil
 from typing import Optional, Union
 
-from autoconf.output import conditional_output, should_output
+from autonerves.output import conditional_output, should_output
 from autofit.database.sqlalchemy_ import sa
 from .abstract import AbstractPaths
 import numpy as np
 
 from autofit.database.model import Fit
-from autoconf.dictable import to_dict, from_dict
+from autonerves.dictable import to_dict, from_dict
 from autofit.database.aggregator.info import Info
 from autofit.non_linear.samples.summary import SamplesSummary
 

--- a/autofit/non_linear/paths/directory.py
+++ b/autofit/non_linear/paths/directory.py
@@ -8,10 +8,10 @@ from pathlib import Path
 from typing import Optional, Union, cast, Type
 import logging
 
-from autoconf import conf
-from autoconf.class_path import get_class
-from autoconf.dictable import to_dict, from_dict
-from autoconf.output import conditional_output, should_output
+from autonerves import conf
+from autonerves.class_path import get_class
+from autonerves.dictable import to_dict, from_dict
+from autonerves.output import conditional_output, should_output
 from autofit.text import formatter
 from autofit.tools.util import open_
 from autofit.non_linear.samples.samples import Samples

--- a/autofit/non_linear/plot/nest_plotters.py
+++ b/autofit/non_linear/plot/nest_plotters.py
@@ -1,7 +1,7 @@
 import numpy as np
 import warnings
 
-from autoconf import conf
+from autonerves import conf
 
 from autofit.non_linear.plot.plot_util import (
     skip_in_test_mode,

--- a/autofit/non_linear/plot/samples_plotters.py
+++ b/autofit/non_linear/plot/samples_plotters.py
@@ -2,7 +2,7 @@ import logging
 
 import numpy as np
 
-from autoconf import conf
+from autonerves import conf
 
 from autofit.non_linear.plot.plot_util import skip_in_test_mode, output_figure
 

--- a/autofit/non_linear/samples/efficient.py
+++ b/autofit/non_linear/samples/efficient.py
@@ -2,7 +2,7 @@ from typing import List, cast, Type
 
 import numpy as np
 
-from autoconf.class_path import get_class
+from autonerves.class_path import get_class
 from .sample import Sample
 from .samples import Samples
 from .pdf import SamplesPDF

--- a/autofit/non_linear/samples/pdf.py
+++ b/autofit/non_linear/samples/pdf.py
@@ -5,8 +5,8 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from autoconf import conf
-from autoconf.output import should_output
+from autonerves import conf
+from autonerves.output import should_output
 from autofit.mapper.model import ModelInstance
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.non_linear.samples.sample import Sample, load_from_table

--- a/autofit/non_linear/samples/sample.py
+++ b/autofit/non_linear/samples/sample.py
@@ -4,7 +4,7 @@ from copy import copy
 from pathlib import Path
 from typing import List, Tuple, Union
 
-from autoconf.class_path import get_class_path
+from autonerves.class_path import get_class_path
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.tools.util import split_paths
 

--- a/autofit/non_linear/samples/samples.py
+++ b/autofit/non_linear/samples/samples.py
@@ -9,8 +9,8 @@ from typing import Dict, List, Optional, Tuple, Union
 import numpy as np
 from pathlib import Path
 
-from autoconf import conf
-from autoconf.class_path import get_class_path
+from autonerves import conf
+from autonerves.class_path import get_class_path
 from autofit import exc
 from autofit.mapper.model import ModelInstance
 from autofit.non_linear.test_mode import skip_checks

--- a/autofit/non_linear/search/abstract_search.py
+++ b/autofit/non_linear/search/abstract_search.py
@@ -18,9 +18,9 @@ import psutil
 if TYPE_CHECKING:
     from autofit.non_linear.result import Result
 
-from autoconf import conf
+from autonerves import conf
 
-from autoconf.output import should_output
+from autonerves.output import should_output
 
 from autofit import exc
 from autofit.database.sqlalchemy_ import sa

--- a/autofit/non_linear/search/mcmc/abstract_mcmc.py
+++ b/autofit/non_linear/search/mcmc/abstract_mcmc.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from autoconf import conf
+from autonerves import conf
 from autofit.database.sqlalchemy_ import sa
 from autofit.non_linear.search.abstract_search import NonLinearSearch
 from autofit.non_linear.initializer import Initializer, InitializerBall

--- a/autofit/non_linear/search/mcmc/blackjax/nuts/search.py
+++ b/autofit/non_linear/search/mcmc/blackjax/nuts/search.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import numpy as np
 
-from autoconf import conf
+from autonerves import conf
 
 from autofit.database.sqlalchemy_ import sa
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
@@ -113,7 +113,7 @@ class BlackJAXNUTS(AbstractMCMC):
             after warmup.
         iterations_per_full_update
             Sample chunk size between ``perform_update`` calls. Inherited
-            from the autoconf config when ``None``.
+            from the autonerves config when ``None``.
         number_of_cores
             Currently unused — single chain runs on a single device. Kept
             for API parity with the other MCMC searches.

--- a/autofit/non_linear/search/mcmc/emcee/search.py
+++ b/autofit/non_linear/search/mcmc/emcee/search.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 
 import numpy as np
 
-from autoconf import conf
+from autonerves import conf
 
 from autofit.database.sqlalchemy_ import sa
 from autofit.mapper.model_mapper import ModelMapper

--- a/autofit/non_linear/search/mle/abstract_mle.py
+++ b/autofit/non_linear/search/mle/abstract_mle.py
@@ -1,6 +1,6 @@
 from abc import ABC
 
-from autoconf import conf
+from autonerves import conf
 from autofit.non_linear.search.abstract_search import NonLinearSearch
 from autofit.non_linear.initializer import InitializerBall
 from autofit.non_linear.plot import subplot_parameters, log_likelihood_vs_iteration

--- a/autofit/non_linear/search/nest/abstract_nest.py
+++ b/autofit/non_linear/search/nest/abstract_nest.py
@@ -2,7 +2,7 @@ from abc import ABC
 from typing import Optional
 import warnings
 
-from autoconf import conf
+from autonerves import conf
 from autofit.database.sqlalchemy_ import sa
 from autofit.non_linear.search.abstract_search import NonLinearSearch
 from autofit.non_linear.initializer import (

--- a/autofit/non_linear/search/updater.py
+++ b/autofit/non_linear/search/updater.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Callable, Optional, Tuple
 import numpy as np
 import psutil
 
-from autoconf import conf
-from autoconf.test_mode import skip_latents
+from autonerves import conf
+from autonerves.test_mode import skip_latents
 
 from autofit import exc
 from autofit.non_linear.paths.database import DatabasePaths

--- a/autofit/non_linear/test_mode.py
+++ b/autofit/non_linear/test_mode.py
@@ -1,3 +1,3 @@
-from autoconf.test_mode import test_mode_level, is_test_mode, skip_fit_output, skip_visualization, skip_checks, test_mode_samples
+from autonerves.test_mode import test_mode_level, is_test_mode, skip_fit_output, skip_visualization, skip_checks, test_mode_samples
 
 __all__ = ["test_mode_level", "is_test_mode", "skip_fit_output", "skip_visualization", "skip_checks", "test_mode_samples"]

--- a/autofit/text/formatter.py
+++ b/autofit/text/formatter.py
@@ -4,7 +4,7 @@ from typing import Tuple, Union
 
 from pathlib import Path
 
-from autoconf import conf
+from autonerves import conf
 from autofit.tools.util import open_
 
 logger = logging.getLogger(__name__)

--- a/autofit/text/text_util.py
+++ b/autofit/text/text_util.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from typing import List
 
-from autoconf import conf
+from autonerves import conf
 from autofit.mapper.prior_model.representative import find_groups
 from autofit.text import formatter as frm, samples_text
 from autofit.tools.util import info_whitespace

--- a/autofit/tools/util.py
+++ b/autofit/tools/util.py
@@ -10,7 +10,7 @@ from typing import Union
 
 import numpy as np
 
-from autoconf import conf
+from autonerves import conf
 
 
 def split_paths(func):

--- a/autofit/visualise.py
+++ b/autofit/visualise.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autofit.mapper.prior_model.abstract import AbstractPriorModel
 from autofit.mapper.prior.uniform import UniformPrior

--- a/docs/cookbooks/result.md
+++ b/docs/cookbooks/result.md
@@ -536,7 +536,7 @@ class Analysis(af.Analysis):
             The paths object which manages all paths, e.g. where the non-linear search outputs are stored,
             visualization, and the pickled objects used by the aggregator output by this function.
         """
-        from autoconf.dictable import to_dict
+        from autonerves.dictable import to_dict
 
         paths.save_json(name="data", object_dict=to_dict(self.data))
         paths.save_json(name="noise_map", object_dict=to_dict(self.noise_map))

--- a/docs/features/interpolate.md
+++ b/docs/features/interpolate.md
@@ -171,7 +171,7 @@ The interpolator and model can be serialized to a .json file using **PyAutoConf*
 This means an interpolator can easily be loaded into other scripts.
 
 ```python
-from autoconf.dictable import output_to_json, from_json
+from autonerves.dictable import output_to_json, from_json
 
 json_file = path.join(dataset_prefix_path, "interpolator.json")
 

--- a/docs/general/configs.md
+++ b/docs/general/configs.md
@@ -15,7 +15,7 @@ The configuration path can also be set manually in a script using the project **
 command (the path to the `output` folder where the results of a non-linear search are stored is also set below):
 
 ```bash
-from autoconf import conf
+from autonerves import conf
 
 conf.instance.push(
     new_path="path/to/config",

--- a/eden.yaml
+++ b/eden.yaml
@@ -1,6 +1,6 @@
 name: autofit
 eden_prefix: VIS_CTI
 eden_dependencies: 
-  - name: autoconf
+  - name: autonerves
 should_rename_modules: false
 should_remove_type_annotation: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 keywords = ["cli"]
 dependencies = [
-    "autoconf",
+    "autonerves",
     "array_api_compat",
     "anesthetic>=2.9.0",
     "corner==2.2.2",
@@ -66,7 +66,7 @@ local_scheme = "no-local-version"
 
 
 [project.optional-dependencies]
-jax = ["autoconf[jax]", "optax"]
+jax = ["autonerves[jax]", "optax"]
 optional = [
     "autofit[jax]",
     "astropy>=5.0",

--- a/test_autofit/aggregator/test_reference.py
+++ b/test_autofit/aggregator/test_reference.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from autoconf.class_path import get_class_path
+from autonerves.class_path import get_class_path
 from autofit.aggregator import Aggregator
 from pathlib import Path
 import autofit as af

--- a/test_autofit/analysis/test_latent_variables.py
+++ b/test_autofit/analysis/test_latent_variables.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import autofit as af
-from autoconf.conf import with_config
+from autonerves.conf import with_config
 from autofit import DirectoryPaths, SamplesPDF
 
 # This test drives the `use_jax=True` path, which needs jax installed (it ships

--- a/test_autofit/conftest.py
+++ b/test_autofit/conftest.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from matplotlib import pyplot
 
-from autoconf import conf
+from autonerves import conf
 from autofit import database as db
 from autofit import fixtures
 from autofit.database.model import sa

--- a/test_autofit/database/migration/test_steps_match.py
+++ b/test_autofit/database/migration/test_steps_match.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 import autofit as af
-from autoconf.conf import output_path_for_test
+from autonerves.conf import output_path_for_test
 from autofit.database import Fit
 from autofit.database.sqlalchemy_ import sa
 

--- a/test_autofit/database/paths/test_paths.py
+++ b/test_autofit/database/paths/test_paths.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from autoconf.conf import output_path_for_test
+from autonerves.conf import output_path_for_test
 
 import autofit as af
 from autofit import database as m

--- a/test_autofit/graphical/gaussian/test_optimizer.py
+++ b/test_autofit/graphical/gaussian/test_optimizer.py
@@ -2,7 +2,7 @@ import pytest
 
 import autofit as af
 import autofit.graphical as g
-from autoconf.conf import output_path_for_test
+from autonerves.conf import output_path_for_test
 from autofit.graphical.utils import Status
 from test_autofit.graphical.gaussian.model import Analysis
 

--- a/test_autofit/graphical/info/test_output.py
+++ b/test_autofit/graphical/info/test_output.py
@@ -2,7 +2,7 @@ import pytest
 
 import autofit as af
 
-from autoconf.conf import with_config
+from autonerves.conf import with_config
 from autofit import graphical as g, DirectoryPaths
 
 MAX_STEPS = 2

--- a/test_autofit/interpolator/test_interpolator.py
+++ b/test_autofit/interpolator/test_interpolator.py
@@ -1,7 +1,7 @@
 import pytest
 
 import autofit as af
-from autoconf.dictable import to_dict, from_dict
+from autonerves.dictable import to_dict, from_dict
 
 
 def test_trivial():

--- a/test_autofit/mapper/model/serialise/test_json.py
+++ b/test_autofit/mapper/model/serialise/test_json.py
@@ -5,7 +5,7 @@ import pytest
 import json
 
 import autofit as af
-from autoconf.dictable import from_dict
+from autonerves.dictable import from_dict
 
 
 @pytest.fixture(name="collection_dict")

--- a/test_autofit/mapper/model/test_regression.py
+++ b/test_autofit/mapper/model/test_regression.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 
 import autofit as af
-from autoconf.exc import ConfigException
+from autonerves.exc import ConfigException
 from autofit.example.model import PhysicalNFW
 from autofit.mapper.mock.mock_model import WithString
 from autofit.mapper.model_object import Identifier

--- a/test_autofit/mapper/test_array.py
+++ b/test_autofit/mapper/test_array.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 import autofit as af
-from autoconf.dictable import to_dict
+from autonerves.dictable import to_dict
 
 
 @pytest.fixture

--- a/test_autofit/mapper/test_parameterization.py
+++ b/test_autofit/mapper/test_parameterization.py
@@ -179,7 +179,7 @@ def test_parameterization_cache_does_not_leak_into_instance():
 
 def test_cached_property_names_classmethod_walks_mro():
     """The ``_cached_property_names`` classmethod on AbstractModel exposes the
-    autoconf ``cached_property_names`` MRO walker. It must pick up
+    autonerves ``cached_property_names`` MRO walker. It must pick up
     descriptors declared on any ancestor and memoise the result on the class."""
 
     import functools

--- a/test_autofit/non_linear/grid/test_paths/test_indicators.py
+++ b/test_autofit/non_linear/grid/test_paths/test_indicators.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 import autofit as af
-from autoconf.conf import output_path_for_test
+from autonerves.conf import output_path_for_test
 from autofit.database.aggregator.scrape import Scraper
 
 output_directory = Path(__file__).parent / "output"

--- a/test_autofit/non_linear/grid/test_sensitivity/test_run.py
+++ b/test_autofit/non_linear/grid/test_sensitivity/test_run.py
@@ -1,4 +1,4 @@
-# from autoconf.conf import with_config
+# from autonerves.conf import with_config
 #
 #
 # @with_config("general", "model", value=True)

--- a/test_autofit/non_linear/paths/test_paths.py
+++ b/test_autofit/non_linear/paths/test_paths.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 import autofit as af
-from autoconf.conf import output_path_for_test
+from autonerves.conf import output_path_for_test
 from autofit.non_linear.paths.null import NullPaths
 
 

--- a/test_autofit/non_linear/paths/test_serialise_paths.py
+++ b/test_autofit/non_linear/paths/test_serialise_paths.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import autofit as af
-from autoconf.dictable import to_dict, from_dict
+from autonerves.dictable import to_dict, from_dict
 
 
 def test_path_prefix():

--- a/test_autofit/non_linear/samples/test_output_type.py
+++ b/test_autofit/non_linear/samples/test_output_type.py
@@ -1,7 +1,7 @@
 import pytest
 
 import autofit as af
-from autoconf.conf import with_config
+from autonerves.conf import with_config
 from autofit import SamplesNest, SearchOutput
 from autofit.non_linear.samples.efficient import EfficientSamples
 

--- a/test_autofit/non_linear/samples/test_pdf.py
+++ b/test_autofit/non_linear/samples/test_pdf.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pytest
 
-from autoconf.conf import with_config
+from autonerves.conf import with_config
 
 import autofit as af
 

--- a/test_autofit/non_linear/search/mle/test_multi_start_gradient.py
+++ b/test_autofit/non_linear/search/mle/test_multi_start_gradient.py
@@ -3,7 +3,7 @@ import pytest
 
 import autofit as af
 from autofit import example
-from autoconf.dictable import from_dict, to_dict
+from autonerves.dictable import from_dict, to_dict
 
 # The MultiStart gradient searches are JAX-native at fit time, but their
 # plumbing (config knobs, dict round-trip, and the internal-results -> Samples

--- a/test_autofit/non_linear/search/optimize/test_drawer.py
+++ b/test_autofit/non_linear/search/optimize/test_drawer.py
@@ -1,7 +1,7 @@
 import pytest
 
 import autofit as af
-from autoconf.dictable import from_dict, to_dict
+from autonerves.dictable import from_dict, to_dict
 
 pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
 

--- a/test_autofit/non_linear/search/test_abstract_search.py
+++ b/test_autofit/non_linear/search/test_abstract_search.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import autofit as af
-from autoconf import conf
+from autonerves import conf
 
 pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
 

--- a/test_autofit/non_linear/search/test_logging.py
+++ b/test_autofit/non_linear/search/test_logging.py
@@ -4,7 +4,7 @@ import shutil
 import pytest
 
 import autofit as af
-from autoconf.conf import with_config
+from autonerves.conf import with_config
 
 
 class Analysis(af.mock.MockAnalysis):

--- a/test_autofit/non_linear/search/test_sneaky_map.py
+++ b/test_autofit/non_linear/search/test_sneaky_map.py
@@ -7,7 +7,7 @@ from dynesty.dynesty import _function_wrapper
 from emcee.ensemble import _FunctionWrapper
 
 import autofit as af
-from autoconf.conf import output_path_for_test
+from autonerves.conf import output_path_for_test
 from autofit.non_linear import fitness as f
 from autofit.non_linear.mock.mock_analysis import MockAnalysis
 from autofit.non_linear.parallel import SneakyPool, SneakyJob

--- a/test_autofit/non_linear/search/test_updater.py
+++ b/test_autofit/non_linear/search/test_updater.py
@@ -1,7 +1,7 @@
 import logging
 from unittest.mock import MagicMock
 
-from autoconf import conf
+from autonerves import conf
 
 from autofit.non_linear.search.updater import SearchUpdater
 

--- a/test_autofit/non_linear/test_dict.py
+++ b/test_autofit/non_linear/test_dict.py
@@ -1,7 +1,7 @@
 import pytest
 
 import autofit as af
-from autoconf.dictable import to_dict, from_dict
+from autonerves.dictable import to_dict, from_dict
 
 
 @pytest.fixture(name="dynesty_dict")

--- a/test_autofit/serialise/test_regression.py
+++ b/test_autofit/serialise/test_regression.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from autoconf.dictable import to_dict, from_dict
+from autonerves.dictable import to_dict, from_dict
 from autofit.mapper.mock.mock_model import MockClassx2Tuple
 import autofit as af
 

--- a/test_autofit/serialise/test_samples.py
+++ b/test_autofit/serialise/test_samples.py
@@ -2,7 +2,7 @@ import autofit as af
 import pytest
 
 from autofit.non_linear.samples.summary import SamplesSummary
-from autoconf.dictable import from_dict, to_dict
+from autonerves.dictable import from_dict, to_dict
 
 
 @pytest.fixture(name="model")


### PR DESCRIPTION
## What

Switch the `autoconf` dependency to its renamed form **`autonerves`**: pyproject pins and every `import autoconf` / `from autoconf` (including the config re-export block). Repo-name references (`PyAutoConf`) are unchanged — they flip with the GitHub repo rename.

⚠️ **Breaking / coordinated**: pairs with PyAutoConf#135 and the other library PRs on the **same-named branch**. CI resolves `autonerves` from the same-named PyAutoConf branch (built as autonerves). Merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_