### PR TITLE
test(interpolator): cover empty-instances IndexError guard

### DIFF
--- a/test_autofit/interpolator/test_interpolator.py
+++ b/test_autofit/interpolator/test_interpolator.py
@@ -13,6 +13,14 @@ def test_trivial():
     assert result is instance
 
 
+def test_no_instances():
+    interpolator = af.LinearInterpolator([])
+
+    with pytest.raises(IndexError, match="no instances"):
+        # noinspection PyStatementEffect
+        interpolator[interpolator.t == 1.5]
+
+
 @pytest.fixture(name="linear_interpolator")
 def make_linear_interpolator(instances):
     return af.LinearInterpolator(instances)


### PR DESCRIPTION
Closes #1411 (library half).

`c8511b553` (2026-04-12) added the empty-instances guard in `autofit/interpolator/abstract.py` but shipped no test. This adds one.

- `test_no_instances` — `af.LinearInterpolator([])` queried at `t == 1.5` must raise `IndexError` matching `"no instances"`.
- numpy-only, no JAX.

`pytest test_autofit/interpolator/` → 36 passed.

The two NEEDS_FIX markers this issue was filed for are stale: `autofit_workspace` was already un-parked upstream (PR #103), and HowToFit is un-parked in a companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)