### PR TITLE
docs: name PYAUTO_TEST_MODE explicitly in should_visualize docstring

### DIFF
--- a/autofit/non_linear/analysis/visualize.py
+++ b/autofit/non_linear/analysis/visualize.py
@@ -27,8 +27,8 @@ class Visualizer:
 
         4) If the analysis is running a database session visualization is switched off.
 
-        5) If PyAutoFit test mode is on visualization is disabled, irrespective of the `force_visualization_overwite`
-        config input.
+        5) If test mode is on (the `PYAUTO_TEST_MODE` environment variable) visualization is disabled, irrespective
+        of the `force_visualization_overwite` config input.
 
         Parameters
         ----------


### PR DESCRIPTION
Companion to PyAutoLabs/PyAutoCTI#95 / PyAutoLabs/PyAutoCTI#96.

`Visualizer.should_visualize`'s docstring point 5 said:

> 5) If PyAutoFit test mode is on visualization is disabled, ...

Naming the *product* rather than the *environment variable* invites readers to invent `PYAUTOFIT_TEST_MODE`, which nothing in the stack reads. The canonical knob is **`PYAUTO_TEST_MODE`** (`PyAutoNerves/autonerves/test_mode.py:14`, alongside `PYAUTO_TEST_MODE_SAMPLES`).

That exact misreading is what produced the dead fixture fixed in PyAutoCTI#96. Docstring-only change; no behaviour change.