### PR TITLE
docs: document the [jax] install extra; sync __version__

### DIFF
--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -148,7 +148,7 @@ def save_abc(pickler, obj):
     pickle._Pickler.save_type(pickler, obj)
 
 
-__version__ = "2026.7.9.1"
+__version__ = "2026.7.22.1"
 
 from autonerves import check_version
 

--- a/autofit/__init__.py
+++ b/autofit/__init__.py
@@ -148,7 +148,7 @@ def save_abc(pickler, obj):
     pickle._Pickler.save_type(pickler, obj)
 
 
-__version__ = "2026.7.22.1"
+__version__ = "2026.7.23.1"
 
 from autonerves import check_version
 

--- a/docs/installation/conda.md
+++ b/docs/installation/conda.md
@@ -24,8 +24,14 @@ The latest version of **PyAutoFit** is installed via pip as follows (specifying 
 the installation has clean dependencies):
 
 ```bash
-pip install autofit
+pip install autofit[jax]
 ```
+
+The `[jax]` extra installs \[**JAX**\](<https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html>) (and
+`optax`), which **PyAutoFit** uses for gradient-based searches and GPU acceleration. **JAX is not installed by
+default** — to install without it, use `pip install autofit` instead. The extra installs CPU-only JAX; for GPU
+support, follow the official \[JAX installation guide\](<https://jax.readthedocs.io/en/latest/installation.html>)
+**before** installing.
 
 Next, clone the `autofit_workspace` (the line `--depth 1` clones only the most recent branch on
 the `autofit_workspace`, reducing the download size):

--- a/docs/installation/pip.md
+++ b/docs/installation/pip.md
@@ -16,8 +16,14 @@ The latest version of **PyAutoFit** is installed via pip as follows (specifying 
 the installation has clean dependencies):
 
 ```bash
-pip install autofit
+pip install autofit[jax]
 ```
+
+The `[jax]` extra installs \[**JAX**\](<https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html>) (and
+`optax`), which **PyAutoFit** uses for gradient-based searches and GPU acceleration. **JAX is not installed by
+default** — a plain `pip install autofit` gives a fully working install that runs on NumPy, without JAX
+acceleration. The extra installs CPU-only JAX; for GPU support, follow the official
+\[JAX installation guide\](<https://jax.readthedocs.io/en/latest/installation.html>) **before** installing.
 
 If this raises no errors **PyAutoFit** is installed! If there is an error check out
 the [troubleshooting section](https://pyautofit.readthedocs.io/en/latest/installation/troubleshooting.html).


### PR DESCRIPTION
## Why

The install docs never mention that JAX is an optional extra. `pip install autofit` installs no JAX/optax, so gradient-based searches are unavailable with no indication why.

## Changes

- Document `pip install autofit[jax]` in both pip and conda install docs, with the JAX-free variant noted.
- Note the extra also brings `optax` (used by the gradient-based searches).
- Sync `__version__` to `2026.7.22.1`.

Companion to PyAutoLens#642.