### PR TITLE
fix: single-core Nautilus fits build no pool (release-integrate corrective, #1442)

### DIFF
--- a/autofit/non_linear/search/nest/nautilus/search.py
+++ b/autofit/non_linear/search/nest/nautilus/search.py
@@ -2,6 +2,7 @@ import numpy as np
 import logging
 import os
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
@@ -327,7 +328,18 @@ class Nautilus(abstract_nest.AbstractNest):
         # A pool object is passed rather than pool=<int> so the pool uses the
         # "fork" start method (see autofit.non_linear.parallel.fork_context) —
         # nautilus builds its internal pools from the default context.
-        with fork_context().Pool(self.number_of_cores) as pool:
+        #
+        # For a single core no pool may be created at all: nautilus treats
+        # pool=None (and the int 1) as fully serial, whereas a Pool(1) object
+        # forces every likelihood call into a forked worker — which deadlocks
+        # in XLA compilation when the likelihood touches JAX, since a forked
+        # child of a JAX-initialized parent cannot compile.
+        if self.number_of_cores <= 1:
+            pool_context = nullcontext(None)
+        else:
+            pool_context = fork_context().Pool(self.number_of_cores)
+
+        with pool_context as pool:
             search_internal = self.sampler_cls(
                 prior=PriorVectorized(model=model),
                 likelihood=fitness.call_wrap,

--- a/test_autofit/non_linear/search/nest/test_nautilus.py
+++ b/test_autofit/non_linear/search/nest/test_nautilus.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import autofit as af
@@ -51,3 +52,36 @@ def test__test_mode():
     search.apply_test_mode()
 
     assert search.n_like_max == 1
+
+
+def test__single_core_builds_no_pool(monkeypatch):
+    """
+    number_of_cores=1 must not construct a multiprocessing pool: nautilus
+    treats pool=None as fully serial, whereas a Pool(1) object forces every
+    likelihood call into a forked worker — which deadlocks in XLA compilation
+    when the likelihood touches JAX (#1442).
+    """
+    from autofit.non_linear.search.nest.nautilus import search as nautilus_search
+
+    def no_fork_context():
+        raise AssertionError(
+            "fork_context must not be used when number_of_cores == 1"
+        )
+
+    monkeypatch.setattr(nautilus_search, "fork_context", no_fork_context)
+    monkeypatch.setenv("PYAUTO_TEST_MODE", "1")
+
+    model = af.Model(af.ex.Gaussian)
+    analysis = af.ex.Analysis(
+        data=np.full(100, 5.0),
+        noise_map=np.full(100, 1.0),
+    )
+
+    search = af.Nautilus(
+        name="nautilus_single_core",
+        unique_tag="single_core_no_pool_test",
+        n_live=10,
+        number_of_cores=1,
+    )
+
+    search.fit(model=model, analysis=analysis)


### PR DESCRIPTION
Corrective PR for the Heart RED reason (quoted verbatim from `pyauto-brain health assess`, 2026-08-01):

> ✗ [validate] release validation FAILED (stage integrate)

Full causal record, authorization quote, and evidence on #1442.

## What this clears

`guides/modeling/advanced/hierarchical.py` TIMEOUT (1800s) in release-integrate runs [30672739606](https://github.com/PyAutoLabs/PyAutoHeart/actions/runs/30672739606) and [30686136529](https://github.com/PyAutoLabs/PyAutoHeart/actions/runs/30686136529) (76s before the regression window).

e6279c53f (#1439) made `Nautilus.fit_multiprocessing` always construct a fork-context `Pool(number_of_cores)`. nautilus treats `pool=None`/`pool=1` as fully serial (`nautilus/sampler.py:286`); a real `Pool(1)` bypasses that guard, so every likelihood call runs in one forked worker, which deadlocks in XLA `backend_compile_and_load` when the likelihood touches JAX (py-spy stacks on #1442). This PR passes `pool=None` at `number_of_cores=1` (pre-#1439 serial behaviour) and keeps the fork-context pool — the actual Python 3.14 forkserver fix — for genuine multi-core runs.

## Evidence

- New regression test `test__single_core_builds_no_pool`: red on main (fork context entered), green here.
- `test_autofit/non_linear/`: 411 passed, 1 skipped.
- Control-vs-patched under the release-profile env (`PYAUTO_TEST_MODE=1`, JAX on): `hierarchical.py` hangs on main (py-spy: main blocked in `pool.map`, worker stuck in XLA compile), completes patched (result posted on #1442).

## Not claimed by this PR

The intermittent `autolens_test multi_dataset/jax_likelihood/delaunay.py` TIMEOUT (present in runs with pre-regression SHAs, passed 18.2s in run 30672739606) is a separate pre-existing flake and remains open.

## Validation plan

Merge → Stage 2 rehearsal (PyAutoHands) + Stage 3 release-integrate (PyAutoHeart) → `release validate --ingest` → fresh Heart verdict; the scheduled nightly performs the release on green under the standing grant (PyAutoBuild#127).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCVfiwJhHuQXxqksPJFCz4
