### PR TITLE
fix: raise SamplesException from latent computation when samples is None (resumed fits)

### DIFF
--- a/autofit/non_linear/analysis/analysis.py
+++ b/autofit/non_linear/analysis/analysis.py
@@ -140,6 +140,11 @@ class Analysis(ABC):
         reads which latents to compute (and how) from ``self.Latent`` (see
         :class:`Latent`). Kept as a method for backwards compatibility — it is
         the entry point called by ``SearchUpdater._compute_latent_samples``.
+
+        Raises ``exc.SamplesException`` if ``samples`` is ``None``, which is
+        what ``result.samples`` yields for a resumed fit whose ``samples.csv``
+        was never written (samples output disabled). See
+        :func:`~autofit.non_linear.analysis.latent.latent_samples_from`.
         """
         return latent_samples_from(self, samples, batch_size=batch_size)
 

--- a/autofit/non_linear/analysis/latent.py
+++ b/autofit/non_linear/analysis/latent.py
@@ -27,6 +27,7 @@ from typing import Optional
 
 import numpy as np
 
+from autofit import exc
 from autofit.non_linear.samples.sample import Sample
 from autofit.non_linear.samples.samples import Samples
 from autofit.non_linear.samples.util import simple_model_for_kwargs
@@ -91,7 +92,34 @@ def latent_samples_from(
 
     Returns ``None`` when no finite latent samples remain (or no latents are
     defined).
+
+    Raises
+    ------
+    exc.SamplesException
+        If ``samples`` is ``None``. This is the resumed-fit case: a search whose
+        fit already completed short-circuits to
+        ``NonLinearSearch.result_via_completed_fit``, which loads the samples
+        back off disk from ``samples.csv``. If that file was never written --
+        because ``output.yaml``'s ``samples: false`` (or ``general.yaml``'s
+        ``samples_to_csv: false``) disabled it -- ``result.samples`` is ``None``
+        and there is nothing to compute latents from. Latent computation needs
+        the full sample list; ``samples_summary.json`` is not a substitute.
     """
+    if samples is None:
+        raise exc.SamplesException(
+            "Cannot compute latent samples: `samples` is None.\n\n"
+            "This usually means the fit was resumed rather than run: a completed "
+            "fit reloads its samples from `samples.csv`, and that file was not "
+            "written because samples output is disabled (`samples: false` in "
+            "`config/output.yaml`, or `samples_to_csv: false` in "
+            "`config/general.yaml`).\n\n"
+            "Latent variables are computed per posterior sample, so the full "
+            "sample list is required -- `samples_summary.json` is not enough. "
+            "Either enable samples output and re-run the fit (deleting the "
+            "existing output so it is not resumed), or pass a `Samples` object "
+            "explicitly."
+        )
+
     batch_size = batch_size or 10
 
     latent = analysis.Latent

--- a/test_autofit/analysis/test_latent.py
+++ b/test_autofit/analysis/test_latent.py
@@ -199,3 +199,39 @@ def test_new_path_single_survivor_summary_does_not_crash():
     _ = latent.summary()
     instance = latent.median_pdf()
     assert instance.fwhm == pytest.approx(FWHM_SIGMA_3)
+
+
+class NoLatentAnalysis(af.Analysis):
+    """An analysis declaring no latent variables at all."""
+
+    def log_likelihood_function(self, instance):
+        return 1.0
+
+
+def test_none_samples_raises_samples_exception():
+    """
+    A resumed fit whose `samples.csv` was never written (samples output
+    disabled) hands `result.samples is None` to `compute_latent_samples`.
+    That must be an intentional, explanatory `SamplesException` -- never an
+    `AttributeError` raised from inside `latent_samples_from` when it
+    dereferences `samples.model`.
+    """
+    with pytest.raises(af.exc.SamplesException) as exc_info:
+        FwhmAnalysis().compute_latent_samples(None)
+
+    message = str(exc_info.value)
+    assert "samples.csv" in message
+    assert "resumed" in message
+
+
+def test_none_samples_raises_via_engine_directly_and_before_latent_lookup():
+    """
+    The guard lives in the engine (so the free-function entry point is covered
+    too) and fires before any latent configuration is consulted -- a `None`
+    samples object is a broken input regardless of whether latents are defined.
+    """
+    with pytest.raises(af.exc.SamplesException):
+        latent_samples_from(FwhmAnalysis(), None)
+
+    with pytest.raises(af.exc.SamplesException):
+        latent_samples_from(NoLatentAnalysis(), None)


### PR DESCRIPTION
## Root cause

On a completed-fit resume, `result_via_completed_fit` reloads samples from disk and swallows `FileNotFoundError` into `samples = None`. When the output config disables samples persistence (`output.yaml: samples: false`, as in autolens_workspace_test), `samples.csv` never exists, so every resumed result carries `samples=None` — and `compute_latent_samples(result.samples)` crashed with `AttributeError: 'NoneType' object has no attribute 'model'` inside `latent_samples_from` (surfaced by the 2026-07-25 full health sweep).

The reload path itself is fine: with `samples: true` (the packaged default) resumed latent computation works unchanged — verified live.

## Change

Raise `exc.SamplesException` from the latent engine when `samples is None`, with a message naming the resumed-fit cause and the remedies. Chosen over returning `None`: the engine's existing `None` returns all mean "the computation ran and nothing survived" (documented), whereas a missing input is a categorically different failure that should not be conflated or silently hidden. `SamplesException` is the established convention for invalid `Samples` input (`Samples.__add__`). Guard sits in the engine so the free-function entry point is covered too, and fires before latent config is consulted.

- `autofit/non_linear/analysis/latent.py` — guard + `Raises` docstring
- `autofit/non_linear/analysis/analysis.py` — `compute_latent_samples` docstring note
- `test_autofit/analysis/test_latent.py` — two new tests (wrapper + engine, guard-ordering lock-in)

## Verification

`pytest test_autofit/` → 1528 passed, 3 skipped (baseline 1526 + 2 new). Workspace_test latent smoke: fresh run passes end-to-end; resumed run now fails with the intentional, documented `SamplesException` instead of an internal `AttributeError` (draft's acceptance criterion).

## Follow-up (not in this PR)

Making resumed latent-script runs actually pass needs the workspace's own call: autolens_workspace_test sets `samples: false`; flipping it (globally or scoped to the latent scripts) verified to make both runs pass. Left as a deliberate workspace policy decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzN9PZfG5zXMVku8ckSqkC)_