### PR TITLE
fix: traced instance attributes never land in pytree aux data

### DIFF
--- a/autofit/jax/pytrees.py
+++ b/autofit/jax/pytrees.py
@@ -166,10 +166,26 @@ def _build_instance_pytree_funcs(cls):
     Classification is read from the shared ``_CLASS_FIELD_CLASSIFIERS`` dict,
     which is updated by every ``register_model`` call. Attributes unknown to
     the classifier (never declared on any walked model) default to constant —
-    safer than tracing an unknown object.
+    safer than tracing an unknown object — with one override: an attribute
+    whose *value* is a JAX array or tracer is always a dynamic child,
+    whatever the classifier says. Such values arise from attributes derived
+    inside ``__init__`` from traced parameters (e.g. an ``NFWMCRLudlowSph``
+    computing ``scale_radius`` from a free ``mass_at_200``); as aux data they
+    survive the flatten as raw Python references and re-enter nested traces
+    (a ``custom_jvp`` rule's inner jvp) as stale tracers, raising
+    ``UnexpectedTracerError``. A traced value is never safe aux.
     """
     constructor_args = _CLASS_CONSTRUCTOR_ARGS.get(cls, ())
     constructor_arg_set = set(constructor_args)
+
+    def _is_jax_value(value):
+        import jax
+
+        if isinstance(value, (jax.Array, jax.core.Tracer)):
+            return True
+        if isinstance(value, (tuple, list)):
+            return any(_is_jax_value(v) for v in value)
+        return False
 
     def _partition(instance):
         classifier = _CLASS_FIELD_CLASSIFIERS.get(cls, {})
@@ -180,7 +196,7 @@ def _build_instance_pytree_funcs(cls):
         for name, value in vars(instance).items():
             if name.startswith("_") or name in ("cls", "id"):
                 continue
-            is_dynamic = classifier.get(name, False)
+            is_dynamic = classifier.get(name, False) or _is_jax_value(value)
             in_ctor = name in constructor_arg_set
             if in_ctor and is_dynamic:
                 ctor_dyn.append((name, value))


### PR DESCRIPTION
Part of PyAutoLabs/PyAutoLens#678 phase B — one of the two defects that killed the cluster `image_plane_solved` gradient cell on the A100s (the other is the PointSolver padded-row fix, PyAutoLabs/PyAutoLens#685).

## Problem

`_build_instance_pytree_funcs` classifies attributes never declared on a walked model as constants → pytree aux data. Attributes **derived inside `__init__` from prior parameters** (e.g. `NFWMCRLudlowSph` computing `kappa_s`/`scale_radius` from a free `mass_at_200`) are exactly such attributes, and under a trace their values are tracers. Aux crosses transformation boundaries as raw Python references, so a `custom_jvp` rule's inner `jax.jvp` receives the instance with a stale `LinearizeTracer` in `scale_radius` and raises `UnexpectedTracerError` the moment it is consumed (`1.0 / self.scale_radius`).

Only gradient paths hit it (Nautilus never runs a JVP rule), and only models with derived-in-`__init__` attributes (galaxy-scale Isothermal cells were unaffected) — which is why this survived until the first cluster MCR-halo gradient search.

## Fix

At flatten time, any attribute whose *value* is a JAX array or tracer is promoted to a dynamic child, whatever the classifier says — a traced value is never safe aux. Concrete Python values keep the constant behaviour, so control flow on constants (`sorted(..., key=lambda g: g.redshift)`, `isinstance` dispatch) is untouched.

## Verification

- Full `test_autofit/`: 1641 passed, 2 skipped.
- New assertion script `autofit_workspace_test/scripts/jax_assertions/derived_attribute_leaves.py` (JAX tests live there per #1247): fails with `UnexpectedTracerError` before this fix, passes after.
- The #678 cluster cell's `value_and_grad` completes after this fix (paired with PyAutoLabs/PyAutoLens#685 for finite gradients).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnTmLoJjJgMTze5uAbg1Jd